### PR TITLE
Set the global Fiber class to Rubinius::Fiber when `require 'fiber'` (needed by blockenspiel)

### DIFF
--- a/lib/fiber.rb
+++ b/lib/fiber.rb
@@ -1,2 +1,4 @@
 # The Fiber code in Rubinius is in the kernel.
 # This file is here for MRI compatibility.
+
+Fiber = Rubinius::Fiber


### PR DESCRIPTION
Blockenspiel checks with a require 'fiber' if it can use fibers or not, it then uses ::Fiber, this doesn't work with the actual code, here's the really simple fix :)

EDIT: matthewd pointed out that maybe it's because Rubinius::Fiber is still experimental, if this is the case removing lib/fiber.rb would be the right thing to do since it doesn't really provide ::Fiber.
