### PR TITLE
Use correct vendored zlib directory. Fixes #1159

### DIFF
--- a/lib/zlib.rb.ffi
+++ b/lib/zlib.rb.ffi
@@ -83,7 +83,7 @@ module Zlib
 
   @@@
   constants :required => true do |c|
-    c.include_dir 'vm/external_libs/zlib'
+    c.include_dir 'vendor/zlib'
     c.include 'zlib.h'
 
     c.const 'ZLIB_VERSION', '%s', '(char *)', nil, to_s
@@ -122,7 +122,7 @@ module Zlib
 
   @@@
   constants do |c|
-    c.include_dir 'vm/external_libs/zlib'
+    c.include_dir 'vendor/zlib'
     c.include 'zconf.h'
 
     c.const 'MAX_WBITS'
@@ -150,7 +150,7 @@ module Zlib
 
   @@@
   constants do |c|
-    c.include_dir 'vm/external_libs/zlib'
+    c.include_dir 'vendor/zlib'
     c.include 'zlib.h'
 
     c.const 'OS_CODE'
@@ -243,7 +243,7 @@ module Zlib
     def self.use_zstream_layout
       @@@
       struct do |s|
-        s.include_dir 'vm/external_libs/zlib'
+        s.include_dir 'vendor/zlib'
         s.include "zlib.h"
 
         s.name "struct z_stream_s"


### PR DESCRIPTION
This patch allows me to build to the next failure on Win7 32bit using MRI 1.8.7.

This is fragile as it trades one hardcoded path for another. This should be changed to using information placed in
Rubinius::BUILD_CONFIG by running ./configure.

Hasn't been regression tested on my Arch system.
