### PR TITLE
This commit fixes some unused variable warnings in 1.9.3dev

### DIFF
--- a/projects/daedalus/dependency_grapher.rb
+++ b/projects/daedalus/dependency_grapher.rb
@@ -46,7 +46,7 @@ class DependencyGrapher
     end
 
     def add_else
-      message = "invalid \#else for #{@parser.stack_top.class} at line #{@parser.line}"
+      "invalid \#else for #{@parser.stack_top.class} at line #{@parser.line}"
     end
 
     # TODO: remove

--- a/rakelib/extensions.rake
+++ b/rakelib/extensions.rake
@@ -22,7 +22,7 @@ end
 
 def rbx_build
   # rbx-build can run even if prefix is used
-  rbx = File.expand_path "../bin/rbx-build", File.dirname(__FILE__)
+  File.expand_path "../bin/rbx-build", File.dirname(__FILE__)
 end
 
 def build_extconf(name, opts)

--- a/rakelib/git.rb
+++ b/rakelib/git.rb
@@ -18,7 +18,6 @@ end
 
 def compare_git_ver
   v = `git version`.scan(/version (\d+).(\d+).(\d+)/).flatten.map { |s| s.to_i }
-  m = [1, 5, 3]
 
   (v <=> MINIMUM_GIT_VERSION) >= 0
 end

--- a/rakelib/instruction_parser.rb
+++ b/rakelib/instruction_parser.rb
@@ -593,7 +593,6 @@ EOM
           last = last[1..-1]
         end
 
-        arguments = last[1..-1]
         unless @produced_extra = @arguments.index(argument)
           raise ParseError, "no argument named '#{arg}' at #{@file.lineno}"
         end

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -33,7 +33,7 @@ namespace :release do
 
     issues = []
     ol.each do |line|
-      if m = /([Ff]ixes|[Cc]loses)\s#(\d+)/.match(line)
+      if /([Ff]ixes|[Cc]loses)\s#(\d+)/.match(line)
         issues << line
       end
     end
@@ -96,7 +96,7 @@ collection, Just-In-Time compilation, and compatibility with existing C APIs.
     fd.puts "##### Bug Fixes\n\n"
     ol.each do |line|
       unless issues.include?(line)
-        hash, message = line.split(" ", 2)
+        message = line.split(" ", 2)[1]
         message.gsub!("_", "\\_")
         fd.puts "* #{message}"
       end


### PR DESCRIPTION
1.9.3dev warns on unused variables.  This cleans up some of the warnings.
