### PR TITLE
More rubinius organization reference changes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ if ENV["RUBYLIB"]
 end
 
 # Wipe out CDPATH, it interferes with building in some cases,
-# see http://github.com/evanphx/rubinius/issues#issue/555
+# see http://github.com/rubinius/rubinius/issues#issue/555
 if ENV["CDPATH"]
   ENV.delete("CDPATH")
 end

--- a/benchmark/bin/bm-automatic
+++ b/benchmark/bin/bm-automatic
@@ -62,7 +62,7 @@ class Commit
 
   def benchmark
     begin
-      execute "git clone git://github.com/evanphx/rubinius.git #{working_path}"
+      execute "git clone git://github.com/rubinius/rubinius.git #{working_path}"
 
       Dir.chdir working_path
       execute 'rake build'

--- a/benchmark/results/templates/rubinius.erb
+++ b/benchmark/results/templates/rubinius.erb
@@ -28,7 +28,7 @@
 
 <div id="site-subtitle">Use Ruby &#8482;</div>
 
-<div id="site-download"><a href="http://github.com/evanphx/rubinius/tree/master"><img src="http://74.217.48.135/assets/2/down_24.png" alt="download git" /> Download with git</a></div>
+<div id="site-download"><a href="http://github.com/rubinius/rubinius/tree/master"><img src="http://74.217.48.135/assets/2/down_24.png" alt="download git" /> Download with git</a></div>
     </div>
   </div>
 

--- a/kernel/common/process.rb
+++ b/kernel/common/process.rb
@@ -92,7 +92,7 @@ module Process
 
       # Do not use Kernel.exit. This raises a SystemExit exception, which
       # will run ensure blocks. This is not what MRI does and causes bugs
-      # in programs. See issue http://github.com/evanphx/rubinius/issues#issue/289 for
+      # in programs. See issue http://github.com/rubinius/rubinius/issues#issue/289 for
       # an example
 
       Kernel.exit! status

--- a/lib/ext/melbourne/visitor.cpp
+++ b/lib/ext/melbourne/visitor.cpp
@@ -334,7 +334,7 @@ namespace melbourne {
       case_level--;
 
       // Be sure to decrease the case_level before processing the else.
-      // See http://github.com/evanphx/rubinius/issues#issue/240 for an example of
+      // See http://github.com/rubinius/rubinius/issues#issue/240 for an example of
       // why.
       if(else_node) {
         els = process_parse_tree(parse_state, ptp, else_node, locals);

--- a/rakelib/git.rake
+++ b/rakelib/git.rake
@@ -2,13 +2,13 @@ namespace :git do
 
   desc "Switch to the commiter URL"
   task :committer do
-    sh "git config remote.origin.url git@github.com:evanphx/rubinius.git"
+    sh "git config remote.origin.url git@github.com:rubinius/rubinius.git"
     puts "\nYou're now accessing rubinius via the committer URL." 
   end
 
   desc "Switch to the anonymous URL"
   task :anon do
-    sh "git config remote.origin.url git://github.com/evanphx/rubinius.git"
+    sh "git config remote.origin.url git://github.com/rubinius/rubinius.git"
     puts "\nYou're now accessing rubinius via the anonymous URL."
   end
 

--- a/vm/drivers/cli.cpp
+++ b/vm/drivers/cli.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
     std::cout << "  rake kernel:clean clean\n";
     std::cout << "  rake\n";
     std::cout << "\nIf the problem persists, please open an issue at:\n";
-    std::cout << "  http://github.com/evanphx/rubinius\n";
+    std::cout << "  http://github.com/rubinius/rubinius\n";
     std::cout << "\nThanks,\n  Management.\n";
     return 1;
   } catch(VMException &e) {

--- a/vm/llvm/jit_compiler.cpp
+++ b/vm/llvm/jit_compiler.cpp
@@ -167,7 +167,7 @@ namespace jit {
     if(Broken or llvm::verifyFunction(*func, PrintMessageAction)) {
       llvm::outs() << "ERROR: complication error detected.\n";
       llvm::outs() << "ERROR: Please report the above message and the\n";
-      llvm::outs() << "       code below to http://github.com/evanphx/rubinius/issues\n";
+      llvm::outs() << "       code below to http://github.com/rubinius/rubinius/issues\n";
       llvm::outs() << *func << "\n";
       function_ = NULL;
       return;

--- a/web/_posts/2010-12-15-rubinius-has-a-blog.markdown
+++ b/web/_posts/2010-12-15-rubinius-has-a-blog.markdown
@@ -7,7 +7,7 @@ author: Brian Ford
 Many thought the day would never come, but Rubinius finally has a blog. That's
 not all, though: We have integrated the website, blog, and documentation using
 Jekyll. The source code for it all is in the main [Rubinius
-repository](http://github.com/evanphx/rubinius).
+repository](http://github.com/rubinius/rubinius).
 
 People have often requested that we write more about the _awesome_ features in
 Rubinius. We hear you and we'd love to do this. However, there is always a

--- a/web/_posts/2011-02-25-why-use-rubinius.markdown
+++ b/web/_posts/2011-02-25-why-use-rubinius.markdown
@@ -59,7 +59,7 @@ Cool.
 
 Well, you should use Rubinius because I said so. Try your code on it. Tell us
 what worked for you. Tell us if something didn't work by opening an
-[issue](https://github.com/evanphx/rubinius/issues/).
+[issue](https://github.com/rubinius/rubinius/issues/).
 Set your imagination loose and tell us what tool you would use if you could.
 
 Spend some time reading the Rubinius source code. Start at the `kernel/`
@@ -166,7 +166,7 @@ Of course, even if the technology in Rubinius sounds terrific in theory, how
 suitable is Rubinius for your application? How does it perform under your
 specific constraints? Again, you do some investigating. You have a solid test
 suite for your application, so you start by running that. If you hit any
-problems, please open an [issue](https://github.com/evanphx/rubinius/issues/)
+problems, please open an [issue](https://github.com/rubinius/rubinius/issues/)
 to let us know.
 
 If everything goes well with the tests, you start running some of the
@@ -550,7 +550,7 @@ about everyone interested in Ruby. Most importantly, try it!
 If we didn't answer your question here, leave us a comment. If you have a
 reason for using Rubinius that we didn't mention, let us know. As always, we
 appreciate your feedback. Chat with us in the #rubinius channel on
-freenode.net, [watch our Github project](https://github.com/evanphx/rubinius),
+freenode.net, [watch our Github project](https://github.com/rubinius/rubinius),
 and [follow us on Twitter](http://twitter.com/rubinius).
 
 P.S. Thanks to David Waite for suggesting the Academic Researcher and Language

--- a/web/_site/2010/12/15/rubinius-has-a-blog/index.html
+++ b/web/_site/2010/12/15/rubinius-has-a-blog/index.html
@@ -70,7 +70,7 @@
 
       <p>Many thought the day would never come, but Rubinius finally has a blog. That&rsquo;s
 not all, though: We have integrated the website, blog, and documentation using
-Jekyll. The source code for it all is in the main <a href="http://github.com/evanphx/rubinius">Rubinius
+Jekyll. The source code for it all is in the main <a href="http://github.com/rubinius/rubinius">Rubinius
 repository</a>.</p>
 
 <p>People have often requested that we write more about the <em>awesome</em> features in

--- a/web/_site/2011/02/25/why-use-rubinius/index.html
+++ b/web/_site/2011/02/25/why-use-rubinius/index.html
@@ -124,7 +124,7 @@ what the big deal is and you&rsquo;re like, &ldquo;Yo, why would I use Rubinius?
 
 <p>Well, you should use Rubinius because I said so. Try your code on it. Tell us
 what worked for you. Tell us if something didn&rsquo;t work by opening an
-<a href="https://github.com/evanphx/rubinius/issues/">issue</a>.
+<a href="https://github.com/rubinius/rubinius/issues/">issue</a>.
 Set your imagination loose and tell us what tool you would use if you could.</p>
 
 <p>Spend some time reading the Rubinius source code. Start at the <code>kernel/</code>
@@ -233,7 +233,7 @@ machine. We are building a variety of diagnostic tools atop this API.</li>
 suitable is Rubinius for your application? How does it perform under your
 specific constraints? Again, you do some investigating. You have a solid test
 suite for your application, so you start by running that. If you hit any
-problems, please open an <a href="https://github.com/evanphx/rubinius/issues/">issue</a>
+problems, please open an <a href="https://github.com/rubinius/rubinius/issues/">issue</a>
 to let us know.</p>
 
 <p>If everything goes well with the tests, you start running some of the
@@ -625,7 +625,7 @@ about everyone interested in Ruby. Most importantly, try it!</p>
 <p>If we didn&rsquo;t answer your question here, leave us a comment. If you have a
 reason for using Rubinius that we didn&rsquo;t mention, let us know. As always, we
 appreciate your feedback. Chat with us in the #rubinius channel on
-freenode.net, <a href="https://github.com/evanphx/rubinius">watch our Github project</a>,
+freenode.net, <a href="https://github.com/rubinius/rubinius">watch our Github project</a>,
 and <a href="http://twitter.com/rubinius">follow us on Twitter</a>.</p>
 
 <p>P.S. Thanks to David Waite for suggesting the Academic Researcher and Language

--- a/web/_site/blog/index.html
+++ b/web/_site/blog/index.html
@@ -998,7 +998,7 @@ what the big deal is and you&rsquo;re like, &ldquo;Yo, why would I use Rubinius?
 
 <p>Well, you should use Rubinius because I said so. Try your code on it. Tell us
 what worked for you. Tell us if something didn&rsquo;t work by opening an
-<a href="https://github.com/evanphx/rubinius/issues/">issue</a>.
+<a href="https://github.com/rubinius/rubinius/issues/">issue</a>.
 Set your imagination loose and tell us what tool you would use if you could.</p>
 
 <p>Spend some time reading the Rubinius source code. Start at the <code>kernel/</code>
@@ -1107,7 +1107,7 @@ machine. We are building a variety of diagnostic tools atop this API.</li>
 suitable is Rubinius for your application? How does it perform under your
 specific constraints? Again, you do some investigating. You have a solid test
 suite for your application, so you start by running that. If you hit any
-problems, please open an <a href="https://github.com/evanphx/rubinius/issues/">issue</a>
+problems, please open an <a href="https://github.com/rubinius/rubinius/issues/">issue</a>
 to let us know.</p>
 
 <p>If everything goes well with the tests, you start running some of the
@@ -1499,7 +1499,7 @@ about everyone interested in Ruby. Most importantly, try it!</p>
 <p>If we didn&rsquo;t answer your question here, leave us a comment. If you have a
 reason for using Rubinius that we didn&rsquo;t mention, let us know. As always, we
 appreciate your feedback. Chat with us in the #rubinius channel on
-freenode.net, <a href="https://github.com/evanphx/rubinius">watch our Github project</a>,
+freenode.net, <a href="https://github.com/rubinius/rubinius">watch our Github project</a>,
 and <a href="http://twitter.com/rubinius">follow us on Twitter</a>.</p>
 
 <p>P.S. Thanks to David Waite for suggesting the Academic Researcher and Language
@@ -2190,7 +2190,7 @@ your hardest problems with Ruby, and have fun doing it.</p>
 
       <p>Many thought the day would never come, but Rubinius finally has a blog. That&rsquo;s
 not all, though: We have integrated the website, blog, and documentation using
-Jekyll. The source code for it all is in the main <a href="http://github.com/evanphx/rubinius">Rubinius
+Jekyll. The source code for it all is in the main <a href="http://github.com/rubinius/rubinius">Rubinius
 repository</a>.</p>
 
 <p>People have often requested that we write more about the <em>awesome</em> features in

--- a/web/_site/feed/atom.xml
+++ b/web/_site/feed/atom.xml
@@ -890,7 +890,7 @@ what the big deal is and you&amp;rsquo;re like, &amp;ldquo;Yo, why would I use R
 
 &lt;p&gt;Well, you should use Rubinius because I said so. Try your code on it. Tell us
 what worked for you. Tell us if something didn&amp;rsquo;t work by opening an
-&lt;a href=&quot;https://github.com/evanphx/rubinius/issues/&quot;&gt;issue&lt;/a&gt;.
+&lt;a href=&quot;https://github.com/rubinius/rubinius/issues/&quot;&gt;issue&lt;/a&gt;.
 Set your imagination loose and tell us what tool you would use if you could.&lt;/p&gt;
 
 &lt;p&gt;Spend some time reading the Rubinius source code. Start at the &lt;code&gt;kernel/&lt;/code&gt;
@@ -999,7 +999,7 @@ machine. We are building a variety of diagnostic tools atop this API.&lt;/li&gt;
 suitable is Rubinius for your application? How does it perform under your
 specific constraints? Again, you do some investigating. You have a solid test
 suite for your application, so you start by running that. If you hit any
-problems, please open an &lt;a href=&quot;https://github.com/evanphx/rubinius/issues/&quot;&gt;issue&lt;/a&gt;
+problems, please open an &lt;a href=&quot;https://github.com/rubinius/rubinius/issues/&quot;&gt;issue&lt;/a&gt;
 to let us know.&lt;/p&gt;
 
 &lt;p&gt;If everything goes well with the tests, you start running some of the
@@ -1391,7 +1391,7 @@ about everyone interested in Ruby. Most importantly, try it!&lt;/p&gt;
 &lt;p&gt;If we didn&amp;rsquo;t answer your question here, leave us a comment. If you have a
 reason for using Rubinius that we didn&amp;rsquo;t mention, let us know. As always, we
 appreciate your feedback. Chat with us in the #rubinius channel on
-freenode.net, &lt;a href=&quot;https://github.com/evanphx/rubinius&quot;&gt;watch our Github project&lt;/a&gt;,
+freenode.net, &lt;a href=&quot;https://github.com/rubinius/rubinius&quot;&gt;watch our Github project&lt;/a&gt;,
 and &lt;a href=&quot;http://twitter.com/rubinius&quot;&gt;follow us on Twitter&lt;/a&gt;.&lt;/p&gt;
 
 &lt;p&gt;P.S. Thanks to David Waite for suggesting the Academic Researcher and Language
@@ -2050,7 +2050,7 @@ your hardest problems with Ruby, and have fun doing it.&lt;/p&gt;
     
     <content type="html">&lt;p&gt;Many thought the day would never come, but Rubinius finally has a blog. That&amp;rsquo;s
 not all, though: We have integrated the website, blog, and documentation using
-Jekyll. The source code for it all is in the main &lt;a href=&quot;http://github.com/evanphx/rubinius&quot;&gt;Rubinius
+Jekyll. The source code for it all is in the main &lt;a href=&quot;http://github.com/rubinius/rubinius&quot;&gt;Rubinius
 repository&lt;/a&gt;.&lt;/p&gt;
 
 &lt;p&gt;People have often requested that we write more about the &lt;em&gt;awesome&lt;/em&gt; features in


### PR DESCRIPTION
Changed only the appropriate references to point from evanphx to rubinius for the Rubinius project and issues. I did verify that all the issue links were correct since the project was moved. 

Hope this helps in some small way.
