### PR TITLE
Add FFI::Pointer.size matching ruby-ffi

### DIFF
--- a/kernel/platform/pointer.rb
+++ b/kernel/platform/pointer.rb
@@ -290,6 +290,10 @@ module FFI
       raise PrimitiveFailure, "set_field failed"
     end
 
+    # Number of bytes taken up by a pointer.
+    def self.size
+      Rubinius::WORDSIZE / 8
+    end
   end
 
   class MemoryPointer < Pointer

--- a/spec/core/ffi/pointer_spec.rb
+++ b/spec/core/ffi/pointer_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "FFI::Pointer#size" do
+  it "should match 1.size" do
+    FFI::Pointer.size.should == 1.size
+  end
+end


### PR DESCRIPTION
Dear Evan,

I use FFI::Pointer.size in a gem to check if I'm on a 32-bit or 64-bit platform, and I imagine I'm not the only one doing that. I relied on it because it's in the ffi gem for MRI. I hope this is a good addition to Rubinius.

Thank you!
    Victor
