### PR TITLE
removed unnecessary 'rubinius::' qualification

### DIFF
--- a/vm/agent.cpp
+++ b/vm/agent.cpp
@@ -50,7 +50,7 @@ namespace rubinius {
 
     if(pipe(control_) != 0) {
       perror("pipe");
-      rubinius::abort();
+      abort();
     }
 
     add_fd(read_control());
@@ -60,12 +60,12 @@ namespace rubinius {
 
     if(pipe(a2r_) != 0) {
       perror("pipe");
-      rubinius::abort();
+      abort();
     }
 
     if(pipe(r2a_) != 0) {
       perror("pipe");
-      rubinius::abort();
+      abort();
     }
 
     add_fd(r2a_agent());

--- a/vm/builtin/channel.cpp
+++ b/vm/builtin/channel.cpp
@@ -104,7 +104,7 @@ namespace rubinius {
 
     // We pin this so we can pass condition_ out without worrying about
     // us moving it.
-    if(!this->pin()) rubinius::abort();
+    if(!this->pin()) abort();
 
     struct timeval tv = {0,0};
     if(use_timed_wait) {

--- a/vm/builtin/nativemethod.cpp
+++ b/vm/builtin/nativemethod.cpp
@@ -147,7 +147,7 @@ namespace rubinius {
   VALUE NativeMethodEnvironment::get_handle(Object* obj) {
     if(obj->reference_p()) {
       if(!current_native_frame_) {
-        rubinius::bug("Unable to create handles with no NMF");
+        bug("Unable to create handles with no NMF");
       }
 
       return current_native_frame_->get_handle(state_, obj);
@@ -178,7 +178,7 @@ namespace rubinius {
 
   capi::HandleSet& NativeMethodEnvironment::handles() {
     if(!current_native_frame_) {
-      rubinius::bug("Requested handles with no frame");
+      bug("Requested handles with no frame");
     }
 
     return current_native_frame_->handles();

--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -107,7 +107,7 @@ namespace rubinius {
     std::cerr << "bug. Please report this on the rubinius issue tracker.\n";
     std::cerr << "Include the following backtrace in the issue:\n\n";
 
-    rubinius::abort();
+    abort();
   }
 
   void Environment::setup_cpp_terminate() {

--- a/vm/inline_cache.cpp
+++ b/vm/inline_cache.cpp
@@ -118,7 +118,7 @@ namespace rubinius {
     } while(1);
 
     // Shouldn't be here!
-    rubinius::abort();
+    abort();
   }
 
   bool InlineCache::fill_private(STATE, Symbol* name, Module* start) {
@@ -185,7 +185,7 @@ namespace rubinius {
     } while(1);
 
     // Shouldn't be here!
-    rubinius::abort();
+    abort();
   }
 
   bool InlineCache::fill_method_missing(STATE, Module* module) {
@@ -230,7 +230,7 @@ namespace rubinius {
     } while(1);
 
     // Shouldn't be here!
-    rubinius::abort();
+    abort();
   }
 
   void InlineCache::run_wb(STATE, CompiledMethod* exec) {

--- a/vm/vm.cpp
+++ b/vm/vm.cpp
@@ -492,7 +492,7 @@ namespace rubinius {
     if(thread_state()->raise_reason() == cNone) {
       std::cout << "Exception propogating, but none registered!\n";
       call_frame->print_backtrace(this);
-      rubinius::abort();
+      abort();
     }
   }
 


### PR DESCRIPTION
there is no need to use extra 'rubinius::' qualification when inside 'rubinius' namespace. i think its even an error on some compilers (intel or visual studio? can't check it right now).
