### PR TITLE
Fix Range#to_a for ranges of Symbols

### DIFF
--- a/kernel/common/range.rb
+++ b/kernel/common/range.rb
@@ -169,6 +169,20 @@ class Range
       first.upto(last) do |s|
         yield s unless @excl && s == last
       end
+    when Symbol
+      current = first
+      if @excl
+        while (current <=> last) < 0
+          yield current
+          current = (current.to_s.bytes.to_a.last + 1).chr.to_sym
+        end
+      else
+        while (c = current <=> last) && c <= 0
+          yield current
+          break if c == 0
+          current = (current.to_s.bytes.to_a.last + 1).chr.to_sym
+        end
+      end
     else
       current = first
       if @excl

--- a/spec/tags/19/ruby/core/range/to_a_tags.txt
+++ b/spec/tags/19/ruby/core/range/to_a_tags.txt
@@ -1,1 +1,0 @@
-fails:Range#to_a works with Ranges of Symbols


### PR DESCRIPTION
This covers the spec in core/range/to_a_spec.rb, but does not fully match the implementation of MRI.

The spec should cover ranges of symbols of length greater than one. Current MRI implementation follows curious logic that is different for symbols of length other than 1.
