### PR TITLE
Fixing README to point to Rubinius organization repository and GitHub iss

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,7 @@ For more information about building and running Rubinius, run 'rake docs'.
 To install Rubinius, use the following steps:
 
   1. Ensure you have MRI 1.8.7+, rubygems, rake, and git installed
-  2. git clone git://github.com/evanphx/rubinius.git
+  2. git clone git://github.com/rubinius/rubinius.git
   3. cd rubinius
   4. ./configure --prefix=/path/to/install/dir
   5. rake install
@@ -105,7 +105,7 @@ improves, overall performance of your code under Rubinius will improve.
 6. Tickets
 
 Please file tickets for bugs or problems that you encounter. The issue tracker
-is: http://github.com/evanphx/rubinius/issues. Run 'rake docs' for more
+is: http://github.com/rubinius/rubinius/issues. Run 'rake docs' for more
 details.
 
 


### PR DESCRIPTION
Fixing README to point to Rubinius organization repository and GitHub issue tracker instead of @evanphx's repository.
