### PR TITLE
better checks for container emptiness

### DIFF
--- a/vm/gc/baker.cpp
+++ b/vm/gc/baker.cpp
@@ -342,8 +342,8 @@ namespace rubinius {
   }
 
   void BakerGC::handle_promotions() {
-    while(promoted_stack_.size() > 0 || !fully_scanned_p()) {
-      while(promoted_stack_.size() > 0) {
+    while(!promoted_stack_.empty() || !fully_scanned_p()) {
+      while(!promoted_stack_.empty()) {
         Object* obj = promoted_stack_.back();
         promoted_stack_.pop_back();
 

--- a/vm/gc/walker.cpp
+++ b/vm/gc/walker.cpp
@@ -102,7 +102,7 @@ namespace rubinius {
   }
 
   Object* ObjectWalker::next() {
-    if(stack_.size() == 0) return 0;
+    if(stack_.empty()) return 0;
 
     Object* obj = stack_.back();
     stack_.pop_back();

--- a/vm/llvm/jit.cpp
+++ b/vm/llvm/jit.cpp
@@ -272,7 +272,7 @@ namespace rubinius {
           // If we've been asked to stop, do so now.
           if(stop_) return;
 
-          while(pending_requests_.size() == 0) {
+          while(pending_requests_.empty()) {
             state = cIdle;
 
             // unlock and wait...


### PR DESCRIPTION
using size() for checking emptiness might be inefficient. empty() has O(1) guarantee and clearly shows intent
