### PR TITLE
[1.9] Added sanity checks for type and frozen.

### DIFF
--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -1405,6 +1405,10 @@ class String
   # This method is specifically part of 1.9 but we enable it in 1.8 also
   # because we need it internally.
   def setbyte(index, byte)
+    raise TypeError, "can't convert #{byte.class} into Integer" unless byte.instance_of?(Fixnum)
+    
+    Rubinius.check_frozen
+
     index = size + index if index < 0
     @data[index] = byte
   end


### PR DESCRIPTION
Fixes tests:

String#setbyte raises a TypeError unless the second argument is an Integer FAILED
String#setbyte raises a RuntimeError if self is frozen FAILED
