### PR TITLE
FFI: read/write_int16 is just an alias to read/write of shorts

### DIFF
--- a/kernel/platform/pointer.rb
+++ b/kernel/platform/pointer.rb
@@ -83,11 +83,15 @@ module FFI
       raise PrimitiveFailure, "Unable to write short"
     end
 
+    alias :write_int16, :write_short
+
     # Read a C short from the memory pointed to.
     def read_short
       Rubinius.primitive :pointer_read_short
       raise PrimitiveFailure, "Unable to read short"
     end
+
+    alias :read_int16, :read_short
 
     # Write +obj+ as a C int at the memory pointed to.
     def write_int(obj)


### PR DESCRIPTION
Title says it, just added some aliases to bring up compatibility with MRI FFI.
