### PR TITLE
[1.9] Patch to add chr to String

### DIFF
--- a/kernel/common/string19.rb
+++ b/kernel/common/string19.rb
@@ -631,4 +631,16 @@ class String
   end
   alias_method :concat, :<<
 
+  # Returns a one-character string at the beginning of the string.
+  #
+  #   a = "abcde"
+  #   a.chr    #=> "a"
+  def chr
+    if empty?
+      self
+    else
+      self[0]
+    end
+  end
+
 end

--- a/spec/tags/19/ruby/core/string/chr_tags.txt
+++ b/spec/tags/19/ruby/core/string/chr_tags.txt
@@ -1,8 +1,2 @@
-fails:String#chr returns a copy of self
-fails:String#chr returns a String
-fails:String#chr returns an empty String if self is an empty String
-fails:String#chr returns a 1-character String
-fails:String#chr returns the character at the start of the String
-fails:String#chr returns a String in the same encoding as self
 fails:String#chr understands multi-byte characters
 fails:String#chr understands Strings that contain a mixture of character widths


### PR DESCRIPTION
Fixes the following failing tests:

String#chr returns a copy of self
String#chr returns a String
String#chr returns an empty String if self is an empty String
String#chr returns a 1-character String
String#chr returns the character at the start of the String
String#chr returns a String in the same encoding as self
