### PR TITLE
Add missing method SystemExit#success?

### DIFF
--- a/kernel/common/exception.rb
+++ b/kernel/common/exception.rb
@@ -311,6 +311,15 @@ class SystemExit < Exception
     @status = status
   end
 
+  ##
+  # Returns true is exiting successfully, false if not. A successful exit is
+  # one with a status equal to 0 (zero). Any other status is considered a
+  # unsuccessful exit.
+
+  def success?
+    status == Process::EXIT_SUCCESS
+  end
+
 end
 
 


### PR DESCRIPTION
I've just submitted a pull request to RubySpec with the corresponding tests:

https://github.com/rubyspec/rubyspec/pull/64
