### PR TITLE
patch Method#name for 1.9

### DIFF
--- a/kernel/common/load_order20.txt
+++ b/kernel/common/load_order20.txt
@@ -77,6 +77,7 @@ marshal19.rbc
 math.rbc
 math19.rbc
 method.rbc
+method19.rbc
 method_table.rbc
 native_method.rbc
 nil.rbc

--- a/kernel/common/method.rb
+++ b/kernel/common/method.rb
@@ -27,10 +27,6 @@ class Method
   attr_reader :defined_in
   attr_reader :executable
 
-  def name
-    @name.to_s
-  end
-
   ##
   # Method objects are equal if they have the same body and are bound to the
   # same object.

--- a/kernel/common/method18.rb
+++ b/kernel/common/method18.rb
@@ -1,3 +1,9 @@
+class Method
+  def name
+    @name.to_s
+  end
+end
+
 class UnboundMethod
 
   def name
@@ -5,3 +11,4 @@ class UnboundMethod
   end
 
 end
+

--- a/kernel/common/method19.rb
+++ b/kernel/common/method19.rb
@@ -1,3 +1,9 @@
+class Method
+  def name
+    @name
+  end
+end
+
 class UnboundMethod
 
   def name
@@ -5,3 +11,4 @@ class UnboundMethod
   end
 
 end
+

--- a/spec/tags/19/ruby/core/method/name_tags.txt
+++ b/spec/tags/19/ruby/core/method/name_tags.txt
@@ -1,2 +1,0 @@
-fails:Method#name returns the name of the method
-fails:Method#name returns the name even when aliased


### PR DESCRIPTION
Fixes Method#name in 1.9 which returns symbol instead of string.
