### PR TITLE
configure checks GNU tools versions on Linux

### DIFF
--- a/configure
+++ b/configure
@@ -53,9 +53,12 @@ class Configure
     @llvm_source_url        = "http://llvm.org/releases/2.8/llvm-2.8.tgz"
     @llvm_asset_path        = "http://asset.rubini.us/prebuilt"
 
-    @gcc_major = `#{@cc} -dumpversion`.strip.split(".")[0,2].join(".")
 
     if @host == "i686-pc-linux-gnu" || @host == "x86_64-unknown-linux-gnu"
+      failure unless check_tool_version @cc, '-dumpversion', /(\d+)\.(\d+)/, [4,1]
+      failure unless check_tool_version 'bison', '--version', /bison \(GNU Bison\) (\d+)\.(\d+)/, [2,4]
+
+      @gcc_major = `#{@cc} -dumpversion`.strip.split(".")[0,2].join(".")
       @llvm_generic_prebuilt  = "llvm-#{@llvm_version}-#{@host}-#{@gcc_major}.tar.bz2"
     else
       @llvm_generic_prebuilt  = "llvm-#{@llvm_version}-#{@host}.tar.bz2"
@@ -790,6 +793,19 @@ int main() { return tgetnum(""); }
     end
 
     return "#{name}-#{version}"
+  end
+
+  def check_tool_version(tool_name, opts, version_regexp, expected_version)
+    @log.write "Checking #{tool_name}:"
+    output = `#{tool_name} #{opts}` rescue 'oops'
+    if $?.exitstatus == 0
+      version = output.scan(version_regexp)[0].map(&:to_i)
+      @log.error "  Expected #{tool_name} version >= #{expected_version.join '.'} , found #{version.join '.'}"
+      (version <=> expected_version) >=0
+    else
+      @log.error "  #{tool_name} not found"
+      false
+    end
   end
 
   def write_config


### PR DESCRIPTION
Hi! I read what you said about changing configure script without too much necessity (evanphx/rubinius#739),
but I never even knew what bison is until I launched Rubinius build for the first time. Exploring build error log is less comfortable than seeing unmet requirements in configure output. 

First I nagged about it in evanphx/rubinius#921, but then I thought I can do it myself and put it in for other people like me, who don't have many C++ development tools installed by default in their distros. (Eventually after a fresh installation of another Linux VM at work I stumble upon even gcc being absent, so this check is not pointless) 

If you pull this, please amend the minimum required tools versions, cause I just guessed minimum gcc from prebuilt llvm artifacts on your site and for bison just put the numbers I have.
