### PR TITLE
Add set_scope instruction

### DIFF
--- a/vm/instructions.def
+++ b/vm/instructions.def
@@ -2278,3 +2278,14 @@ instruction push_type() [ -- constant ]
   stack_push(G(type));
 end
 
+# [Description]
+#   Set the scope of the current `CompiledMethod` to the given `StaticScope`
+#   on the stack.
+
+instruction set_scope() [ scope -- ]
+  Object* obj = stack_pop();
+  StaticScope* scope = as<StaticScope>(obj);
+  call_frame->cm->scope(state, scope);
+  call_frame->static_scope_ = scope;
+end
+

--- a/vm/llvm/jit_util.cpp
+++ b/vm/llvm/jit_util.cpp
@@ -365,6 +365,18 @@ extern "C" {
     CPP_CATCH
   }
 
+  Object* rbx_set_scope(STATE, CallFrame* call_frame, Object* top) {
+    CPP_TRY
+
+    StaticScope* scope = as<StaticScope>(top);
+    call_frame->cm->scope(state, scope);
+    // call_frame->static_scope_ = scope;
+
+    return Qnil;
+
+    CPP_CATCH
+  }
+
   Object* rbx_cast_for_splat_block_arg(STATE, CallFrame* call_frame, Arguments& args) {
     if(args.total() == 1) {
       Object* obj = args.get_argument(0);

--- a/vm/llvm/jit_visit.hpp
+++ b/vm/llvm/jit_visit.hpp
@@ -2027,6 +2027,26 @@ use_send:
       b().CreateCall(func, call_args, call_args+3);
     }
 
+    void visit_set_scope() {
+      std::vector<const Type*> types;
+
+      types.push_back(VMTy);
+      types.push_back(CallFrameTy);
+      types.push_back(ObjType);
+
+      FunctionType* ft = FunctionType::get(ObjType, types, false);
+      Function* func = cast<Function>(
+          module_->getOrInsertFunction("rbx_set_scope", ft));
+
+      Value* call_args[] = {
+        vm_,
+        call_frame_,
+        stack_pop()
+      };
+
+      b().CreateCall(func, call_args, call_args+3);
+    }
+
     Object* current_literal(opcode which) {
       return info().method()->literals()->at(which);
     }

--- a/web/_includes/instructions.markdown
+++ b/web/_includes/instructions.markdown
@@ -2221,3 +2221,18 @@
 <tr><td></td><td>...</td></tr>
 </tbody>
 </table>
+<h3><a class="instruction" name="set_scope">set_scope()</a></h3>
+
+   Set the scope of the current `CompiledMethod` to the given `StaticScope`
+   on the stack.
+
+
+<table class="stack_effect">
+<thead>
+<tr><th>Before</th><th>After</th></tr>
+</thead>
+<tbody>
+<tr><td>scope</td><td>...</td></tr>
+<tr><td>...</td><td></td></tr>
+</tbody>
+</table>


### PR DESCRIPTION
Sets the scope of the current `CompiledMethod` to the given `StaticScope` on the stack.

This is similar to (and based on) `add_scope`, but isn't module-based, so it's a bit more primitive.
