### PR TITLE
Fixing 1.9 spec: Add in ability for Array#zip to use #each if #to_ary is 

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -1686,43 +1686,6 @@ class Array
     out
   end
 
-  #  call-seq:
-  #     array.zip(arg, ...)                   -> an_array
-  #     array.zip(arg, ...) {| arr | block }  -> nil
-  #
-  #  Converts any arguments to arrays, then merges elements of
-  #  <i>self</i> with corresponding elements from each argument. This
-  #  generates a sequence of <code>self.size</code> <em>n</em>-element
-  #  arrays, where <em>n</em> is one more that the count of arguments. If
-  #  the size of any argument is less than <code>enumObj.size</code>,
-  #  <code>nil</code> values are supplied. If a block given, it is
-  #  invoked for each output array, otherwise an array of arrays is
-  #  returned.
-  #
-  #     a = [ 4, 5, 6 ]
-  #     b = [ 7, 8, 9 ]
-  #     [1,2,3].zip(a, b)      #=> [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
-  #     [1,2].zip(a,b)         #=> [[1, 4, 7], [2, 5, 8]]
-  #     a.zip([1,2],[8])       #=> [[4,1,8], [5,2,nil], [6,nil,nil]]
-  #
-  def zip(*others)
-    out = Array.new(size) { [] }
-    others = others.map { |ary| ary.to_ary }
-
-    size.times do |i|
-      slot = out.at(i)
-      slot << @tuple.at(@start + i)
-      others.each { |ary| slot << ary.at(i) }
-    end
-
-    if block_given?
-      out.each { |ary| yield ary }
-      return nil
-    end
-
-    out
-  end
-
   def unshift(*values)
     return self if values.empty?
 

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -19,7 +19,7 @@ class Array
     result[n..size] = []
     result
   end
-  
+
   # Recursively flatten any contained Arrays into an one-dimensional result.
   # The optional level argument determines the level of recursion to flatten
   def flatten(level=-1)
@@ -130,5 +130,42 @@ class Array
     @total = array.total
 
     self
+  end
+
+  #  call-seq:
+  #     array.zip(arg, ...)                   -> an_array
+  #     array.zip(arg, ...) {| arr | block }  -> nil
+  #
+  #  Converts any arguments to arrays, then merges elements of
+  #  <i>self</i> with corresponding elements from each argument. This
+  #  generates a sequence of <code>self.size</code> <em>n</em>-element
+  #  arrays, where <em>n</em> is one more that the count of arguments. If
+  #  the size of any argument is less than <code>enumObj.size</code>,
+  #  <code>nil</code> values are supplied. If a block given, it is
+  #  invoked for each output array, otherwise an array of arrays is
+  #  returned.
+  #
+  #     a = [ 4, 5, 6 ]
+  #     b = [ 7, 8, 9 ]
+  #     [1,2,3].zip(a, b)      #=> [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+  #     [1,2].zip(a,b)         #=> [[1, 4, 7], [2, 5, 8]]
+  #     a.zip([1,2],[8])       #=> [[4,1,8], [5,2,nil], [6,nil,nil]]
+  #
+  def zip(*others)
+    out = Array.new(size) { [] }
+    others = others.map { |ary| ary.to_ary }
+
+    size.times do |i|
+      slot = out.at(i)
+      slot << @tuple.at(@start + i)
+      others.each { |ary| slot << ary.at(i) }
+    end
+
+    if block_given?
+      out.each { |ary| yield ary }
+      return nil
+    end
+
+    out
   end
 end

--- a/spec/ruby/core/array/zip_spec.rb
+++ b/spec/ruby/core/array/zip_spec.rb
@@ -35,7 +35,7 @@ describe "Array#zip" do
           [3,4].each(&b)
         end
       end.new
-      
+
       [1, 2].zip(obj).should == [[1, 3], [2, 4]]
     end
   end

--- a/spec/tags/19/ruby/core/array/zip_tags.txt
+++ b/spec/tags/19/ruby/core/array/zip_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#zip uses #each to extract arguments' elements when #to_ary fails


### PR DESCRIPTION
Fixing 1.9 spec: Add in ability for Array#zip to use #each if #to_ary is not defined.
