### PR TITLE
Failing spec: Instance_eval with string prevents inner eval'ing of local variables

### DIFF
--- a/spec/ruby/core/kernel/instance_eval_spec.rb
+++ b/spec/ruby/core/kernel/instance_eval_spec.rb
@@ -114,6 +114,24 @@ describe "Kernel#instance_eval" do
     end
   end
 
+  it 'allows evaling local variables when using a block' do
+    obj = Object.new
+    result = obj.instance_eval do
+      foo = 123
+      eval('foo')
+    end
+    result.should == 123
+  end
+
+  it 'allows evaling local variables when using a string' do
+    obj = Object.new
+    result = obj.instance_eval %{
+      foo = 123
+      eval('foo')
+    }
+    result.should == 123
+  end
+
   it "gets constants in the receiver if a string given" do
     KernelSpecs::InstEvalOuter::Inner::X_BY_STR.should == 2
   end


### PR DESCRIPTION
While investigating a [failing spec](https://github.com/codegram/rack-webconsole/issues/36) in rack-webconsole with rbx and rbx-2.0.0, and thanks to a patch by @rogerleite, I've tried to track down where the bug lies in Rbx and found out this (using both rbx-master and rbx-2.0.0pre):

``` ruby
foo = 5
Object.new.instance_eval """
  bar = 3
  p eval('bar') # Cannot see bar
  p eval('foo') # But can see foo
"""
# nil
#5
```

Nevertheless, if we use a block everything's alright:

``` ruby
foo = 5
Object.new.instance_eval do
  bar = 3
  p eval('bar') # Can see both bar
  p eval('foo') # and foo
end
#3
#5
```

I've also included a passing spec for the instance_eval with a block and a failing spec for the instance_eval with a string.

I'd be happy to implement a fix, will investigate what's happening. Any feedback is appreciated :)
