### PR TITLE
Multiverse: in configure file, build_ruby should not alter RbConfig::CONFIG["RUBY_INSTALL_NAME"]

### DIFF
--- a/configure
+++ b/configure
@@ -708,7 +708,7 @@ int main() { return tgetnum(""); }
   # script. That path will be made available to the rest of the build system
   # so the same version of ruby is invoked as needed.
   def build_ruby
-    bin = RbConfig::CONFIG["RUBY_INSTALL_NAME"] || RbConfig::CONFIG["ruby_install_name"]
+    bin = RbConfig::CONFIG["RUBY_INSTALL_NAME"].dup || RbConfig::CONFIG["ruby_install_name"].dup
     bin << (RbConfig::CONFIG['EXEEXT'] || RbConfig::CONFIG['exeext'] || '')
     File.join(RbConfig::CONFIG['bindir'], bin)
   end


### PR DESCRIPTION
In `configure`, there is a `build_ruby` method. This method (unintentionally) alters `RbConfig::CONFIG["RUBY_INSTALL_NAME"]` when `RbConfig::CONFIG['EXEEXT']` is appended to `bin`. This only manifests itself when `RbConfig::CONFIG['EXEEXT']` is not an empty string. For example, MinGW32.

This also wouldn't really create problems except that `build_ruby` is called twice in `configure`. By the end, `config.rb` has
    :build_ruby => "ruby.exe.exe"
written to it, under MinGW32.

By `#dup`ing, we get rid of this problem.
