### PR TITLE
fixed memory leak, memory allocated by new[] was freed by delete instead 

### DIFF
--- a/vm/util/bert.hpp
+++ b/vm/util/bert.hpp
@@ -271,7 +271,7 @@ namespace bert {
       if(term->contains_string_p() && term->string() == 0) {
         char* buf = new char[term->integer() + 1];
         if(!reader_.read(term->integer(), buf)) {
-          delete buf;
+          delete[] buf;
           return false;
         }
 


### PR DESCRIPTION
fixed memory leak, memory allocated by new[] was freed by delete instead of delete[]
