### PR TITLE
Use Array#at instead of Array#[] for Array#==

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -482,7 +482,7 @@ class Array
 
     Thread.detect_recursion self, other do
       i = -1
-      each { |x| return false unless x == other[i+=1] }
+      each { |x| return false unless x == other.at(i+=1) }
     end
 
     true

--- a/spec/ruby/core/array/equal_value_spec.rb
+++ b/spec/ruby/core/array/equal_value_spec.rb
@@ -56,4 +56,8 @@ describe "Array#==" do
   it "returns false for [NaN] == [NaN]" do
     [nan_value].should_not == [nan_value]
   end
+
+  it "returns true even when the Array#[] contract has been broken" do
+    IndexOverrideArray.new(1, 2, 3).should == IndexOverrideArray.new(1, 2, 3)
+  end
 end

--- a/spec/ruby/core/array/fixtures/classes.rb
+++ b/spec/ruby/core/array/fixtures/classes.rb
@@ -101,6 +101,12 @@ module ArraySpecs
     end
   end
 
+  class IndexOverrideArray < Array
+    def [](index)
+      nil
+    end
+  end
+
   class ArrayConvertable
     attr_accessor :called
     def initialize(*values, &block)


### PR DESCRIPTION
Datamapper < 1.1.0 breaks the contract of Array#[] and therefore breaks the contract of Array#==.
Array#at is less commonly overridden and therefore a better choice for Array#==. 

I'm not sure if I wrote the test correctly or completely, but the concept is there. 
