### PR TITLE
Implement Numeric#real? under 1.9

### DIFF
--- a/kernel/common/fixnum19.rb
+++ b/kernel/common/fixnum19.rb
@@ -3,10 +3,6 @@ class Fixnum < Integer
     0
   end
 
-  def real?
-    true
-  end
-
   # Must be it's own method, so that super calls the correct method
   # on Numeric
   def div(o)

--- a/kernel/common/float19.rb
+++ b/kernel/common/float19.rb
@@ -6,10 +6,6 @@ class Float
     0
   end
 
-  def real?
-    true
-  end
-
   def numerator
     if nan?
       NAN

--- a/kernel/common/numeric19.rb
+++ b/kernel/common/numeric19.rb
@@ -30,4 +30,8 @@ class Numeric
   def denominator
     to_r.denominator
   end
+
+  def real?
+    true
+  end
 end

--- a/spec/ruby/core/numeric/real_spec.rb
+++ b/spec/ruby/core/numeric/real_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../../../shared/complex/numeric/real', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
 
 ruby_version_is "1.9" do
   describe "Numeric#real" do
@@ -9,6 +10,8 @@ end
 
 ruby_version_is "1.9" do
   describe "Numeric#real?" do
-    it "needs to be reviewed for spec completeness"
+    it "returns true" do
+      NumericSpecs::Subclass.new.real?.should == true
+    end
   end
 end


### PR DESCRIPTION
As per [MRI](https://github.com/ruby/ruby/blob/trunk/numeric.c#L462), move `Fixnum#real?` and `Float#real?` into `Numeric#real?` and add spec to test that it always returns `true` under 1.9. Commit extracted from pull request #1348 following @guilleiguaran's suggestion.
