### PR TITLE
Make Module#constants accept and understand the all parameter in 1.9 mode

### DIFF
--- a/kernel/common/module.rb
+++ b/kernel/common/module.rb
@@ -447,33 +447,6 @@ class Module
 
   alias_method :class_exec, :module_exec
 
-  def constants
-    tbl = Rubinius::LookupTable.new
-
-    @constant_table.each do |name, val|
-      tbl[name] = true
-    end
-
-    current = self.direct_superclass
-
-    while current and current != Object
-      current.constant_table.each do |name, val|
-        tbl[name] = true unless tbl.has_key? name
-      end
-
-      current = current.direct_superclass
-    end
-
-    # special case: Module.constants returns Object's constants
-    if self.equal? Module
-      Object.constant_table.each do |name, val|
-        tbl[name] = true unless tbl.has_key? name
-      end
-    end
-
-    Rubinius.convert_to_names tbl.keys
-  end
-
   def const_get(name)
     name = normalize_const_name(name)
 

--- a/kernel/common/module18.rb
+++ b/kernel/common/module18.rb
@@ -1,4 +1,31 @@
 class Module
+  def constants
+    tbl = Rubinius::LookupTable.new
+
+    @constant_table.each do |name, val|
+      tbl[name] = true
+    end
+
+    current = self.direct_superclass
+
+    while current and current != Object
+      current.constant_table.each do |name, val|
+        tbl[name] = true unless tbl.has_key? name
+      end
+
+      current = current.direct_superclass
+    end
+
+    # special case: Module.constants returns Object's constants
+    if self.equal? Module
+      Object.constant_table.each do |name, val|
+        tbl[name] = true unless tbl.has_key? name
+      end
+    end
+
+    Rubinius.convert_to_names tbl.keys
+  end
+
   def const_defined?(name)
     name = normalize_const_name(name)
     return true if @constant_table.has_key? name

--- a/kernel/common/module19.rb
+++ b/kernel/common/module19.rb
@@ -74,4 +74,33 @@ class Module
     Rubinius.inc_global_serial
     return nil
   end
+
+  def constants(all=nil)
+    tbl = Rubinius::LookupTable.new
+
+    @constant_table.each do |name, val|
+      tbl[name] = true
+    end
+
+    if all || all.nil?
+      current = self.direct_superclass
+
+      while current and current != Object
+        current.constant_table.each do |name, val|
+          tbl[name] = true unless tbl.has_key? name
+        end
+
+        current = current.direct_superclass
+      end
+    end
+
+    # special case: Module.constants returns Object's constants
+    if self.equal?(Module) && all.nil?
+      Object.constant_table.each do |name, val|
+        tbl[name] = true unless tbl.has_key? name
+      end
+    end
+
+    Rubinius.convert_to_names tbl.keys
+  end
 end

--- a/spec/tags/19/ruby/core/module/constants_tags.txt
+++ b/spec/tags/19/ruby/core/module/constants_tags.txt
@@ -1,3 +1,0 @@
-fails:Module.constants returns Module's constants when given a parameter
-fails:Module#constants returns an array of Symbol names of all constants defined in the moduleand all included modules
-fails:Module#constants doesn't returns inherited constants when passed false


### PR DESCRIPTION
When trying to run my Rails 3.1.0 app, I ran into an error around Module#constants. Digging in, ActiveSupport [tries to invoke Module#constants with all=false](https://github.com/rails/rails/blob/1b819d32f6302e300da0188c4edb0f3b7bd48886/activesupport/lib/active_support/core_ext/module/introspection.rb#L79), but in Rubinius it doesn't accept a parameter. This patch adds support for the all parameter and fixes 3 tests for core/module/constants.

This is my first patch to Rubinius, so I'd love feedback on how I could do better in terms of process or code!
