### PR TITLE
Draft implementation of Base64.strict_decode64 and Base64.urlsafe_decode64

### DIFF
--- a/lib/base64.rb
+++ b/lib/base64.rb
@@ -39,7 +39,16 @@
 
 module Base64
   ENCODE_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-  DECODE_TABLE = 0.upto(ENCODE_TABLE.length - 1).inject({}) { | holder,i | holder[ENCODE_TABLE[i..i]] = i; holder }
+  DECODE_TABLE = { 'A' => 0, 'B' => 1, 'C' => 2, 'D' => 3, 'E' => 4, 'F' => 5, 'G' => 6, 
+  'H' => 7, 'I' => 8, 'J' => 9, 'K' => 10, 'L' => 11, 'M' => 12, 'N' => 13, 'O' => 14, 
+  'P' => 15, 'Q' => 16, 'R' => 17, 'S' => 18, 'T' => 19, 'U' => 20, 'V' => 21, 'W' => 22,
+  'X' => 23, 'Y' => 24, 'Z' => 25, 'a' => 26, 'b' => 27, 'c' => 28, 'd' => 29, 'e' => 30,
+  'f' => 31, 'g' => 32, 'h' => 33, 'i' => 34, 'j' => 35, 'k' => 36, 'l' => 37, 'm' => 38,
+  'n' => 39, 'o' => 40, 'p' => 41, 'q' => 42, 'r' => 43, 's' => 44, 't' => 45, 'u' => 46, 
+  'v' => 47, 'w' => 48, 'x' => 49, 'y' => 50, 'z' => 51, '0' => 52, '1' => 53, '2' => 54, 
+  '3' => 55, '4' => 56, '5' => 57, '6' => 58, '7' => 59, '8' => 60, '9' => 61, '+' => 62, 
+  '/' => 63 }
+
   module_function
 
   # Returns the Base64-decoded version of +str+.


### PR DESCRIPTION
In Ruby 1.9.2, some [new methods were added](http://www.ruby-doc.org/stdlib/libdoc/base64/rdoc/classes/Base64.html) to the Base64 module for strict encoding/decoding based on [RFC 4648](http://www.ietf.org/rfc/rfc4648.txt), in addition to URL safe versions.

While attempting to port over some of the MRI tests to RubySpec, I noticed that base64 test wasn't passing because rubinius didn't implement these newly added methods, so I decided to attempt to implement them myself. Since I noticed that strict_decode64 had cases where ArgumentError was thrown, and that urlsafe_decode64 is simply a call to it with string translations, I decided to start there.

Now in strict decoding, the following rules apply:
- All characters in the string must have respective entries in the base64 alphabet
- As base64 decoding operates in units of 4 characters, the string length must be divisible by 4
- padding:
  - must occur at the end of the string
  - have at most two occurrences
  - is meant to act as a placeholder for a 0 byte value

In MRI, strict_decode64 is implemented as such:

``` ruby
  # Returns the Base64-decoded version of +str+.
  # This method complies with RFC 4648.
  # ArgumentError is raised if +str+ is incorrectly padded or contains
  # non-alphabet characters.  Note that CR or LF are also rejected.
  def strict_decode64(str)
    str.unpack("m0").first
  end
```

This of course leads to some C code in pack.c:

``` c
if (len == 0) {
  while (s < send) {
    a = b = c = d = -1;
    a = b64_xtable[(unsigned char)*s++];
    if (s >= send || a == -1) rb_raise(rb_eArgError, "invalid base64");
    b = b64_xtable[(unsigned char)*s++];
    if (s >= send || b == -1) rb_raise(rb_eArgError, "invalid base64");
    if (*s == '=') {
      if (s + 2 == send && *(s + 1) == '=') break;
      rb_raise(rb_eArgError, "invalid base64");
    }
    c = b64_xtable[(unsigned char)*s++];
    if (s >= send || c == -1) rb_raise(rb_eArgError, "invalid base64");
    if (s + 1 == send && *s == '=') break;
    d = b64_xtable[(unsigned char)*s++];
    if (d == -1) rb_raise(rb_eArgError, "invalid base64");
    *ptr++ = a << 2 | b >> 4;
    *ptr++ = b << 4 | c >> 2;
    *ptr++ = c << 6 | d;
  }
  if (c == -1) {
    *ptr++ = a << 2 | b >> 4;
    if (b & 0xf) rb_raise(rb_eArgError, "invalid base64");
  }
  else if (d == -1) {
    *ptr++ = a << 2 | b >> 4;
    *ptr++ = b << 4 | c >> 2;
    if (c & 0x3) rb_raise(rb_eArgError, "invalid base64");
  }
}
```

This can definitely be written in C for speed, but I chose to write it in Ruby because:
- One of the main goals of Rubinius is Ruby written in Ruby
- The C version is written in a very algorithm style manner, which makes it harder to follow
- Due to the fact that the C implementation uses a lot of pointer arithmetic, it makes it very hard to work with debugging wise
- Being a strict implementation, the emphasis is more on the integrity of the input, so a speed loss is already assumed
- I just finished watching Rocky the movie

All code was built using yesterday's trunk. In order to hopefully increase readability of the code, I've added comments, made the variable names a bit more verbose, and added indentation and whitespacing as necessary. This can of course be modified to be more concise. In creating the implementation the main difficulty that I had was that the algorithm works with strings on a byte level. This is why the usage of .pack("c*") was necessary.

Another thing to add is that I noticed odd behavior in indexing strings in rubinius trunk:

```
irb(main):001:0> mystring = "test"
=> "test"
irb(main):002:0> mystring[0]
=> 116
irb(main):003:0> mystring[0..0]
=> "t"
```

This is why you'll notice a lot of range usage. I'll file a bug report separately if this behavior is not intentional. At any rate, I've used the range indexing as a workaround. As for the test case, I used a modified version of the MRI base64 test suite:

``` ruby
# encoding: UTF-8

require "test/unit"
require "base64"

class TestBase64 < Test::Unit::TestCase
  def test_sample
    assert_equal("U2VuZCByZWluZm9yY2VtZW50cw==\n", Base64.encode64('Send reinforcements'))
    assert_equal('Send reinforcements', Base64.decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n"))
    assert_equal(
      "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n",
      Base64.encode64("Now is the time for all good coders\nto learn Ruby"))
    assert_equal(
      "Now is the time for all good coders\nto learn Ruby",
      Base64.decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n"))
    assert_equal(
      "VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGlu\nZSB0aHJlZQpBbmQgc28gb24uLi4K\n",
      Base64.encode64("This is line one\nThis is line two\nThis is line three\nAnd so on...\n"))
    assert_equal(
      "This is line one\nThis is line two\nThis is line three\nAnd so on...\n",
      Base64.decode64("VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGluZSB0aHJlZQpBbmQgc28gb24uLi4K"))
  end

  def test_sample_decode64_strict
    assert_equal('Send reinforcements', Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw=="))
    assert_equal(
      "Now is the time for all good coders\nto learn Ruby",
      Base64.strict_decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gUnVieQ=="))
    assert_equal(
      "This is line one\nThis is line two\nThis is line three\nAnd so on...\n",
      Base64.strict_decode64("VGhpcyBpcyBsaW5lIG9uZQpUaGlzIGlzIGxpbmUgdHdvClRoaXMgaXMgbGluZSB0aHJlZQpBbmQgc28gb24uLi4K"))
    assert_equal(
      Base64.strict_decode64("44OG44K544OI"),
      "テスト")
  end

  def test_encode64
    assert_equal("", Base64.encode64(""))
    assert_equal("AA==\n", Base64.encode64("\0"))
    assert_equal("AAA=\n", Base64.encode64("\0\0"))
    assert_equal("AAAA\n", Base64.encode64("\0\0\0"))
    assert_equal("/w==\n", Base64.encode64("\377"))
    assert_equal("//8=\n", Base64.encode64("\377\377"))
    assert_equal("////\n", Base64.encode64("\377\377\377"))
    assert_equal("/+8=\n", Base64.encode64("\xff\xef"))
  end

  def test_decode64
    assert_equal("", Base64.decode64(""))
    assert_equal("\0", Base64.decode64("AA==\n"))
    assert_equal("\0\0", Base64.decode64("AAA=\n"))
    assert_equal("\0\0\0", Base64.decode64("AAAA\n"))
    assert_equal("\377", Base64.decode64("/w==\n"))
    assert_equal("\377\377", Base64.decode64("//8=\n"))
    assert_equal("\377\377\377", Base64.decode64("////\n"))
    assert_equal("\xff\xef", Base64.decode64("/+8=\n"))
  end

  def test_strict_decode64
    assert_equal("", Base64.strict_decode64(""))
    assert_equal("\0", Base64.strict_decode64("AA=="))
    assert_equal("\0\0", Base64.strict_decode64("AAA="))
    assert_equal("\0\0\0", Base64.strict_decode64("AAAA"))
    assert_equal("\377", Base64.strict_decode64("/w=="))
    assert_equal("\377\377", Base64.strict_decode64("//8="))
    assert_equal("\377\377\377", Base64.strict_decode64("////"))
    assert_equal("\xff\xef", Base64.strict_decode64("/+8="))

    assert_raise(ArgumentError) { Base64.strict_decode64("^") }
    assert_raise(ArgumentError) { Base64.strict_decode64("A") }
    assert_raise(ArgumentError) { Base64.strict_decode64("A^") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AA") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AA=") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AA===") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AA=x") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AAA") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AAA^") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AB==") }
    assert_raise(ArgumentError) { Base64.strict_decode64("AAB=") }
  end

  def test_urlsafe_decode64
    assert_equal("", Base64.urlsafe_decode64(""))
    assert_equal("\0", Base64.urlsafe_decode64("AA=="))
    assert_equal("\0\0", Base64.urlsafe_decode64("AAA="))
    assert_equal("\0\0\0", Base64.urlsafe_decode64("AAAA"))
    assert_equal("\377", Base64.urlsafe_decode64("_w=="))
    assert_equal("\377\377", Base64.urlsafe_decode64("__8="))
    assert_equal("\377\377\377", Base64.urlsafe_decode64("____"))
    assert_equal("\xff\xef", Base64.urlsafe_decode64("_+8="))
  end
end
```

The main modifications were:
- Addition of test_sample_decode64_strict, which is test_sample's decoding tests modified to use strict_decode64. It also does a quick test against some Japanese text.
- Removal of the urlsafe_encode64 and strict_encode64 related tests, as those are yet to be implemented

A run with the modified base64 library on a checkout of yesterday's trunk produces the following result:

```
SOLAR:rubinius chriswhite$ rbx base64_test.rb
Loaded suite base64_test
Started
......
Finished in 0.004471999999999999 seconds.

6 tests, 53 assertions, 0 failures, 0 errors
```

As for the explanation of the algorithm, I've added a good amount of inline commenting which will hopefully explain how the code is operating. Let me know if anything needs further clarification, or if any other information is necessary.
