### PR TITLE
Fix to Benchmark class

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -444,7 +444,7 @@ module Benchmark
     #
     # An in-place version of #add.
     #
-    def add!
+    def add!(&blk)
       t = Benchmark.measure(&blk)
       @utime  = utime + t.utime
       @stime  = stime + t.stime


### PR DESCRIPTION
The `add!` method on `Benchmark` class was missing `&blk` parameter causing error when used.
