### PR TITLE
Array#shuffle returns an array if the object is not an array instance

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -1090,11 +1090,6 @@ class Array
     new_range n, new_size
   end
 
-  # Returns a new array with elements of this array shuffled.
-  def shuffle
-    dup.shuffle!
-  end
-
   # Shuffles elements in self in place.
   def shuffle!
     Rubinius.check_frozen

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -491,6 +491,11 @@ class Array
   alias_method :initialize_copy, :replace
   private :initialize_copy
 
+  # Returns a new array with elements of this array shuffled.
+  def shuffle
+    dup.shuffle!
+  end
+
   # Deletes the element(s) given by an index (optionally with a length)
   # or by a range. Returns the deleted object, subarray, or nil if the
   # index is out of range. Equivalent to:

--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -660,6 +660,12 @@ class Array
     replace ary unless size == ary.size
   end
 
+  # Returns a new array with elements of this array shuffled.
+  def shuffle
+    return dup.shuffle! if instance_of? Array
+    Array.new(self).shuffle!
+  end
+
   # Deletes the element(s) given by an index (optionally with a length)
   # or by a range. Returns the deleted object, subarray, or nil if the
   # index is out of range. Equivalent to:

--- a/spec/tags/19/ruby/core/array/shuffle_tags.txt
+++ b/spec/tags/19/ruby/core/array/shuffle_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#shuffle does not return subclass instances with Array subclass


### PR DESCRIPTION
- moved Array#shuffle from kernel/common/array.rb to array18.rb
- moved Array#shuffle from kernel/common/array.rb to array19.rb, check
  if self is an instance of Array and if not make it an Array instance
- removed failed tag file
