### PR TITLE
Improves performance of String#[] method when passing Fixnum.

### DIFF
--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -254,6 +254,15 @@ class String
     end
 
     case index
+    when Fixnum
+      # The same code as in else section.
+      # Copied here to improve performance because Fixnum index is
+      # often used to iterate through String object.
+      index = Rubinius::Type.coerce_to index, Fixnum, :to_int
+      index = @num_bytes + index if index < 0
+
+      return if index < 0 || @num_bytes <= index
+      return @data[index]
     when Regexp
       match_data = index.search_region(self, 0, @num_bytes, true)
       Regexp.last_match = match_data


### PR DESCRIPTION
Hi,
this patch is related to issue #985. CSV.rb base on String#[] method to iterate through entire string object.
Before applying this patch running this code:

```
require 'csv'
CSV.foreach 'test.csv' do |row|
end
```

on 31MB file takes:
- ruby 1.9.2-p180:
  ruby test.rb  8,96s user 0,06s system 99% cpu 9,028 total
- ruby 1.8.7-p334:
  ruby test.rb  197,54s user 0,52s system 99% cpu 3:18,26 total
- rubinius 1.2.4dev (1.8.7 5cb7a7d2 yyyy-mm-dd JI):
  ruby test.rb  168,26s user 0,60s system 100% cpu 2:48,36 total
- rubinius-patched:
  ruby test.rb  116,09s user 0,40s system 100% cpu 1:55,85 total

After applying this patch it takes ~30% less time to complete.
