### PR TITLE
MRI 1.9 Module#constants and Module#const_get fixes

### DIFF
--- a/kernel/common/module18.rb
+++ b/kernel/common/module18.rb
@@ -1,4 +1,31 @@
 class Module
+  def constants
+    tbl = Rubinius::LookupTable.new
+
+    @constant_table.each do |name, val|
+      tbl[name] = true
+    end
+
+    current = self.direct_superclass
+
+    while current and current != Object
+      current.constant_table.each do |name, val|
+        tbl[name] = true unless tbl.has_key? name
+      end
+
+      current = current.direct_superclass
+    end
+
+    # special case: Module.constants returns Object's constants
+    if self.equal? Module
+      Object.constant_table.each do |name, val|
+        tbl[name] = true unless tbl.has_key? name
+      end
+    end
+
+    Rubinius.convert_to_names tbl.keys
+  end
+
   def const_defined?(name)
     name = normalize_const_name(name)
     return true if @constant_table.has_key? name

--- a/vm/capi/module.cpp
+++ b/vm/capi/module.cpp
@@ -3,6 +3,8 @@
 #include "builtin/symbol.hpp"
 #include "builtin/autoload.hpp"
 
+#include "vm/configuration.hpp"
+
 #include "helpers.hpp"
 #include "call_frame.hpp"
 
@@ -27,8 +29,15 @@ extern "C" {
   }
 
   int rb_const_defined_at(VALUE module_handle, ID const_id) {
-    return rb_funcall(module_handle,
-        rb_intern("const_defined?"), 1, ID2SYM(const_id));
+    NativeMethodEnvironment* env = NativeMethodEnvironment::get();
+
+    if(LANGUAGE_18_ENABLED(env->state())) {
+      return rb_funcall(module_handle,
+          rb_intern("const_defined?"), 1, ID2SYM(const_id));
+    } else {
+      return rb_funcall(module_handle,
+          rb_intern("const_defined?"), 2, ID2SYM(const_id), Qfalse);
+    }
   }
 
   ID rb_frame_last_func() {


### PR DESCRIPTION
Subj.

These changes break the rb_const_defined_at CApi method, but I don't know how to introduce version-conditional behavior in CApi compatibility layer.

```

2)
CApiModule rb_const_defined_at does not search in ancestors for the constant FAILED
Expected true to be false
                                      /expectations.rb:15
          { } in Object#__script__ at spec/ruby/optional/capi/module_spec.rb:119
  BasicObject(Object)#instance_eval at kernel/common/eval19.rb:43
      { } in Enumerable(Array)#all? at kernel/common/enumerable.rb:235
                         Array#each at kernel/bootstrap/array.rb:66
             Enumerable(Array)#all? at kernel/common/enumerable.rb:235
                         Array#each at kernel/bootstrap/array.rb:66
                         Array#each at kernel/bootstrap/array.rb:66
                 Object#__script__ at spec/ruby/optional/capi/module_spec.rb:25
                        Kernel.load at kernel/common/kernel.rb:687
  BasicObject(Object)#instance_eval at kernel/common/eval19.rb:43
                         Array#each at kernel/bootstrap/array.rb:66
   Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:65
   Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:107
            Rubinius::Loader#script at kernel/loader.rb:618
              Rubinius::Loader#main at kernel/loader.rb:772

3)
CApiModule rb_const_defined_at does not search in Object FAILED
Expected true to be false
                                      /expectations.rb:15
          { } in Object#__script__ at spec/ruby/optional/capi/module_spec.rb:123
  BasicObject(Object)#instance_eval at kernel/common/eval19.rb:43
      { } in Enumerable(Array)#all? at kernel/common/enumerable.rb:235
                         Array#each at kernel/bootstrap/array.rb:66
             Enumerable(Array)#all? at kernel/common/enumerable.rb:235
                         Array#each at kernel/bootstrap/array.rb:66
                         Array#each at kernel/bootstrap/array.rb:66
                 Object#__script__ at spec/ruby/optional/capi/module_spec.rb:25
                        Kernel.load at kernel/common/kernel.rb:687
  BasicObject(Object)#instance_eval at kernel/common/eval19.rb:43
                         Array#each at kernel/bootstrap/array.rb:66
   Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:65
   Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:107
            Rubinius::Loader#script at kernel/loader.rb:618
              Rubinius::Loader#main at kernel/loader.rb:772
```
