### PR TITLE
Added spec for 1.8 behavior of Enumerator#next

### DIFF
--- a/spec/ruby/shared/enumerator/next.rb
+++ b/spec/ruby/shared/enumerator/next.rb
@@ -17,6 +17,14 @@ describe :enum_next, :shared => true do
     lambda { @enum.next }.should raise_error(StopIteration)
   end
 
+  ruby_version_is ""..."1.9" do
+    it "is rewound after encountering a StopIteration" do
+      3.times { @enum.next }
+      lambda { @enum.next }.should raise_error(StopIteration)
+      @enum.next.should == 1
+    end
+  end
+
   ruby_version_is "1.9" do
     it "cannot be called again until the enumerator is rewound" do
       3.times { @enum.next }


### PR DESCRIPTION
Separated this out into its own pull request. Just some additional coverage of Enumerator#next under 1.8.
