### PR TITLE
`rbx report` should not fail silently when Gist submission didn't work

### DIFF
--- a/lib/bin/report.rb
+++ b/lib/bin/report.rb
@@ -3,6 +3,8 @@
 require 'open-uri'
 require 'net/https'
 
+GistSubmissionError = Class.new(StandardError)
+
 module Gist
   extend self
 
@@ -24,6 +26,10 @@ module Gist
     req.form_data = data(name, nil, content, private_gist)
 
     res = http.start {|h| h.request(req) }
+
+    unless res.kind_of?(Net::HTTPRedirection)
+      raise GistSubmissionError, %Q{Could not submit gist (#{res.code} #{res.message}). Make sure you've set github.user and github.token in your Git config, or submit the crash report located at '#{ENV['HOME']}/.rubinius_last_error' manually.}
+    end
 
     copy res['Location']
   end


### PR DESCRIPTION
When `github.token` and/or `github.user` aren't set in Git's config, then `rbx report` will silently swallow the error and continue, and won't print an URL for the user to add to their report.

This is fixed by raising an exception when the response from github isn't a 3xx response.
