### PR TITLE
[1.9] Fixes for two failing IO#readbyte tests

### DIFF
--- a/kernel/common/io.rb
+++ b/kernel/common/io.rb
@@ -830,7 +830,7 @@ class IO
   def getbyte
     char = read 1
     return nil if char.nil?
-    char[0]
+    char.bytes.to_a[0]
   end
 
   ##
@@ -1079,6 +1079,7 @@ class IO
 
   def readbyte
     byte = getbyte
+    raise EOFError, "end of file reached" unless byte
     raise EOFError, "end of file" unless bytes
     byte
   end

--- a/spec/tags/19/ruby/core/io/readbyte_tags.txt
+++ b/spec/tags/19/ruby/core/io/readbyte_tags.txt
@@ -1,2 +1,0 @@
-fails:IO#readbyte reads one byte from the stream
-fails:IO#readbyte raises EOFError on EOF


### PR DESCRIPTION
IO#readbyte reads one byte from the stream
IO#readbyte raises EOFError on EOF
