### PR TITLE
Patched Kernel#instance_variables for 1.9

### DIFF
--- a/kernel/common/kernel.rb
+++ b/kernel/common/kernel.rb
@@ -470,6 +470,17 @@ module Kernel
   end
   private :all_instance_variables
 
+  def instance_variables
+    ary = []
+    all_instance_variables.each do |sym|
+      ary << sym if sym.is_ivar?
+    end
+
+    Rubinius.convert_to_names ary
+  end
+
+  alias_method :__instance_variables__, :instance_variables
+
   def instance_variable_defined?(name)
     Rubinius.primitive :object_ivar_defined
 

--- a/kernel/common/kernel18.rb
+++ b/kernel/common/kernel18.rb
@@ -9,17 +9,6 @@ module Kernel
     end
   end
 
-  def instance_variables
-    ary = []
-    all_instance_variables.each do |sym|
-      ary << sym.to_s if sym.is_ivar?
-    end
-
-    return ary
-  end
-
-  alias_method :__instance_variables__, :instance_variables
-
   def Integer(obj)
     case obj
     when Integer

--- a/kernel/common/kernel19.rb
+++ b/kernel/common/kernel19.rb
@@ -7,17 +7,6 @@ module Kernel
     end.send(:define_method, *args, &block)
   end
 
-  def instance_variables
-    ary = []
-    all_instance_variables.each do |sym|
-      ary << sym if sym.is_ivar?
-    end
-
-    return ary
-  end
-
-  alias_method :__instance_variables__, :instance_variables
-
   def Integer(obj, base=nil)
     if obj.kind_of? String
       if obj.empty?


### PR DESCRIPTION
Fixes the following failures under 1.9:
- Kernel#instance_variables immediate values returns the correct array if an instance variable is added
- Kernel#instance_variables regular objects returns the correct array if an instance variable is added
