### PR TITLE
Ordered hash

### DIFF
--- a/kernel/common/marshal.rb
+++ b/kernel/common/marshal.rb
@@ -165,7 +165,7 @@ class Hash
     raise TypeError, "can't dump hash with default proc" if default_proc
 
     #excluded_ivars = %w[@bins @count @records]
-    excluded_ivars = %w[@capacity @mask @max_entries @size @entries]
+    excluded_ivars = %w[@capacity @mask @max_entries @size @entries @first @last]
 
     out =  ms.serialize_instance_variables_prefix(self, excluded_ivars)
     out << ms.serialize_extended_object(self)


### PR DESCRIPTION
[Sorry, I did this work on Hydra since that's where 1.9 work is ongoing. My previous pull request was to master, which was incorrect. Apologies for any spam that may have caused.]

This change implements insert-ordered enumeration of Hash objects as in Ruby 1.9. It does so by making the hash entries into a linked list that gets appended to on insert and removed on delete. I believe this is the implementation with the most minimal performance impact as it leaves both insertion and removal as O(1) operations. You could get away with one less reference per Entry if you were willing to allow removal to be O(n) (it would have to scan the entries to find the previous one in order to correctly unlink it).

I'm not sure what the appropriate process is for adding specs for this, especially seeing as it is not standard 1.8 behaviour (though it does not violate 1.8 behaviour, either). I'd be happy to update my changes to spec it more specifically with some guidance.
