### PR TITLE
array flatten benchmark

### DIFF
--- a/benchmark/core/array/flatten.rb
+++ b/benchmark/core/array/flatten.rb
@@ -1,0 +1,28 @@
+require 'benchmark'
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+
+  flat_array = (0...50).to_a
+
+  nested_array = (0...5).to_a
+  3.times do
+    nested_array = (0...5).map { nested_array }
+  end
+
+  x.report "array flatten - flat" do
+    flat_array.flatten
+  end
+
+  x.report "array flatten! - flat" do
+    flat_array.dup.flatten!
+  end
+
+  x.report "array flatten - nested" do
+    nested_array.flatten
+  end
+
+  x.report "array flatten! - nested" do
+    nested_array.dup.flatten!
+  end
+end


### PR DESCRIPTION
Benchmarks Array#flatten and Array#flatten! with both flat and nested arrays

rbx benchmark/bin/benchmark -tx -tr benchmark/core/array/flatten.rb 

```
=== bin/rbx ===
array flatten - flat     1234.4 (±23.9%) i/s -       5355 in   5.029306s (cycle=85)
array flatten! - flat     1343.5 (±7.6%) i/s -       6696 in   5.020795s (cycle=108)
array flatten - nested       94.1 (±5.3%) i/s -        477 in   5.082482s (cycle=9)
array flatten! - nested       94.9 (±8.4%) i/s -        477 in   5.067893s (cycle=9)
=== ruby ===
array flatten - flat    55871.8 (±12.0%) i/s -     276911 in   5.031293s (cycle=4133)
array flatten! - flat    50886.4 (±20.7%) i/s -     237220 in   5.011234s (cycle=4090)
array flatten - nested     3981.7 (±5.9%) i/s -      20072 in   5.059200s (cycle=386)
array flatten! - nested     3937.0 (±8.5%) i/s -      19800 in   5.069800s (cycle=396)
```

Comparing benchmark/core/array/flatten.rb:array flatten! - nested:
                ruby:       3936 i/s
             bin/rbx:         94 i/s - 41.48x slower
Comparing benchmark/core/array/flatten.rb:array flatten - flat:
                ruby:      55871 i/s
             bin/rbx:       1234 i/s - 45.26x slower
Comparing benchmark/core/array/flatten.rb:array flatten! - flat:
                ruby:      50886 i/s
             bin/rbx:       1343 i/s - 37.88x slower
Comparing benchmark/core/array/flatten.rb:array flatten - nested:
                ruby:       3981 i/s
             bin/rbx:         94 i/s - 42.31x slower
