### PR TITLE
Fix SortedSet to ensure objects comparable with <=>

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -460,6 +460,7 @@ class SortedSet < Set
   end
 
   def add(o)
+    raise ArgumentError, "value must respond to <=>" unless o.respond_to?(:<=>)
     @keys = nil
     @hash[o] = true
     self


### PR DESCRIPTION
Makes 2 failing specs pass for SortedSet:
- SortedSet#add takes only values which responds <=>
- SortedSet#initialize takes only values which respond to <=>
