### PR TITLE
update BigDecimalCmp to return false when comparing to NaN

### DIFF
--- a/lib/ext/bigdecimal/bigdecimal.c
+++ b/lib/ext/bigdecimal/bigdecimal.c
@@ -732,6 +732,7 @@ BigDecimalCmp(VALUE self, VALUE r,char op)
     S_INT e;
     Real *a, *b;
     GUARD_OBJ(a,GetVpValue(self,1));
+    if(VpIsNaN(a)) return Qfalse;
     b = GetVpValue(r,0);
     if(!b) {
         ID f = 0;
@@ -748,6 +749,7 @@ BigDecimalCmp(VALUE self, VALUE r,char op)
         return rb_num_coerce_cmp(self,r,f);
     }
     SAVE(b);
+    if(VpIsNaN(b)) return Qfalse;
     e = VpComp(a, b);
     if(e==999) return Qnil;
     switch(op)
@@ -786,6 +788,11 @@ BigDecimal_nonzero(VALUE self)
 static VALUE
 BigDecimal_comp(VALUE self, VALUE r)
 {
+    Real *a, *b;
+    GUARD_OBJ(a,GetVpValue(self,1));
+    GUARD_OBJ(b,GetVpValue(self,0));
+    if(VpIsNaN(a) || VpIsNaN(b)) return Qnil;
+
     return BigDecimalCmp(self, r, '*');
 }
 

--- a/spec/tags/18/ruby/library/bigdecimal/case_compare_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/case_compare_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#=== NaN is never equal to any number
 fails:BigDecimal#=== returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/18/ruby/library/bigdecimal/eql_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/eql_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#eql? NaN is never equal to any number
 fails:BigDecimal#eql? returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/18/ruby/library/bigdecimal/equal_value_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/equal_value_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#== NaN is never equal to any number
 fails:BigDecimal#== returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/18/ruby/library/bigdecimal/gt_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/gt_tags.txt
@@ -1,3 +1,1 @@
-fails:BigDecimal#> properly handles NaN values
-fails:BigDecimal#> properly handles NaN values
 fails:BigDecimal#> raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/18/ruby/library/bigdecimal/gte_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/gte_tags.txt
@@ -1,3 +1,1 @@
-fails:BigDecimal#>= properly handles NaN values
-fails:BigDecimal#>= properly handles NaN values
 fails:BigDecimal#>= returns nil if the argument is nil

--- a/spec/tags/18/ruby/library/bigdecimal/lt_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/lt_tags.txt
@@ -1,3 +1,1 @@
-fails:BigDecimal#< properly handles NaN values
-fails:BigDecimal#< properly handles NaN values
 fails:BigDecimal#< raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/18/ruby/library/bigdecimal/lte_tags.txt
+++ b/spec/tags/18/ruby/library/bigdecimal/lte_tags.txt
@@ -1,3 +1,1 @@
-fails:BigDecimal#<= properly handles NaN values
-fails:BigDecimal#<= properly handles NaN values
 fails:BigDecimal#<= raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/19/ruby/library/bigdecimal/case_compare_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/case_compare_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#=== NaN is never equal to any number
 fails:BigDecimal#=== returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/19/ruby/library/bigdecimal/eql_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/eql_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#eql? NaN is never equal to any number
 fails:BigDecimal#eql? returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/19/ruby/library/bigdecimal/equal_value_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/equal_value_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#== NaN is never equal to any number
 fails:BigDecimal#== returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/19/ruby/library/bigdecimal/gt_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/gt_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#> properly handles NaN values
 fails:BigDecimal#> raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/19/ruby/library/bigdecimal/gte_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/gte_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#>= properly handles NaN values
 fails:BigDecimal#>= returns nil if the argument is nil

--- a/spec/tags/19/ruby/library/bigdecimal/lt_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/lt_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#< properly handles NaN values
 fails:BigDecimal#< raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/19/ruby/library/bigdecimal/lte_tags.txt
+++ b/spec/tags/19/ruby/library/bigdecimal/lte_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#<= properly handles NaN values
 fails:BigDecimal#<= raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/20/ruby/library/bigdecimal/case_compare_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/case_compare_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#=== NaN is never equal to any number
 fails:BigDecimal#=== returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/20/ruby/library/bigdecimal/eql_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/eql_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#eql? NaN is never equal to any number
 fails:BigDecimal#eql? returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/20/ruby/library/bigdecimal/equal_value_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/equal_value_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#== NaN is never equal to any number
 fails:BigDecimal#== returns false when compared objects that can not be coerced into BigDecimal

--- a/spec/tags/20/ruby/library/bigdecimal/gt_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/gt_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#> properly handles NaN values
 fails:BigDecimal#> raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/20/ruby/library/bigdecimal/gte_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/gte_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#>= properly handles NaN values
 fails:BigDecimal#>= returns nil if the argument is nil

--- a/spec/tags/20/ruby/library/bigdecimal/lt_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/lt_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#< properly handles NaN values
 fails:BigDecimal#< raises an ArgumentError if the argument can't be coerced into a BigDecimal

--- a/spec/tags/20/ruby/library/bigdecimal/lte_tags.txt
+++ b/spec/tags/20/ruby/library/bigdecimal/lte_tags.txt
@@ -1,2 +1,1 @@
-fails:BigDecimal#<= properly handles NaN values
 fails:BigDecimal#<= raises an ArgumentError if the argument can't be coerced into a BigDecimal


### PR DESCRIPTION
Passes comparison specs for BigDecimal regarding NaN now. `BigDecimal_comp` had to be modified because, unlike all other comparisons, it returns `nil` when comparing NaN.
