### PR TITLE
Array#compact makes the array trusted and untainted

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -364,12 +364,6 @@ class Array
     end
   end
 
-  # Returns a copy of self with all nil elements removed
-  def compact
-    out = dup
-    out.compact! || out
-  end
-
   # Removes all nil elements from self, returns nil if no changes
   def compact!
     Rubinius.check_frozen

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -225,6 +225,12 @@ class Array
     at Kernel.rand(size)
   end
 
+  # Returns a copy of self with all nil elements removed
+  def compact
+    out = dup
+    out.compact! || out
+  end
+
   # Appends the elements in the other Array to self
   def concat(other)
     Rubinius.primitive :array_concat

--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -527,6 +527,15 @@ class Array
     return self
   end
 
+  # Returns a copy of self with all nil elements removed
+  def compact
+    out = dup
+    out.untaint if out.tainted?
+    out.trust if out.untrusted?
+
+    out.compact! || out
+  end
+
   def compile_repeated_combinations(combination_size, place, index, depth, &block)
     if depth > 0
       (length - index).times do |i|

--- a/spec/tags/19/ruby/core/array/compact_tags.txt
+++ b/spec/tags/19/ruby/core/array/compact_tags.txt
@@ -1,2 +1,0 @@
-fails:Array#compact does not keep tainted status even if all elements are removed
-fails:Array#compact does not keep untrusted status even if all elements are removed


### PR DESCRIPTION
- moved Array#compact from kernel/common/array.rb to array18.rb
- moved Array#compact from kernel/common/array.rb to array19.rb and
  flags the array as trusted and untainted
- removed failed tag file
