### PR TITLE
Fixing Hash[] when passing an Array

### DIFF
--- a/kernel/common/hash.rb
+++ b/kernel/common/hash.rb
@@ -82,7 +82,7 @@ class Hash
       elsif obj.respond_to? :to_hash
         return new.replace(Type.coerce_to(obj, Hash, :to_hash))
       elsif obj.is_a?(Array) # See redmine # 1385
-        h = {}
+        h = new
         args.first.each do |arr|
           next unless arr.respond_to? :to_ary
           arr = arr.to_ary

--- a/spec/ruby/core/hash/constructor_spec.rb
+++ b/spec/ruby/core/hash/constructor_spec.rb
@@ -44,5 +44,6 @@ describe "Hash.[]" do
   it "returns an instance of the class it's called on" do
     hash_class[MyHash[1, 2]].class.should == hash_class
     MyHash[hash_class[1, 2]].should be_kind_of(MyHash)
+    MyHash[[1,2,3,4]].should be_kind_of(MyHash)    
   end
 end


### PR DESCRIPTION
Hi Guys,

I found this bug trying to run the rails test suite with rubinius. When you create a new hash class, that inherit from Hash (like ActiveSupport::HashWithIndifferentAccess) and create a new object using [] method, it returns an instance of a hash, instead of a instance of the new class. this patch solves it.
