### PR TITLE
Fixes 1.9 Spec: Passes RUBY_REVISION spec

### DIFF
--- a/kernel/delta/ruby_constants.rb
+++ b/kernel/delta/ruby_constants.rb
@@ -5,7 +5,7 @@ RUBY_ENGINE       = "rbx"
 RUBY_PLATFORM     = Rubinius::HOST.dup
 RUBY_RELEASE_DATE = Rubinius::RELEASE_DATE.dup
 RUBY_COPYRIGHT    = "rubinius - Copyright (C) 2006-2011 Evan Phoenix"
-
+RUBY_REVISION     = 0
 # Must be last, it reads the above constants
 RUBY_DESCRIPTION  = Rubinius.version
 


### PR DESCRIPTION
Small commit that passes related spec. Would love to hear on ideas on how to calculate the exact revision number or if it's something that rubinius would use. 
