### PR TITLE
#send/#__send__ must do all coercion in the primitive

### DIFF
--- a/kernel/bootstrap/basicobject.rb
+++ b/kernel/bootstrap/basicobject.rb
@@ -29,19 +29,6 @@ class BasicObject
   #
   def __send__(message, *args)
     Rubinius.primitive :object_send
-
-    # MRI checks for Fixnum explicitly and raises ArgumentError
-    # instead of TypeError. Seems silly, so we don't bother.
-    #
-    case message
-    when String
-      message = Rubinius::Type.coerce_to message, Symbol, :to_sym
-    when Symbol
-      # nothing!
-    else
-      raise TypeError, "#{message.inspect} is not a symbol"
-    end
-
-    __send__ message, *args
+    raise PrimitiveFailure, "#__send__ primitive failed"
   end
 end

--- a/kernel/common/kernel19.rb
+++ b/kernel/common/kernel19.rb
@@ -77,20 +77,7 @@ module Kernel
   #
   def send(message, *args)
     Rubinius.primitive :object_send
-
-    # MRI checks for Fixnum explicitly and raises ArgumentError
-    # instead of TypeError. Seems silly, so we don't bother.
-    #
-    case message
-    when String
-      message = Rubinius::Type.coerce_to message, Symbol, :to_sym
-    when Symbol
-      # nothing!
-    else
-      raise TypeError, "#{message.inspect} is not a symbol"
-    end
-
-    __send__ message, *args
+    raise PrimitiveFailure, "#send primitive failed"
   end
 
   def proc(&prc)


### PR DESCRIPTION
Coercing Ruby-side and then re-calling #send/#**send** would
produce incorrect results when sending messages that are sensitive
to the call stack like send("**callee**") and the regex globals
following send("gsub").

The previous retry code also failed to pass the block parameter. It
was essentially unreachable anyway, but for clarity I think this is
better.
