### PR TITLE
Removed a tag for Kernel#respond_to? that is no longer failing

### DIFF
--- a/spec/tags/19/ruby/core/kernel/respond_to_tags.txt
+++ b/spec/tags/19/ruby/core/kernel/respond_to_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#respond_to? returns false for a method which exists but is unimplemented


### PR DESCRIPTION
While poking around I discovered that this spec is now passing.
