### PR TITLE
Noticed a small typo in Rubinius::LookupTable#values

### DIFF
--- a/kernel/bootstrap/lookuptable.rb
+++ b/kernel/bootstrap/lookuptable.rb
@@ -96,7 +96,7 @@ module Rubinius
 
     def values
       Ruby.primitive :lookuptable_values
-      raise PrimitiveFailure, "LookupTable#keys primitive failed"
+      raise PrimitiveFailure, "LookupTable#values primitive failed"
     end
 
     def each


### PR DESCRIPTION
The error message was the same as Rubinius::LookupTable#keys. I changed it to say values instead of keys
## 

Nick
