### PR TITLE
Fix undefined local variables in File.lchown 

### DIFF
--- a/kernel/common/file.rb
+++ b/kernel/common/file.rb
@@ -289,7 +289,7 @@ class File < IO
     end
 
     paths.each do |path|
-      POSIX.lchown StringValue(path), owner_int, group_int
+      POSIX.lchown StringValue(path), owner, group
     end
 
     paths.size


### PR DESCRIPTION
This fix lchown_spec.
Before:
1 file, 5 examples, 0 expectations, 0 failures, 5 errors
After:
1 file, 5 examples, 13 expectations, 0 failures, 0 errors
