### PR TITLE
Raise RangeError when given a negative value to String concat.

### DIFF
--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -88,29 +88,6 @@ class String
     r
   end
 
-  # Append --- Concatenates the given object to <i>self</i>. If the object is a
-  # <code>Fixnum</code> between 0 and 255, it is converted to a character before
-  # concatenation.
-  #
-  #   a = "hello "
-  #   a << "world"   #=> "hello world"
-  #   a.concat(33)   #=> "hello world!"
-  def <<(other)
-    modify!
-
-    unless other.kind_of? String
-      if other.kind_of?(Integer) && other >= 0 && other <= 255
-        other = other.chr
-      else
-        other = StringValue(other)
-      end
-    end
-
-    taint if other.tainted?
-    append(other)
-  end
-  alias_method :concat, :<<
-
   # call-seq:
   #   str <=> other_str   => -1, 0, +1
   #

--- a/kernel/common/string18.rb
+++ b/kernel/common/string18.rb
@@ -544,4 +544,27 @@ class String
   # Returns a new string with the characters from <i>self</i> in reverse order.
   #
   #   "stressed".reverse   #=> "desserts"
+
+  # Append --- Concatenates the given object to <i>self</i>. If the object is a
+  # <code>Fixnum</code> between 0 and 255, it is converted to a character before
+  # concatenation.
+  #
+  #   a = "hello "
+  #   a << "world"   #=> "hello world"
+  #   a.concat(33)   #=> "hello world!"
+  def <<(other)
+    modify!
+
+    unless other.kind_of? String
+      if other.kind_of?(Integer) && other >= 0 && other <= 255
+        other = other.chr
+      else
+        other = StringValue(other)
+      end
+    end
+
+    taint if other.tainted?
+    append(other)
+  end
+  alias_method :concat, :<<
 end

--- a/kernel/common/string19.rb
+++ b/kernel/common/string19.rb
@@ -605,4 +605,30 @@ class String
   # Returns a new string with the characters from <i>self</i> in reverse order.
   #
   #   "stressed".reverse   #=> "desserts"
+
+  # Append --- Concatenates the given object to <i>self</i>. If the object is a
+  # <code>Fixnum</code> between 0 and 255, it is converted to a character before
+  # concatenation.
+  #
+  #   a = "hello "
+  #   a << "world"   #=> "hello world"
+  #   a.concat(33)   #=> "hello world!"
+  def <<(other)
+    modify!
+
+    unless other.kind_of? String
+      if other.kind_of?(Integer) && other >= 0 && other <= 255
+        other = other.chr
+      elsif other.kind_of?(Integer) && other < 0
+        raise RangeError, "negative argument"
+      else
+        other = StringValue(other)
+      end
+    end
+
+    taint if other.tainted?
+    append(other)
+  end
+  alias_method :concat, :<<
+
 end

--- a/spec/ruby/library/stringscanner/shared/concat.rb
+++ b/spec/ruby/library/stringscanner/shared/concat.rb
@@ -18,7 +18,12 @@ describe :strscan_concat_fixnum, :shared => true do
     lambda { a.send(@method, 333) }.should raise_error(TypeError)
     b = StringScanner.new("")
     lambda { b.send(@method, (256 * 3 + 64)) }.should raise_error(TypeError)
-    lambda { b.send(@method, -200)           }.should raise_error(TypeError)
+    ruby_version_is '1.8' ... '1.9' do
+      lambda { b.send(@method, -200)           }.should raise_error(TypeError)
+    end
+    ruby_version_is '1.9' do
+      lambda { b.send(@method, -200)           }.should raise_error(RangeError)
+    end
   end
 
   it "doesn't call to_int on the argument" do


### PR DESCRIPTION
Fixed failing 1.9 test to raise RangeError when a negative value is given to concat.
