### PR TITLE
Fix RubySpec for StringIO#readbyte.

### DIFF
--- a/lib/19/stringio.rb
+++ b/lib/19/stringio.rb
@@ -314,7 +314,9 @@ class StringIO
     getc
   end
 
-  alias_method :readbyte, :readchar
+  def readbyte
+    readchar.getbyte(0)
+  end
 
   def readline(sep = $/)
     raise IO::EOFError, "end of file reached" if eof?

--- a/spec/tags/19/ruby/library/stringio/readbyte_tags.txt
+++ b/spec/tags/19/ruby/library/stringio/readbyte_tags.txt
@@ -1,1 +1,0 @@
-fails:StringIO#readbyte reads the next 8-bit byte from self's current position


### PR DESCRIPTION
Fix one of the last failing spec for StringIO#readbyte.
