### PR TITLE
Removing tag for a Struct.new spec that is now passing

### DIFF
--- a/spec/tags/19/ruby/core/struct/new_tags.txt
+++ b/spec/tags/19/ruby/core/struct/new_tags.txt
@@ -1,1 +1,0 @@
-fails:Struct.new processes passed block with instance_eval


### PR DESCRIPTION
While looking at failing specs I discovered this tag is no longer needed. My guess is it started passing back when I added fixes for Kernel#instance_variables.
