### PR TITLE
Make Delegator delegate eql? and hash

### DIFF
--- a/lib/delegate.rb
+++ b/lib/delegate.rb
@@ -180,6 +180,14 @@ class Delegator
     initialize_methods(obj)
     __setobj__(obj)
   end
+
+  def eql?(obj)
+    __getobj__.eql?(obj)
+  end
+
+  def hash
+    __getobj__.hash
+  end
 end
 
 #


### PR DESCRIPTION
Makes the following specs pass:
- Delegator#eql?  - is delegated
- Delegator#hash  - is delegated
