### PR TITLE
Fixing inplace edit when no backup extension provided

### DIFF
--- a/kernel/common/argf.rb
+++ b/kernel/common/argf.rb
@@ -489,6 +489,8 @@ module Rubinius
         @init = true
       end
 
+      File.unlink(@backup_filename) if @backup_filename && $-i == ""
+
       return false if @use_stdin_only || ARGV.empty?
 
       @advance = false
@@ -498,11 +500,11 @@ module Rubinius
       @filename = file
 
       if $-i && @stream != STDIN
-        @original_stdout = $stdout
-        @backup_filename = "#{@filename}#{$-i}"
+        backup_extension = $-i == "" ? ".bak" : $-i
+        @backup_filename = "#{@filename}#{backup_extension}"
         File.rename(@filename, @backup_filename)
         @stream = File.open(@backup_filename, "r")
-        $stdout = @current_output = File.open(@filename, "w")
+        $stdout = File.open(@filename, "w")
       end
 
       return true

--- a/spec/tags/ruby/core/argf/gets_tags.txt
+++ b/spec/tags/ruby/core/argf/gets_tags.txt
@@ -1,1 +1,0 @@
-fails:ARGF.gets modifies the files when in place edit mode is on

--- a/spec/tags/ruby/core/argf/readline_tags.txt
+++ b/spec/tags/ruby/core/argf/readline_tags.txt
@@ -1,1 +1,0 @@
-fails:ARGF.readline modifies the files when in place edit mode is on


### PR DESCRIPTION
Implemented failing test for inplace edit
