### PR TITLE
Object#{dup,clone} preserves untrusted state from the original

### DIFF
--- a/spec/tags/19/ruby/core/object/clone_tags.txt
+++ b/spec/tags/19/ruby/core/object/clone_tags.txt
@@ -1,1 +1,0 @@
-fails:Object#clone preserves untrusted state from the original

--- a/spec/tags/19/ruby/core/object/dup_tags.txt
+++ b/spec/tags/19/ruby/core/object/dup_tags.txt
@@ -1,1 +1,0 @@
-fails:Object#dup preserves untrusted state from the original

--- a/vm/builtin/object.cpp
+++ b/vm/builtin/object.cpp
@@ -29,6 +29,8 @@
 
 #include "vm/object_utils.hpp"
 
+#include "configuration.hpp"
+
 namespace rubinius {
 
   Class* Object::class_object(STATE) const {
@@ -131,6 +133,10 @@ namespace rubinius {
         ivars(state, clt->duplicate(state));
 
       };
+    }
+
+    if(!LANGUAGE_18_ENABLED(state) && other->untrusted_p(state) == Qtrue) {
+      untrust(state);
     }
 
     return this;


### PR DESCRIPTION
For reference see this #1356
