### PR TITLE
Fix checking bison in configure

### DIFF
--- a/configure
+++ b/configure
@@ -74,7 +74,7 @@ class Configure
 
     if @host == "i686-pc-linux-gnu" || @host == "x86_64-unknown-linux-gnu"
       failure unless check_tool_version @cc, '-dumpversion', /(\d+)\.(\d+)/, [4,1]
-      failure unless check_tool_version 'bison', '--version', /bison \(GNU Bison\) (\d+)\.(\d+)/, [2,4]
+      failure unless check_tool_version 'bison', '--version', /bison \(GNU bison\) (\d+)\.(\d+)/, [2,4]
 
       @gcc_major = `#{@cc} -dumpversion`.strip.split(".")[0,2].join(".")
       @llvm_generic_prebuilt  = "llvm-#{@llvm_version}-#{@host}-#{@gcc_major}.tar.bz2"


### PR DESCRIPTION
./configure
Checking gcc:
  Expected gcc version >= 4.1 , found 4.6
Checking bison:
./configure:928:in `check_tool_version': undefined method`map' for nil:NilClass (NoMethodError)
    from ./configure:77:in `initialize'
    from ./configure:1284:in`new'
    from ./configure:128
