### PR TITLE
Fixing Array#choice on 19

### DIFF
--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -6,6 +6,25 @@ class Array
     Rubinius::Type.try_convert obj, Array, :to_ary
   end
 
+  def choice(n=undefined)
+    raise NoMethodError if size == 0
+    return at(Kernel.rand(size)) if n.equal? undefined
+
+    n = Type.coerce_to(n, Fixnum, :to_int)
+    raise ArgumentError, "negative array size" if n < 0
+
+    n = size if n > size
+    result = Array.new(self)
+
+    n.times do |i|
+      r = i + Kernel.rand(size - i)
+      result.tuple.swap(i,r)
+    end
+
+    result[n..size] = []
+    result
+  end
+
   def flatten(level=-1)
     level = Rubinius::Type.coerce_to(level, Integer, :to_int)
     return self.dup if level == 0


### PR DESCRIPTION
This was one of the failing Array specs. I'd love some feedback, as it's just an extra guard clause over the 1.8 version, I'm not sure if I should be abstracting both of those away somewhere...
