### PR TITLE
Add `read_ulong` to FFI pointer

### DIFF
--- a/kernel/platform/pointer.rb
+++ b/kernel/platform/pointer.rb
@@ -135,9 +135,17 @@ module FFI
     end
 
     # Read a C long from the memory pointed to.
-    def read_long
+    def read_long(sign=true)
+      read_long_signed(sign)
+    end
+
+    def read_long_signed(sign)
       Rubinius.primitive :pointer_read_long
       raise PrimitiveFailure, "Unable to read long"
+    end
+
+    def read_ulong
+      read_long_signed(false)
     end
 
     # Write +obj+ as a C long long at the memory pointed to.

--- a/vm/builtin/ffi_pointer.cpp
+++ b/vm/builtin/ffi_pointer.cpp
@@ -185,8 +185,12 @@ namespace rubinius {
     return val;
   }
 
-  Integer* Pointer::read_long(STATE) {
-    return Integer::from(state, *(long*)pointer);
+  Integer* Pointer::read_long(STATE, Object* sign) {
+    if(RTEST(sign)) {
+      return Integer::from(state, *(long*)pointer);
+    } else {
+      return Integer::from(state, *(unsigned long*)pointer);
+    }
   }
 
   Integer* Pointer::write_long_long(STATE, Integer* val) {
@@ -206,12 +210,12 @@ namespace rubinius {
   Float* Pointer::read_float(STATE) {
     return Float::create(state, (double)(*(float*)pointer));
   }
-  
+
   Float* Pointer::write_double(STATE, Float* flt) {
     *(double*)pointer = flt->val;
     return flt;
   }
-  
+
   Float* Pointer::read_double(STATE) {
     return Float::create(state, *(double*)pointer);
   }
@@ -456,7 +460,7 @@ namespace rubinius {
         result = NULL;
       } else {
         String* str = as<String>(val);
-        /* TODO this is probably not correct. Saving away an 
+        /* TODO this is probably not correct. Saving away an
          * internal pointer to the string means that when the string
          * moves, the data will point at the wrong place. Probably need to
          * copy the string data instead */

--- a/vm/builtin/ffi_pointer.hpp
+++ b/vm/builtin/ffi_pointer.hpp
@@ -53,7 +53,7 @@ namespace rubinius {
     Integer* write_long(STATE, Integer* val);
 
     // Rubinius.primitive :pointer_read_long
-    Integer* read_long(STATE);
+    Integer* read_long(STATE, Object* sign);
 
     // Rubinius.primitive :pointer_write_long_long
     Integer* write_long_long(STATE, Integer* val);


### PR DESCRIPTION
MRI FFI supports unsigned longs. This adds support just for reading them.
