### PR TITLE
Put List inside Rubinius:: namespace to avoid namespace conflicts

### DIFF
--- a/vm/builtin/list.cpp
+++ b/vm/builtin/list.cpp
@@ -21,9 +21,11 @@ namespace rubinius {
   /* Register the List and List::Node classes as globals */
   void List::init(STATE) {
     Class* cls;
-    cls = state->new_class("List", G(object));
+    cls = state->new_class_under("List", G(rubinius));
+
     GO(list).set(cls);
     cls->set_object_type(state, ListType);
+    G(list)->name(state, state->symbol("Rubinius::List"));
 
     GO(list_node).set(state->new_class("Node", G(object), cls));
 


### PR DESCRIPTION
I've found a namespace conflict with List in a gem.

Now List is Rubinius::List so that there are no conflicts!
