### PR TITLE
Fix String#upto for 1.9

### DIFF
--- a/kernel/common/string19.rb
+++ b/kernel/common/string19.rb
@@ -51,13 +51,15 @@ class String
         current += 1
       end
     else
-      after_stop = exclusive ? stop : stop.succ
-      current = self
+      unless stop.size < size
+        after_stop = exclusive ? stop : stop.succ
+        current = self
 
-      until current == after_stop
-        yield current
-        current = StringValue(current.succ)
-        break if current.size > stop.size || current.size == 0
+        until current == after_stop
+          yield current
+          current = StringValue(current.succ)
+          break if current.size > stop.size || current.size == 0
+        end
       end
     end
     self


### PR DESCRIPTION
Hi, i made the 'upto' method doesn't call a block when the stop length is less than the self length.
