### PR TITLE
Fixed spec the URI method returns the argument if it is a URI object

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -605,6 +605,8 @@ module Kernel
   #
   # This method is introduced at 1.8.2.
   def URI(uri_str) # :doc:
+    return uri_str if uri_str.is_a? URI
+
     URI.parse(uri_str)
   end
   module_function :URI


### PR DESCRIPTION
Pretty small change.

The spec passes, but I'm not sure the code handles all cases or is idiomatic :-)
