### PR TITLE
Fixed Net::HTTPHeader#content_range returns a Range object that represent

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1364,13 +1364,13 @@ module Net   #:nodoc:
       return nil unless @header['content-range']
       m = %r<bytes\s+(\d+)-(\d+)/(\d+|\*)>i.match(self['Content-Range']) or
           raise HTTPHeaderSyntaxError, 'wrong Content-Range format'
-      m[1].to_i .. m[2].to_i + 1
+      m[1].to_i .. m[2].to_i
     end
 
     # The length of the range represented in Content-Range: header.
     def range_length
       r = content_range() or return nil
-      r.end - r.begin
+      r.end - r.begin + 1
     end
 
     # Returns a content type string such as "text/html".

--- a/spec/tags/18/ruby/library/net/http/httpheader/content_range_tags.txt
+++ b/spec/tags/18/ruby/library/net/http/httpheader/content_range_tags.txt
@@ -1,1 +1,0 @@
-fails:Net::HTTPHeader#content_range returns a Range object that represents the 'Content-Range' header entry

--- a/spec/tags/19/ruby/library/net/http/httpheader/content_range_tags.txt
+++ b/spec/tags/19/ruby/library/net/http/httpheader/content_range_tags.txt
@@ -1,1 +1,0 @@
-fails:Net::HTTPHeader#content_range returns a Range object that represents the 'Content-Range' header entry

--- a/spec/tags/20/ruby/library/net/http/httpheader/content_range_tags.txt
+++ b/spec/tags/20/ruby/library/net/http/httpheader/content_range_tags.txt
@@ -1,1 +1,0 @@
-fails:Net::HTTPHeader#content_range returns a Range object that represents the 'Content-Range' header entry


### PR DESCRIPTION
Basically copied from trunk MRI
http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/lib/net/http.rb?view=markup&pathrev=33086
