### PR TITLE
Hydra: fix Melbourne for MRI extension build

### DIFF
--- a/lib/ext/melbourne/parser_state19.hpp
+++ b/lib/ext/melbourne/parser_state19.hpp
@@ -4,7 +4,6 @@
 #include "node19.hpp"
 #include "node_types19.hpp"
 #include "local_state.hpp"
-#include "encoding_compat.hpp"
 
 #include "bstrlib.h"
 
@@ -13,6 +12,8 @@
 
 namespace melbourne {
   namespace grammar19 {
+
+#include "encoding_compat.hpp"
 
 #define QUID    quark
 


### PR DESCRIPTION
At least under ruby18, the build of Melbourne extension for MRI was failing with the following:

```
grammar19.cpp:(.text+0x13c): undefined reference to `rb_usascii_encoding()'
[...]
```

and indeed it seems `encoding_compat.cpp` defines this function et. al. in the `melbourne::grammar19` namespace, while the declarations were made outside the namespace.
