### PR TITLE
fix segfault when BUILTIN_TYPE is used

### DIFF
--- a/spec/ruby/optional/capi/ext/object_spec.c
+++ b/spec/ruby/optional/capi/ext/object_spec.c
@@ -238,6 +238,43 @@ static VALUE so_is_type_data(VALUE self, VALUE obj) {
 }
 #endif
 
+#ifdef HAVE_BUILTIN_TYPE
+static VALUE so_is_builtin_type_object(VALUE self, VALUE obj) {
+  if(BUILTIN_TYPE(obj) == T_OBJECT) {
+    return Qtrue;
+  }
+  return Qfalse;
+}
+
+static VALUE so_is_builtin_type_array(VALUE self, VALUE obj) {
+  if(BUILTIN_TYPE(obj) == T_ARRAY) {
+    return Qtrue;
+  }
+  return Qfalse;
+}
+
+static VALUE so_is_builtin_type_module(VALUE self, VALUE obj) {
+  if(BUILTIN_TYPE(obj) == T_MODULE) {
+    return Qtrue;
+  }
+  return Qfalse;
+}
+
+static VALUE so_is_builtin_type_class(VALUE self, VALUE obj) {
+  if(BUILTIN_TYPE(obj) == T_CLASS) {
+    return Qtrue;
+  }
+  return Qfalse;
+}
+
+static VALUE so_is_builtin_type_data(VALUE self, VALUE obj) {
+  if(BUILTIN_TYPE(obj) == T_DATA) {
+    return Qtrue;
+  }
+  return Qfalse;
+}
+#endif
+
 #ifdef HAVE_RB_TO_INT
 static VALUE object_spec_rb_to_int(VALUE self, VALUE obj) {
   return rb_to_int(obj);
@@ -416,6 +453,14 @@ void Init_object_spec() {
   rb_define_method(cls, "rb_is_type_module", so_is_type_module, 1);
   rb_define_method(cls, "rb_is_type_class", so_is_type_class, 1);
   rb_define_method(cls, "rb_is_type_data", so_is_type_data, 1);
+#endif
+
+#ifdef HAVE_BUILTIN_TYPE
+  rb_define_method(cls, "rb_is_builtin_type_object", so_is_builtin_type_object, 1);
+  rb_define_method(cls, "rb_is_builtin_type_array", so_is_builtin_type_array, 1);
+  rb_define_method(cls, "rb_is_builtin_type_module", so_is_builtin_type_module, 1);
+  rb_define_method(cls, "rb_is_builtin_type_class", so_is_builtin_type_class, 1);
+  rb_define_method(cls, "rb_is_builtin_type_data", so_is_builtin_type_data, 1);
 #endif
 
 #ifdef HAVE_RB_TO_INT

--- a/spec/ruby/optional/capi/ext/rubyspec.h
+++ b/spec/ruby/optional/capi/ext/rubyspec.h
@@ -262,6 +262,7 @@
 #define HAVE_RB_TO_INT                     1
 #define HAVE_RTEST                         1
 #define HAVE_TYPE                          1
+#define HAVE_BUILTIN_TYPE                  1
 
 /* Proc */
 #define HAVE_RB_PROC_NEW                   1

--- a/spec/ruby/optional/capi/object_spec.rb
+++ b/spec/ruby/optional/capi/object_spec.rb
@@ -194,6 +194,18 @@ describe "CApiObject" do
     @o.rb_is_type_data(Time.now).should == true
   end
 
+  it "BUILTIN_TYPE should return the type constant for the object" do
+    class DescArray < Array
+    end
+    @o.rb_is_builtin_type_object([]).should == false
+    @o.rb_is_builtin_type_object(ObjectTest.new).should == true
+    @o.rb_is_builtin_type_array([]).should == true
+    @o.rb_is_builtin_type_array(DescArray.new).should == true
+    @o.rb_is_builtin_type_module(ObjectTest).should == false
+    @o.rb_is_builtin_type_class(ObjectTest).should == true
+    @o.rb_is_builtin_type_data(Time.now).should == true
+  end
+
   describe "RTEST" do
     it "returns C false if passed Qfalse" do
       @o.RTEST(false).should be_false

--- a/vm/capi/include/ruby.h
+++ b/vm/capi/include/ruby.h
@@ -657,6 +657,11 @@ VALUE rb_uint2big(unsigned long number);
 /** Return an integer type id for the object. @see rb_type() */
 #define TYPE(handle)      rb_type(handle)
 
+/** Alias to rb_type. This is not exactly the same as in MRI, but it makes sure
+ * that it won't segfault if you give BUILTIN_TYPE an immediate such as a Fixnum
+ */
+#define BUILTIN_TYPE(handle) rb_type(handle)
+
 /** Convert unsigned int to a Ruby Integer. */
 #define UINT2FIX(i)       UINT2NUM((i))
 


### PR DESCRIPTION
When building xapian-ruby embedded in xapian_db, is was failing because of a call to BUILTIN_TYPE. With some help of Dirk Jan a fix for this. It is fixed by implementing it as an alias for TYPE.
