### PR TITLE
Add a spec for Module#const_defined wrt include

### DIFF
--- a/spec/ruby/core/module/const_defined_spec.rb
+++ b/spec/ruby/core/module/const_defined_spec.rb
@@ -36,6 +36,11 @@ describe "Module#const_defined?" do
     ConstantSpecs::ContainerA.const_defined?("ChildA").should == true
   end
 
+  it "returns true for included constants" do
+    ConstantSpecs::ContainerC.should have_constant("ClassHA")
+    ConstantSpecs::ContainerC.const_defined?(:ClassHA).should be_true
+  end
+
   ruby_version_is ""..."1.9" do
     it "returns false if the constant is not defined in the receiver" do
       ConstantSpecs::ContainerA::ChildA.const_defined?(:CS_CONST4).should == false

--- a/spec/ruby/fixtures/constants.rb
+++ b/spec/ruby/fixtures/constants.rb
@@ -184,6 +184,16 @@ module ConstantSpecs
   module ModuleG
   end
 
+  # Included in ContainerC
+  module ModuleH
+    class ClassHA
+    end
+  end
+
+  class ContainerC
+    include ModuleH
+  end
+
   # The following classes/modules have the same structure as the ones above
   # but the constants are set as the specs are run.
 


### PR DESCRIPTION
It seems like #const_defined? does not pick up (some?) constants pulled in with #include, which would explain bug #865
