### PR TITLE
changed postfix operators to prefix operators for non-primitive types

### DIFF
--- a/vm/agent.cpp
+++ b/vm/agent.cpp
@@ -381,7 +381,7 @@ namespace rubinius {
               continue;
             }
           }
-          i++;
+          ++i;
         }
 
         if(!found) {

--- a/vm/agent_components.cpp
+++ b/vm/agent_components.cpp
@@ -82,7 +82,7 @@ namespace agent {
     virtual ~Tree() {
       for(NamedItems::iterator i = hash_.begin();
           i != hash_.end();
-          i++) {
+          ++i) {
         delete i->second;
       }
     }
@@ -121,7 +121,7 @@ namespace agent {
 
       for(NamedItems::iterator i = hash_.begin();
           i != hash_.end();
-          i++) {
+          ++i) {
         Item* item = i->second;
         output.e().write_binary(item->name());
       }
@@ -231,7 +231,7 @@ namespace agent {
 
       for(config::Items::iterator i = shared_.config.items_begin();
           i != shared_.config.items_end();
-          i++) {
+          ++i) {
         config::ConfigItem* item = *i;
         output.e().write_binary(item->name());
       }
@@ -290,7 +290,7 @@ namespace agent {
 
       for(CallFrameLocationList::iterator i = shared_.call_frame_locations().begin();
           i != shared_.call_frame_locations().end();
-          i++) {
+          ++i) {
         CallFrame* loc = *(*i);
 
         std::ostringstream ss;
@@ -322,7 +322,7 @@ namespace agent {
 
       for(std::list<ManagedThread*>::iterator i = thrs->begin();
           i != thrs->end();
-          i++) {
+          ++i) {
         ManagedThread* thr = *i;
 
         if(VM* vm = thr->as_vm()) {

--- a/vm/builtin/compiledmethod.cpp
+++ b/vm/builtin/compiledmethod.cpp
@@ -296,7 +296,7 @@ namespace rubinius {
 
     for(IndirectLiterals::iterator i = vmm->indirect_literals().begin();
         i != vmm->indirect_literals().end();
-        i++) {
+        ++i) {
       Object** ptr = (*i);
       if((tmp = mark.call(*ptr)) != NULL) {
         *ptr = tmp;

--- a/vm/builtin/executable.cpp
+++ b/vm/builtin/executable.cpp
@@ -78,7 +78,7 @@ namespace rubinius {
     if(!inliners_ || inliners_ == (Inliners*)Qnil) return;
     for(std::list<CompiledMethod*>::const_iterator i = inliners_->inliners().begin();
         i != inliners_->inliners().end();
-        i++) {
+        ++i) {
       (*i)->backend_method()->deoptimize(state, *i);
     }
 
@@ -101,7 +101,7 @@ namespace rubinius {
 
       for(std::list<CompiledMethod*>::iterator i = inl->inliners().begin();
           i != inl->inliners().end();
-          i++) {
+          ++i) {
         CompiledMethod* cm = *i;
 
         Object* tmp = mark.call(cm);
@@ -126,7 +126,7 @@ namespace rubinius {
     if(exc->inliners_) {
       for(std::list<CompiledMethod*>::iterator i = exc->inliners_->inliners().begin();
           i != exc->inliners_->inliners().end();
-          i++) {
+          ++i) {
         visit.call(*i);
       }
     }

--- a/vm/builtin/find_object.cpp
+++ b/vm/builtin/find_object.cpp
@@ -160,7 +160,7 @@ namespace rubinius {
       TypeInfo* ti = state->om->type_info[obj->type_id()];
       for(TypeInfo::Slots::iterator i = ti->slots.begin();
           i != ti->slots.end();
-          i++) {
+          ++i) {
         Symbol* sym = Symbol::from_index(i->first);
         if(obj->get_ivar(state, sym) == target_) return true;
       }

--- a/vm/builtin/heap_dump.cpp
+++ b/vm/builtin/heap_dump.cpp
@@ -167,7 +167,7 @@ namespace rubinius {
     ~Layout() {
       for(LayoutMapping::iterator i = subtrees_.begin();
           i != subtrees_.end();
-          i++) {
+          ++i) {
         delete i->second;
       }
     }
@@ -200,7 +200,7 @@ namespace rubinius {
       std::vector<int> sym_ids;
       for(SymbolList::iterator i = syms.begin();
           i != syms.end();
-          i++) {
+          ++i) {
         sym_ids.push_back(enc.initialize_symbol(state, *i));
       }
 
@@ -209,7 +209,7 @@ namespace rubinius {
 
       for(std::vector<int>::iterator i = sym_ids.begin();
           i != sym_ids.end();
-          i++) {
+          ++i) {
         enc.write4(*i);
       }
     }
@@ -224,7 +224,7 @@ namespace rubinius {
     TypeInfo* ti = state->om->type_info[obj->type_id()];
     for(TypeInfo::Slots::iterator i = ti->slots.begin();
         i != ti->slots.end();
-        i++) {
+        ++i) {
       syms.push_back(Symbol::from_index(i->first));
     }
 
@@ -246,7 +246,7 @@ namespace rubinius {
     // Look down the Layout tree to find the one we want.
     for(SymbolList::iterator i = syms.begin();
         i != syms.end();
-        i++) {
+        ++i) {
       current = current->find_subtree(*i);
     }
 
@@ -353,7 +353,7 @@ namespace rubinius {
     void dump_ivars(STATE, Object* obj, SymbolList& syms) {
       for(SymbolList::iterator i = syms.begin();
           i != syms.end();
-          i++) {
+          ++i) {
         dump_reference(state, obj->get_ivar(state, *i));
       }
     }

--- a/vm/builtin/nativemethod.cpp
+++ b/vm/builtin/nativemethod.cpp
@@ -40,7 +40,7 @@ namespace rubinius {
     flush_cached_data();
     for(capi::HandleSet::iterator i = handles_.begin();
         i != handles_.end();
-        i++) {
+        ++i) {
       capi::Handle* handle = *i;
       handle->deref();
     }
@@ -104,7 +104,7 @@ namespace rubinius {
     if(check_handles_) {
       for(capi::HandleSet::iterator i = handles_.begin();
           i != handles_.end();
-          i++) {
+          ++i) {
         capi::Handle* handle = *i;
         handle->flush(env);
       }
@@ -127,7 +127,7 @@ namespace rubinius {
     if(check_handles_) {
       for(capi::HandleSet::iterator i = handles_.begin();
           i != handles_.end();
-          i++) {
+          ++i) {
         capi::Handle* handle = *i;
         handle->update(env);
       }

--- a/vm/config_parser.cpp
+++ b/vm/config_parser.cpp
@@ -40,7 +40,7 @@ namespace rubinius {
     ConfigParser::ConfigMap::iterator i = variables.begin();
     while(i != variables.end()) {
       delete i->second;
-      i++;
+      ++i;
     }
   }
 
@@ -176,7 +176,7 @@ namespace rubinius {
       if(i->second->in_section(prefix)) {
         list->push_back(i->second);
       }
-      i++;
+      ++i;
     }
 
     return list;
@@ -185,7 +185,7 @@ namespace rubinius {
   void ConfigParser::update_configuration(Configuration& config) {
     for(ConfigParser::ConfigMap::iterator i = variables.begin();
         i != variables.end();
-        i++) {
+        ++i) {
       if(!config.import(i->first.c_str(), i->second->value.c_str())) {
         if(i->second->in_section("vm.") ||
            i->second->in_section("jit.") ||

--- a/vm/gc/baker.cpp
+++ b/vm/gc/baker.cpp
@@ -136,12 +136,12 @@ namespace rubinius {
 
     for(std::list<gc::WriteBarrier*>::iterator wbi = object_memory_->aux_barriers().begin();
         wbi != object_memory_->aux_barriers().end();
-        wbi++) {
+        ++wbi) {
       gc::WriteBarrier* wb = *wbi;
       ObjectArray* rs = wb->swap_remember_set();
       for(ObjectArray::iterator oi = rs->begin();
           oi != rs->end();
-          oi++) {
+          ++oi) {
         tmp = *oi;
 
         if(tmp) {
@@ -160,7 +160,7 @@ namespace rubinius {
     if(data.threads()) {
       for(std::list<ManagedThread*>::iterator i = data.threads()->begin();
           i != data.threads()->end();
-          i++) {
+          ++i) {
         for(Roots::Iterator ri((*i)->roots()); ri.more(); ri.advance()) {
           ri->set(saw_object(ri->get()));
         }
@@ -208,7 +208,7 @@ namespace rubinius {
     if(gh) {
       for(std::list<capi::Handle**>::iterator i = gh->begin();
           i != gh->end();
-          i++) {
+          ++i) {
         capi::Handle** loc = *i;
         if(capi::Handle* hdl = *loc) {
           if(!CAPI_REFERENCE_P(hdl)) continue;
@@ -257,7 +257,7 @@ namespace rubinius {
     // Walk all the call frames
     for(CallFrameLocationList::iterator i = data.call_frames().begin();
         i != data.call_frames().end();
-        i++) {
+        ++i) {
       CallFrame** loc = *i;
       walk_call_frame(*loc);
     }
@@ -406,7 +406,7 @@ namespace rubinius {
     if(object_memory_->running_finalizers()) {
       for(std::list<FinalizeObject>::iterator i = object_memory_->finalize().begin();
           i != object_memory_->finalize().end();
-          i++) {
+          ++i) {
         if(i->object) {
           i->object = saw_object(i->object);
         }
@@ -473,7 +473,7 @@ namespace rubinius {
       if(remove) {
         i = object_memory_->finalize().erase(i);
       } else {
-        i++;
+        ++i;
       }
     }
   }

--- a/vm/gc/gc.cpp
+++ b/vm/gc/gc.cpp
@@ -234,7 +234,7 @@ namespace rubinius {
 
     for(ObjectArray::iterator i = weak_refs_->begin();
         i != weak_refs_->end();
-        i++) {
+        ++i) {
       WeakRef* ref = try_as<WeakRef>(*i);
       if(!ref) continue; // WTF.
 

--- a/vm/gc/immix.cpp
+++ b/vm/gc/immix.cpp
@@ -142,7 +142,7 @@ namespace rubinius {
     if(data.threads()) {
       for(std::list<ManagedThread*>::iterator i = data.threads()->begin();
           i != data.threads()->end();
-          i++) {
+          ++i) {
         for(Roots::Iterator ri((*i)->roots()); ri.more(); ri.advance()) {
           ri->set(saw_object(ri->get()));
         }
@@ -168,7 +168,7 @@ namespace rubinius {
     if(gh) {
       for(std::list<capi::Handle**>::iterator i = gh->begin();
           i != gh->end();
-          i++) {
+          ++i) {
         capi::Handle** loc = *i;
         if(capi::Handle* hdl = *loc) {
           if(!CAPI_REFERENCE_P(hdl)) continue;
@@ -215,7 +215,7 @@ namespace rubinius {
     // Walk all the call frames
     for(CallFrameLocationList::const_iterator i = data.call_frames().begin();
         i != data.call_frames().end();
-        i++) {
+        ++i) {
       callframes++;
       CallFrame** loc = *i;
       walk_call_frame(*loc);
@@ -244,7 +244,7 @@ namespace rubinius {
 
     for(ObjectArray::iterator oi = current_rs->begin();
         oi != current_rs->end();
-        oi++) {
+        ++oi) {
       tmp = *oi;
       // unremember_object throws a NULL in to remove an object
       // so we don't have to compact the set in unremember
@@ -261,12 +261,12 @@ namespace rubinius {
 
     for(std::list<gc::WriteBarrier*>::iterator wbi = object_memory_->aux_barriers().begin();
         wbi != object_memory_->aux_barriers().end();
-        wbi++) {
+        ++wbi) {
       gc::WriteBarrier* wb = *wbi;
       ObjectArray* rs = wb->remember_set();
       for(ObjectArray::iterator oi = rs->begin();
           oi != rs->end();
-          oi++) {
+          ++oi) {
         tmp = *oi;
 
         if(tmp) {
@@ -374,7 +374,7 @@ namespace rubinius {
     if(object_memory_->running_finalizers()) {
       for(std::list<FinalizeObject>::iterator i = object_memory_->finalize().begin();
           i != object_memory_->finalize().end();
-          i++) {
+          ++i) {
         if(i->object) {
           i->object = saw_object(i->object);
         }
@@ -440,7 +440,7 @@ namespace rubinius {
       if(remove) {
         i = object_memory_->finalize().erase(i);
       } else {
-        i++;
+        ++i;
       }
     }
   }

--- a/vm/gc/inflated_headers.cpp
+++ b/vm/gc/inflated_headers.cpp
@@ -7,7 +7,7 @@ namespace rubinius {
   InflatedHeaders::~InflatedHeaders() {
     for(Chunks::iterator i = chunks_.begin();
         i != chunks_.end();
-        i++) {
+        ++i) {
       InflatedHeader* chunk = *i;
       delete[] chunk;
     }
@@ -57,7 +57,7 @@ namespace rubinius {
         delete[] chunk;
         i = chunks_.erase(i);
       } else {
-        i++;
+        ++i;
       }
     }
 
@@ -67,7 +67,7 @@ namespace rubinius {
 
     for(Chunks::iterator i = chunks_.begin();
         i != chunks_.end();
-        i++) {
+        ++i) {
       InflatedHeader* chunk = *i;
 
       for(size_t j = 0; j < cChunkSize; j++) {

--- a/vm/gc/marksweep.cpp
+++ b/vm/gc/marksweep.cpp
@@ -34,7 +34,7 @@ namespace rubinius {
   void MarkSweepGC::free_objects() {
     std::list<Object*>::iterator i;
 
-    for(i = entries.begin(); i != entries.end(); i++) {
+    for(i = entries.begin(); i != entries.end(); ++i) {
       free_object(*i, true);
     }
   }
@@ -132,7 +132,7 @@ namespace rubinius {
     // Walk all the call frames
     for(CallFrameLocationList::const_iterator i = call_frames.begin();
         i != call_frames.end();
-        i++) {
+        ++i) {
       CallFrame** loc = *i;
       walk_call_frame(*loc);
     }
@@ -163,7 +163,7 @@ namespace rubinius {
     for(i = entries.begin(); i != entries.end();) {
       Object* obj = *i;
       if(obj->marked_p(object_memory_->mark())) {
-        i++;
+        ++i;
       } else {
         free_object(obj);
         i = entries.erase(i);
@@ -197,7 +197,7 @@ namespace rubinius {
 
     for(std::list<Object*>::iterator i = entries.begin();
         i != entries.end();
-        i++) {
+        ++i) {
       Object* obj = *i;
       Class* cls = obj->class_object(object_memory_->state);
 
@@ -218,7 +218,7 @@ namespace rubinius {
 
     for(std::map<Class*,PerClass>::iterator i = stats.begin();
         i != stats.end();
-        i++) {
+        ++i) {
       std::cout << i->first->name()->c_str(object_memory_->state) << "\n"
                 << "  objects: " << i->second.objects << "\n"
                 << "    bytes: " << i->second.bytes << "\n";
@@ -264,7 +264,7 @@ namespace rubinius {
   ObjectPosition MarkSweepGC::validate_object(Object* obj) {
     std::list<Object*>::iterator i;
 
-    for(i = entries.begin(); i != entries.end(); i++) {
+    for(i = entries.begin(); i != entries.end(); ++i) {
       if(*i == obj) return cMatureObject;
     }
 

--- a/vm/gc/walker.cpp
+++ b/vm/gc/walker.cpp
@@ -34,12 +34,12 @@ namespace rubinius {
 
     for(std::list<gc::WriteBarrier*>::iterator wbi = object_memory_->aux_barriers().begin();
         wbi != object_memory_->aux_barriers().end();
-        wbi++) {
+        ++wbi) {
       gc::WriteBarrier* wb = *wbi;
       ObjectArray* rs = wb->remember_set();
       for(ObjectArray::iterator oi = rs->begin();
           oi != rs->end();
-          oi++) {
+          ++oi) {
         tmp = *oi;
 
         if(tmp) saw_object(tmp);
@@ -53,7 +53,7 @@ namespace rubinius {
     if(data.threads()) {
       for(std::list<ManagedThread*>::iterator i = data.threads()->begin();
           i != data.threads()->end();
-          i++) {
+          ++i) {
         for(Roots::Iterator ri((*i)->roots()); ri.more(); ri.advance()) {
           saw_object(ri->get());
         }
@@ -95,7 +95,7 @@ namespace rubinius {
     // Walk all the call frames
     for(CallFrameLocationList::iterator i = data.call_frames().begin();
         i != data.call_frames().end();
-        i++) {
+        ++i) {
       CallFrame** loc = *i;
       walk_call_frame(*loc);
     }

--- a/vm/gc/write_barrier.cpp
+++ b/vm/gc/write_barrier.cpp
@@ -24,7 +24,7 @@ namespace gc {
   void WriteBarrier::unremember_object(Object* target) {
     for(ObjectArray::iterator oi = remember_set_->begin();
         oi != remember_set_->end();
-        oi++) {
+        ++oi) {
       if(*oi == target) {
         *oi = NULL;
         target->clear_remember();

--- a/vm/inline_cache.cpp
+++ b/vm/inline_cache.cpp
@@ -648,7 +648,7 @@ namespace rubinius {
     CacheVector& vec = caches_[sym->index()];
     for(CacheVector::iterator i = vec.begin();
         i != vec.end();
-        i++) {
+        ++i) {
       if(*i == cache) {
         vec.erase(i);
         return;
@@ -661,7 +661,7 @@ namespace rubinius {
 
     for(CacheVector::iterator i = vec.begin();
         i != vec.end();
-        i++) {
+        ++i) {
       (*i)->clear();
     }
   }
@@ -678,10 +678,10 @@ namespace rubinius {
 
     for(CacheHash::iterator hi = caches_.begin();
         hi != caches_.end();
-        hi++) {
+        ++hi) {
       for(CacheVector::iterator vi = hi->second.begin();
           vi != hi->second.end();
-          vi++) {
+          ++vi) {
         InlineCache* ic = *vi;
         int seen = ic->classes_seen();
         if(ic->seen_classes_overflow() > 0) {
@@ -710,10 +710,10 @@ namespace rubinius {
 
     for(CacheHash::iterator hi = caches_.begin();
         hi != caches_.end();
-        hi++) {
+        ++hi) {
       for(CacheVector::iterator vi = hi->second.begin();
           vi != hi->second.end();
-          vi++) {
+          ++vi) {
         InlineCache* ic = *vi;
         int seen = ic->classes_seen();
         if(ic->seen_classes_overflow() > 0) {
@@ -741,10 +741,10 @@ namespace rubinius {
 
     for(CacheHash::iterator hi = caches_.begin();
         hi != caches_.end();
-        hi++) {
+        ++hi) {
       for(CacheVector::iterator vi = hi->second.begin();
           vi != hi->second.end();
-          vi++) {
+          ++vi) {
         InlineCache* ic = *vi;
         if(ic->seen_classes_overflow() > 0) {
           ic->print(state, std::cerr);

--- a/vm/llvm/cfg.hpp
+++ b/vm/llvm/cfg.hpp
@@ -99,7 +99,7 @@ namespace jit {
     ~CFGCalculator() {
       for(Blocks::iterator i = blocks_.begin();
           i != blocks_.end();
-          i++) {
+          ++i) {
         delete i->second;
       }
     }

--- a/vm/llvm/jit_compiler.cpp
+++ b/vm/llvm/jit_compiler.cpp
@@ -160,7 +160,7 @@ namespace jit {
 
     for(std::vector<BasicBlock*>::iterator i = to_remove.begin();
         i != to_remove.end();
-        i++) {
+        ++i) {
       (*i)->eraseFromParent();
     }
 

--- a/vm/llvm/jit_runtime.cpp
+++ b/vm/llvm/jit_runtime.cpp
@@ -32,7 +32,7 @@ namespace jit {
 
     for(std::list<jit::RuntimeData*>::iterator i = runtime_data_.begin();
         i != runtime_data_.end();
-        i++) {
+        ++i) {
       jit::RuntimeData* rd = *i;
 
       tmp = mark.call(rd->method());
@@ -58,7 +58,7 @@ namespace jit {
   void RuntimeDataHolder::visit_all(ObjectVisitor& visit) {
     for(std::list<jit::RuntimeData*>::iterator i = runtime_data_.begin();
         i != runtime_data_.end();
-        i++) {
+        ++i) {
       jit::RuntimeData* rd = *i;
 
       visit.call(rd->method());
@@ -71,7 +71,7 @@ namespace jit {
   void RuntimeDataHolder::run_write_barrier(gc::WriteBarrier* wb, Object* obj) {
     for(std::list<jit::RuntimeData*>::iterator i = runtime_data_.begin();
         i != runtime_data_.end();
-        i++) {
+        ++i) {
       jit::RuntimeData* rd = *i;
 
       obj->write_barrier(wb, rd->method());

--- a/vm/llvm/jit_visit.hpp
+++ b/vm/llvm/jit_visit.hpp
@@ -1537,7 +1537,7 @@ namespace rubinius {
 
       for(std::list<JITMethodInfo*>::iterator i = in_scope.begin();
           i != in_scope.end();
-          i++ ) {
+          ++i) {
         nfo = *i;
 
         JITInlineBlock* ib = nfo->inline_block();

--- a/vm/llvm/passes.cpp
+++ b/vm/llvm/passes.cpp
@@ -42,10 +42,10 @@ namespace {
 
       for(Function::iterator bb = f.begin(), e = f.end();
           bb != e;
-          bb++) {
+          ++bb) {
         for(BasicBlock::iterator inst = bb->begin();
             inst != bb->end();
-            inst++) {
+            ++inst) {
           ICmpInst* icmp = dyn_cast<ICmpInst>(inst);
           if(icmp == NULL) continue;
 
@@ -128,10 +128,10 @@ namespace {
 
       for(Function::iterator bb = f.begin(), e = f.end();
           bb != e;
-          bb++) {
+          ++bb) {
         for(BasicBlock::iterator inst = bb->begin();
             inst != bb->end();
-            inst++) {
+            ++inst) {
           CallInst* call = dyn_cast<CallInst>(inst);
           if(!call) continue;
 
@@ -166,7 +166,7 @@ namespace {
 
       for(std::vector<CallInst*>::iterator i = to_remove.begin();
           i != to_remove.end();
-          i++) {
+          ++i) {
         CallInst* call = *i;
         for(Value::use_iterator u = call->use_begin();
             u != call->use_end(); /* nothing */)
@@ -262,10 +262,10 @@ namespace {
 
       for(Function::iterator bb = f.begin(), e = f.end();
           bb != e;
-          bb++) {
+          ++bb) {
         for(BasicBlock::iterator inst = bb->begin();
             inst != bb->end();
-            inst++) {
+            ++inst) {
           CallInst *call = dyn_cast<CallInst>(inst);
           if(call == NULL) continue;
 
@@ -287,7 +287,7 @@ namespace {
 
       for(std::vector<CallInst*>::iterator i = to_remove.begin();
           i != to_remove.end();
-          i++) {
+          ++i) {
         (*i)->eraseFromParent();
       }
 

--- a/vm/objectmemory.cpp
+++ b/vm/objectmemory.cpp
@@ -194,7 +194,7 @@ namespace rubinius {
     if(data.threads()) {
       for(std::list<ManagedThread*>::iterator i = data.threads()->begin();
           i != data.threads()->end();
-          i++) {
+          ++i) {
         refill_slab((*i)->local_slab());
       }
     }
@@ -561,7 +561,7 @@ namespace rubinius {
   void ObjectMemory::set_ruby_finalizer(Object* obj, Object* fin) {
     // See if there already one.
     for(std::list<FinalizeObject>::iterator i = finalize_.begin();
-        i != finalize_.end(); i++)
+        i != finalize_.end(); ++i)
     {
       if(i->object == obj) {
         if(fin->nil_p()) {
@@ -699,7 +699,7 @@ namespace rubinius {
     {
       FinalizeObject& fi = *i;
 
-      if(!kind_of<IO>(fi.object)) { i++; continue; }
+      if(!kind_of<IO>(fi.object)) { ++i; continue; }
 
       // Only finalize things that haven't been finalized.
       if(fi.status != FinalizeObject::eFinalized) {
@@ -914,7 +914,7 @@ namespace rubinius {
     std::cout << ary.size() << " total references:\n";
     for(ObjectArray::iterator i = ary.begin();
         i != ary.end();
-        i++) {
+        ++i) {
       std::cout << "  " << (*i)->to_s(state, true)->c_str(state) << "\n";
 
       if(++count == 100) break;

--- a/vm/symboltable.cpp
+++ b/vm/symboltable.cpp
@@ -116,7 +116,7 @@ namespace rubinius {
         symbols[hash] = v;
       } else {
         SymbolIds& v = entry->second;
-        for(SymbolIds::iterator i = v.begin(); i != v.end(); i++) {
+        for(SymbolIds::iterator i = v.begin(); i != v.end(); ++i) {
           std::string& s = strings[*i];
 
           if(!strcmp(s.c_str(), str)) return Symbol::from_index(*i);
@@ -186,7 +186,7 @@ namespace rubinius {
 
     for(SymbolStrings::iterator i = strings.begin();
         i != strings.end();
-        i++) {
+        ++i) {
       total += i->size();
       total += sizeof(std::string);
     }
@@ -198,8 +198,8 @@ namespace rubinius {
     size_t idx = 0;
     Array* ary = Array::create(state, this->size());
 
-    for(SymbolMap::iterator s = symbols.begin(); s != symbols.end(); s++) {
-      for(SymbolIds::iterator i = s->second.begin(); i != s->second.end(); i++) {
+    for(SymbolMap::iterator s = symbols.begin(); s != symbols.end(); ++s) {
+      for(SymbolIds::iterator i = s->second.begin(); i != s->second.end(); ++i) {
         ary->set(state, idx++, (Object*)Symbol::from_index(state, *i));
       }
     }

--- a/vm/util/bert.hpp
+++ b/vm/util/bert.hpp
@@ -582,7 +582,7 @@ namespace bert {
         if(elements_) {
           for(ValueList::iterator i = elements_->begin();
               i != elements_->end();
-              i++) {
+              ++i) {
             delete *i;
           }
           delete elements_;
@@ -674,7 +674,7 @@ namespace bert {
 
       for(ValueList::iterator i = elements_->begin();
           i != elements_->end();
-          i++, j++) {
+          ++i, ++j) {
         (*i)->print(stream);
         if(j != last) stream << ", ";
       }

--- a/vm/util/configuration.hpp
+++ b/vm/util/configuration.hpp
@@ -187,7 +187,7 @@ namespace config {
 
       for(std::vector<Bool*>::iterator i = sub_bools_.begin();
           i != sub_bools_.end();
-          i++) {
+          ++i) {
         (*i)->set(str);
       }
     }
@@ -200,7 +200,7 @@ namespace config {
   inline bool Configuration::import(const char* key, const char* val) {
     for(Items::iterator i = items_.begin();
         i != items_.end();
-        i++) {
+        ++i) {
       ConfigItem* item = *i;
       if(item->set_maybe(key, val)) return true;
     }
@@ -211,7 +211,7 @@ namespace config {
   inline ConfigItem* Configuration::find(const char* key) {
     for(Items::iterator i = items_.begin();
         i != items_.end();
-        i++) {
+        ++i) {
       ConfigItem* item = *i;
       if(item->equal_p(key)) return item;
     }
@@ -222,7 +222,7 @@ namespace config {
   inline void Configuration::print(bool desc) {
     for(Items::iterator i = items_.begin();
         i != items_.end();
-        i++) {
+        ++i) {
       ConfigItem* item = *i;
       std::cout << item->name() << ": ";
       item->print_value(std::cout);

--- a/vm/util/immix.hpp
+++ b/vm/util/immix.hpp
@@ -421,7 +421,7 @@ namespace immix {
     ~BlockAllocator() {
       for(Chunks::iterator i = chunks_.begin();
           i != chunks_.end();
-          i++) {
+          ++i) {
         Chunk* chunk = *i;
         chunk->free();
       }
@@ -498,7 +498,7 @@ namespace immix {
     void reset() {
       for(Chunks::iterator i = chunks_.begin();
           i != chunks_.end();
-          i++) {
+          ++i) {
         Chunk* chunk = *i;
         chunk->update_stats();
       }
@@ -708,7 +708,7 @@ namespace immix {
     void sweep_blocks() {
       for(BlockList::const_iterator i = evacuate_.begin();
           i != evacuate_.end();
-          i++) {
+          ++i) {
         Block* block = *i;
         if(block->status() == cEvacuate) {
           block->set_status(cFree);
@@ -780,7 +780,7 @@ namespace immix {
       Chunks& chunks = block_allocator_.chunks();
       for(Chunks::iterator i = chunks.begin();
           i != chunks.end();
-          i++) {
+          ++i) {
         if((*i)->contains_address(addr)) return true;
       }
 

--- a/vm/vmmethod.cpp
+++ b/vm/vmmethod.cpp
@@ -146,7 +146,7 @@ namespace rubinius {
 
     for(IndirectLiterals::iterator i = indirect_literals_.begin();
         i != indirect_literals_.end();
-        i++) {
+        ++i) {
       delete[] *i;
     }
   }


### PR DESCRIPTION
Preincrementing is never slower than postincrementing and can be faster. Compilers can optimize it but since there is no additional cost it's better to do it idiomatic way. Additional benefit is consistent style for non primitive types across all C++ Rubinius codebase.
