### PR TITLE
Fix 1.9 spec: Array#insert raises a RuntimeError on frozen arrays

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -1020,24 +1020,6 @@ class Array
 
   alias_method :indices, :indexes
 
-  # For a positive index, inserts the given values before
-  # the element at the given index. Negative indices count
-  # backwards from the end and the values are inserted
-  # after them.
-  def insert(idx, *items)
-    return self if items.length == 0
-
-    Rubinius.check_frozen
-
-    # Adjust the index for correct insertion
-    idx = Rubinius::Type.coerce_to idx, Fixnum, :to_int
-    idx += (@total + 1) if idx < 0    # Negatives add AFTER the element
-    raise IndexError, "#{idx} out of bounds" if idx < 0
-
-    self[idx, 0] = items   # Cheat
-    self
-  end
-
   # Produces a printable string of the Array. The string
   # is constructed by calling #inspect on all elements.
   # Descends through contained Arrays, recursive ones

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -31,6 +31,24 @@ class Array
     nil
   end
 
+  # For a positive index, inserts the given values before
+  # the element at the given index. Negative indices count
+  # backwards from the end and the values are inserted
+  # after them.
+  def insert(idx, *items)
+    return self if items.length == 0
+
+    Rubinius.check_frozen
+
+    # Adjust the index for correct insertion
+    idx = Rubinius::Type.coerce_to idx, Fixnum, :to_int
+    idx += (@total + 1) if idx < 0    # Negatives add AFTER the element
+    raise IndexError, "#{idx} out of bounds" if idx < 0
+
+    self[idx, 0] = items   # Cheat
+    self
+  end
+
   ##
   #  call-seq:
   #     arr.pack ( aTemplateString ) -> aBinaryString

--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -33,6 +33,24 @@ class Array
     nil
   end
 
+  # For a positive index, inserts the given values before
+  # the element at the given index. Negative indices count
+  # backwards from the end and the values are inserted
+  # after them.
+  def insert(idx, *items)
+    Rubinius.check_frozen
+
+    return self if items.length == 0
+
+    # Adjust the index for correct insertion
+    idx = Rubinius::Type.coerce_to idx, Fixnum, :to_int
+    idx += (@total + 1) if idx < 0    # Negatives add AFTER the element
+    raise IndexError, "#{idx} out of bounds" if idx < 0
+
+    self[idx, 0] = items   # Cheat
+    self
+  end
+
   def keep_if(&block)
     Rubinius.check_frozen
 

--- a/spec/tags/19/ruby/core/array/insert_tags.txt
+++ b/spec/tags/19/ruby/core/array/insert_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#insert raises a RuntimeError on frozen arrays when the array would not be modified


### PR DESCRIPTION
The complete failing spec was:

```
Array#insert raises a RuntimeError on frozen arrays when the array would not be modified
```
