### PR TITLE
guard against possible null pointer dereference

### DIFF
--- a/vm/builtin/block_environment.cpp
+++ b/vm/builtin/block_environment.cpp
@@ -246,9 +246,13 @@ namespace rubinius {
     // over again (ie Proc.new) so we mark the method as not
     // inlinable so that this works even with the JIT on.
 
+    if(!target) {
+      return Qnil;
+    }
+
     target->cm->backend_method()->set_no_inline();
 
-    if(target && target->scope) {
+    if(target->scope) {
       return target->scope->block();
     }
 


### PR DESCRIPTION
if 'target' can be null better to check it before calling 'target->cm->backend_method()->set_no_inline();'
in that case we don't need extra check when checking for 'target->scope'
