### PR TITLE
a couple fixes for Actor::Filter#after

### DIFF
--- a/lib/actor/filter.rb
+++ b/lib/actor/filter.rb
@@ -52,7 +52,7 @@ class Filter
   def after(seconds, &action)
     raise ArgumentError, "no timeout given" unless action
     seconds = seconds.to_f
-    if @timeout and seconds < @timeout
+    if !@timeout or seconds < @timeout
       @timeout = seconds
       @timeout_action = action
     end


### PR DESCRIPTION
`@timeout` is nil for the initial comparison, so just check for its existence. The error test above is also corrected to check the proper argument.
