### PR TITLE
Fix DeferedBreakPoint typo

### DIFF
--- a/lib/rubinius/debugger.rb
+++ b/lib/rubinius/debugger.rb
@@ -50,20 +50,20 @@ class Rubinius::Debugger
     }
 
     @loaded_hook = proc { |file|
-      check_defered_breakpoints
+      check_deferred_breakpoints
     }
 
     @added_hook = proc { |mod, name, exec|
-      check_defered_breakpoints
+      check_deferred_breakpoints
     }
 
     # Use a few Rubinius specific hooks to trigger checking
-    # for defered breakpoints.
+    # for deferred breakpoints.
 
     Rubinius::CodeLoader.loaded_hook.add @loaded_hook
     Rubinius.add_method_hook.add @added_hook
 
-    @defered_breakpoints = []
+    @deferred_breakpoints = []
 
     @user_variables = 0
 
@@ -266,15 +266,15 @@ class Rubinius::Debugger
     @breakpoints[i-1] = nil
   end
 
-  def add_defered_breakpoint(klass_name, which, name, line)
-    dbp = DeferedBreakPoint.new(self, @current_frame, klass_name, which, name,
-                                line, @defered_breakpoints)
-    @defered_breakpoints << dbp
+  def add_deferred_breakpoint(klass_name, which, name, line)
+    dbp = DeferredBreakPoint.new(self, @current_frame, klass_name, which, name,
+                                line, @deferred_breakpoints)
+    @deferred_breakpoints << dbp
     @breakpoints << dbp
   end
 
-  def check_defered_breakpoints
-    @defered_breakpoints.delete_if do |bp|
+  def check_deferred_breakpoints
+    @deferred_breakpoints.delete_if do |bp|
       bp.resolve!
     end
   end

--- a/lib/rubinius/debugger/breakpoint.rb
+++ b/lib/rubinius/debugger/breakpoint.rb
@@ -77,7 +77,7 @@ class Rubinius::Debugger
     end
   end
 
-  class DeferedBreakPoint
+  class DeferredBreakPoint
     def initialize(debugger, frame, klass, which, name, line=nil, list=nil)
       @debugger = debugger
       @frame = frame
@@ -117,7 +117,7 @@ class Rubinius::Debugger
     end
 
     def describe
-      "#{descriptor} - unknown location (defered)"
+      "#{descriptor} - unknown location (deferred)"
     end
 
     def delete!

--- a/lib/rubinius/debugger/commands.rb
+++ b/lib/rubinius/debugger/commands.rb
@@ -131,7 +131,7 @@ To breakpoint on class method start of Debugger line 4, use:
           klass = run_code(klass_name)
         rescue NameError
           error "Unable to find class/module: #{m[1]}"
-          ask_defered klass_name, which, name, line
+          ask_deferred klass_name, which, name, line
           return
         end
 
@@ -143,7 +143,7 @@ To breakpoint on class method start of Debugger line 4, use:
           end
         rescue NameError
           error "Unable to find method '#{name}' in #{klass}"
-          ask_defered klass_name, which, name, line
+          ask_deferred klass_name, which, name, line
           return
         end
 
@@ -154,12 +154,12 @@ To breakpoint on class method start of Debugger line 4, use:
         return bp
       end
 
-      def ask_defered(klass_name, which, name, line)
+      def ask_deferred(klass_name, which, name, line)
         answer = ask "Would you like to defer this breakpoint to later? [y/n] "
 
         if answer.strip.downcase[0] == ?y
-          @debugger.add_defered_breakpoint(klass_name, which, name, line)
-          info "Defered breakpoint created."
+          @debugger.add_deferred_breakpoint(klass_name, which, name, line)
+          info "Deferred breakpoint created."
         end
       end
 


### PR DESCRIPTION
Here's a simple patch to change `Rubinius::Debugger::DeferedBreakPoint` to `Rubinius::Debugger::DeferredBreakPoint`.
