### PR TITLE
Updated benchmark/bin/benchmark so rvm-managed rubies are easier

### DIFF
--- a/benchmark/bin/benchmark
+++ b/benchmark/bin/benchmark
@@ -19,7 +19,10 @@ compare_targets = []
 
 opt = OptionParser.new do |o|
   o.on("-t", "--target TARGET", String,
-          "Use multiple TARGETs for comparison: r:ruby|r19:ruby19|x:rbx|j:jruby") do |t|
+          "Use multiple TARGETs for comparison:",
+          "<path-to-ruby-binary>: will use exact ruby binary",
+          "shortcuts: r:ruby | r19:ruby19 | x:rbx | j:jruby",
+          "^<name>: rvm-managed ruby; will use ~/.rvm/rubies/<name>/bin/ruby") do |t|
     case t
     when 'r', 'ruby'
       targets << 'ruby'
@@ -40,6 +43,9 @@ opt = OptionParser.new do |o|
         rescue TypeError
           targets << t
         end
+      elsif t[0,1] == "^"
+        puts "Found rvm-managed ruby: " + t[1..-1]
+        targets << File.expand_path("~/.rvm/rubies/" + t[1..-1] + "/bin/ruby")
       else
         targets << t
       end


### PR DESCRIPTION
So I chose `^` as the character that identifies an rvm-managed ruby. For example:

```
bin/benchmark -t x -t ^ruby-1.9.2-p180 ...
```

I only thought for about 60 seconds before picking `^`. Let me know if there is a better character.

This also changes the help text, which is maybe more verbose than you want:

```
Usage: benchmark [options]
    -t, --target TARGET              Use multiple TARGETs for comparison:
                                     <path-to-ruby-binary>: will use exact ruby binary
                                     shortcuts: r:ruby | r19:ruby19 | x:rbx | j:jruby
                                     ^<name>: rvm-managed ruby; will use ~/.rvm/rubies/<name>/bin/ruby
    -p, --profile                    Profile code while benchmarking (rbx only)
    -e, --end                        Report all stats after all suitse have run
    -T OPTION                        Add more arguments to each target
    -s, --save PATH                  Save the results to a file
```
