### PR TITLE
Fix source_location for methods defined using define_method

### DIFF
--- a/kernel/bootstrap/block_environment.rb
+++ b/kernel/bootstrap/block_environment.rb
@@ -45,6 +45,14 @@ module Rubinius
       def splat
         @block_env.method.splat
       end
+
+      def file
+        @block_env.file
+      end
+
+      def defined_line
+        @block_env.line
+      end
     end
   end
 end

--- a/kernel/common/delegated_method.rb
+++ b/kernel/common/delegated_method.rb
@@ -27,5 +27,9 @@ module Rubinius
         0 # meh
       end
     end
+
+    def source_location
+      @receiver.source_location
+    end
   end
 end

--- a/kernel/common/method.rb
+++ b/kernel/common/method.rb
@@ -100,6 +100,8 @@ class Method
   def source_location
     if @executable.respond_to? :file
       [@executable.file.to_s, @executable.defined_line]
+    elsif @executable.respond_to? :source_location
+      @executable.source_location
     else
       nil
     end
@@ -257,6 +259,8 @@ class UnboundMethod
   def source_location
     if @executable.respond_to? :file
       [@executable.file.to_s, @executable.defined_line]
+    elsif @executable.respond_to? :source_location
+      @executable.source_location
     else
       nil
     end


### PR DESCRIPTION
Rubinius returns nil, MRI 1.9.2 does not.

I've committed the tests to rubyspec here, pull request submitted:

https://github.com/oggy/rubyspec/commit/8883d7337ecb2937e916eef826d16756e2b9df42

(I realize Rubinius HEAD doesn't yet claim to be fully 1.9-compliant, but this at least makes this feature compatible.)
