### PR TITLE
2.0.0pre configure fix for zlib

### DIFF
--- a/configure
+++ b/configure
@@ -858,7 +858,7 @@ int main() { return tgetnum(""); }
       @rb_readline = true
     end
 
-    @vendor_zlib = false unless @features["vendor-zlib"]
+    @vendor_zlib = true if @features["vendor-zlib"]
   end
 
   def process


### PR DESCRIPTION
Needed to allow build to proceed on Win7 32bit. The build was failing because the `vendor/zlib` dependency hadn't been built.

Configuration WFM when tested with `ruby configure` (on by default), `ruby configure --with-vendor-zlib`, and `ruby configure --without-vendor-zlib` 

Appears relevant to `master`
