### PR TITLE
Replaced expect documentation with documentation provided in ruby

### DIFF
--- a/lib/expect.rb
+++ b/lib/expect.rb
@@ -1,36 +1,15 @@
 # This is originally from the pty extension that comes with MRI
 # by default.
-#
-# Documentation by Mike Ballou and Brian Miller on 06/21/2011
+
 $expect_verbose = false
 
 class IO
-  # == Overview
-  # expect(match) listens to an IO input stream and returns the contents when
-  # the match is found. If a block is provided, it returns the block applied
-  # to the string
-  #  
-  # +pat+ is the pattern that will be matched against the input. +pat+ can be
-  # a string or a Regexp
-  # +timeout+ is the amount of time the method will try to read from the IO
-  # object before returning. Leaving the +timeout+ to +nil+ causes the read to
-  # block infinitely until an event transpires.
-  #
-  # expect can take a block that will be executed if the input read matches
-  # the pattern provided.
-  #
-  # == Examples of use
-  # 
-  # === With a block
-  #
-  #   STDIN.expect(/stop/) do |m|
-  #     puts "For the love of god " + m
-  #   end
-  #
-  # === Without a block
-  #
-  #   STDIN.expect(/stop/)
-  
+  # Reads ios until pattern matches or the timeout is over. It returns
+  # an array with the read buffer, followed by the matches. If a block is given,
+  # the result is yielded to the block and returns nil. The optional timeout parameter defines,
+  # in seconds, the total time to wait for pattern. If it is over of eof is found, it 
+  # returns/yields nil. However, the buffer in a timeout session is kept for the next expect call.
+  # The default timeout is 9999999 seconds.
   def expect(pat,timeout=9999999)
     case pat
     when String


### PR DESCRIPTION
As mentioned in https://github.com/rubinius/rubinius/pull/1039 I should have checked the ruby repo for docs first.
