### PR TITLE
Array#reject should return a new array without custom instance variables

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -952,14 +952,6 @@ class Array
     nil
   end
 
-  # Returns a new Array by removing items from self for
-  # which block is true. An Array is also returned when
-  # invoked on subclasses. See #reject!
-  def reject(&block)
-    return to_enum(:reject) unless block_given?
-    dup.delete_if(&block)
-  end
-
   # Equivalent to #delete_if except that returns nil if
   # no changes were made.
   def reject!(&block)

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -475,6 +475,14 @@ class Array
     concat args
   end
 
+  # Returns a new Array by removing items from self for
+  # which block is true. An Array is also returned when
+  # invoked on subclasses. See #reject!
+  def reject(&block)
+    return to_enum(:reject) unless block_given?
+    dup.delete_if(&block)
+  end
+
   # Replaces contents of self with contents of other,
   # adjusting size as needed.
   def replace(other)

--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -540,6 +540,14 @@ class Array
 
   private :compile_repeated_combinations
 
+  # Returns a new Array by removing items from self for
+  # which block is true. An Array is also returned when
+  # invoked on subclasses. See #reject!
+  def reject(&block)
+    return to_enum(:reject) unless block_given?
+    Array.new(self).delete_if(&block)
+  end
+
   #  call-seq:
   #     ary.repeated_permutation(n) { |p| block } -> ary
   #     ary.repeated_permutation(n)               -> an_enumerator

--- a/spec/tags/19/ruby/core/array/reject_tags.txt
+++ b/spec/tags/19/ruby/core/array/reject_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#reject does not retain instance variables


### PR DESCRIPTION
- moved Array#reject from kernel/common/array.rb to array18.rb
- moved Array#reject from kernel/common/array.rb to array19.rb and
  called Array#map after Array#delete_if
- removed failed tag file
