### PR TITLE
Implement Symbol#succ

### DIFF
--- a/kernel/common/symbol19.rb
+++ b/kernel/common/symbol19.rb
@@ -56,4 +56,8 @@ class Symbol
   def upcase
     to_s.upcase.to_sym
   end
+
+  def succ
+    to_s.succ.to_sym
+  end
 end


### PR DESCRIPTION
This is not covered by RubySpec. The implementation matches MRI.
