### PR TITLE
Modifed URI to pass rubyspecs

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -457,7 +457,7 @@ module URI
   # == Args
   #
   # +uri_str+::
-  #   String with URI.
+  #   String like object with URI.
   #
   # == Description
   #
@@ -481,6 +481,17 @@ module URI
   #   # => "www.ruby-lang.org" 
   # 
   def self.parse(uri)
+    case uri
+    when Generic
+      uri
+    when String
+      parse_string(uri)
+    else
+      parse_other(uri)
+    end
+  end
+
+  def self.parse_string(uri) # :nodoc:
     scheme, userinfo, host, port, 
       registry, path, opaque, query, fragment = self.split(uri)
 
@@ -492,6 +503,17 @@ module URI
       Generic.new(scheme, userinfo, host, port, 
                   registry, path, opaque, query, 
                   fragment)
+    end
+  end
+
+  def self.parse_other(uri) # :nodoc:
+    uri = uri.respond_to?(:to_str) ? uri.to_str : uri.to_s
+
+    if uri.is_a?(String)
+      parse_string(uri)
+    else
+      raise ArgumentError,
+        "Bad argument(expected URI object, URI string, or string-like object)"
     end
   end
 

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -769,14 +769,7 @@ module URI
     # return base and rel.
     # you can modify `base', but can not `rel'.
     def merge0(oth)
-      case oth
-      when Generic
-      when String
-        oth = URI.parse(oth)
-      else
-        raise ArgumentError,
-          "bad argument(expected URI object or URI string)"
-      end
+      oth = URI.parse(oth)
 
       if self.relative? && oth.relative?
         raise BadURIError, 
@@ -840,14 +833,7 @@ module URI
     private :route_from_path
 
     def route_from0(oth)
-      case oth
-      when Generic
-      when String
-        oth = URI.parse(oth)
-      else
-        raise ArgumentError,
-          "bad argument(expected URI object or URI string)"
-      end
+      oth = URI.parse(oth)
 
       if self.relative?
         raise BadURIError, 
@@ -952,14 +938,7 @@ module URI
     #   #=> #<URI::Generic:0x2020c2f6 URL:/main.rbx?page=1>
     #    
     def route_to(oth)
-      case oth
-      when Generic
-      when String
-        oth = URI.parse(oth)
-      else
-        raise ArgumentError,
-          "bad argument(expected URI object or URI string)"
-      end
+      oth = URI.parse(oth)
 
       oth.route_from(self)
     end
@@ -1108,6 +1087,9 @@ module URI
     end
 
     @@to_s = Kernel.instance_method(:to_s)
+    
+    alias :to_str :to_s
+    
     def inspect
       @@to_s.bind(self).call.sub!(/>\z/) {" URL:#{self}>"}
     end


### PR DESCRIPTION
I've made some small changes to the URI stuff in lib so that it passes the rubyspecs when running 'bin/mspec spec/ruby/library/uri'. The only thing I'm on the fence about is how I should add documentation around the new methods(if I even should), or if it's fine the way it is.
