### PR TITLE
This converts bound_method to be an attr_accessor

### DIFF
--- a/kernel/common/proc.rb
+++ b/kernel/common/proc.rb
@@ -84,13 +84,7 @@ class Proc
   alias_method :yield, :call
 
   class Method < Proc
-    def bound_method
-      @bound_method
-    end
-
-    def bound_method=(other)
-      @bound_method = other
-    end
+    attr_accessor :bound_method
 
     def self.__from_method__(meth)
       obj = allocate()


### PR DESCRIPTION
This converts bound_method to be an attr_accessor rather than a wordy getter / setter.
