### PR TITLE
Fixed Net::HTTPHeader#fetch returns the default value when there is no en

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1209,7 +1209,7 @@ module Net   #:nodoc:
     # if there's no header field named key.  See Hash#fetch
     def fetch(key, *args, &block)   #:yield: +key+
       a = @header.fetch(key.downcase, *args, &block)
-      a.join(', ')
+      a.kind_of?(Array) ? a.join(', ') : a
     end
 
     # Iterates for each header names and values.

--- a/spec/tags/18/ruby/library/net/http/httpheader/fetch_tags.txt
+++ b/spec/tags/18/ruby/library/net/http/httpheader/fetch_tags.txt
@@ -1,2 +1,0 @@
-fails:Net::HTTPHeader#fetch when passed key, default returns the default value when there is no entry for the passed key
-fails:Net::HTTPHeader#fetch when passed key and block yieldsand returns the block's return value when there is no entry for the passed key

--- a/spec/tags/19/ruby/library/net/http/httpheader/fetch_tags.txt
+++ b/spec/tags/19/ruby/library/net/http/httpheader/fetch_tags.txt
@@ -1,2 +1,0 @@
-fails:Net::HTTPHeader#fetch when passed key, default returns the default value when there is no entry for the passed key
-fails:Net::HTTPHeader#fetch when passed key and block yieldsand returns the block's return value when there is no entry for the passed key

--- a/spec/tags/20/ruby/library/net/http/httpheader/fetch_tags.txt
+++ b/spec/tags/20/ruby/library/net/http/httpheader/fetch_tags.txt
@@ -1,2 +1,0 @@
-fails:Net::HTTPHeader#fetch when passed key, default returns the default value when there is no entry for the passed key
-fails:Net::HTTPHeader#fetch when passed key and block yieldsand returns the block's return value when there is no entry for the passed key


### PR DESCRIPTION
Copied implementation from the redmine issue mentioned in the spec:
   http://redmine.ruby-lang.org/issues/show/445
