### PR TITLE
Fixes to one of the new require specs, to guarantee ordering of operations.

### DIFF
--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -644,34 +644,47 @@ describe :kernel_require, :shared => true do
 
           t1_res = nil
           t2_res = nil
+          
+          t1_running = false
+          t2_running = false
+          
+          t2 = nil
 
           t1 = Thread.new do
+            t1_running = true
+            
             lambda {
               @object.require(@path)
             }.should raise_error(RuntimeError)
-
+            
             # This hits the bug. Because MRI removes it's internal lock from a table
             # when the exception is raised, this #require doesn't see that t2 is
             # in the middle of requiring the file, so this #require runs when it should
             # not.
             #
             # Sometimes this raises a ThreadError also, but I'm not sure why.
+            Thread.pass until t2_running && t2[:in_concurrent_rb] == true
             t1_res = @object.require(@path)
 
             Thread.pass until fin
+            
             ScratchPad.recorded << :t1_post
           end
-
+          
           t2 = Thread.new do
-            Thread.pass until $con1_ready
+            t2_running = true
+            
+            Thread.pass until t1_running && t1[:in_concurrent_rb] == true
+            
             begin
               t2_res = @object.require(@path)
+              
               ScratchPad.recorded << :t2_post
             ensure
               fin = true
             end
           end
-
+          
           t1.join
           t2.join
 

--- a/spec/ruby/fixtures/code/concurrent.rb
+++ b/spec/ruby/fixtures/code/concurrent.rb
@@ -1,5 +1,6 @@
 ScratchPad.recorded << :con_pre
 $con1_ready = true
+Thread.current[:in_concurrent_rb] = true
 sleep 0.5
 if $con1_raise
   $con1_raise = false


### PR DESCRIPTION
The original spec did not guarantee the "2nd" require started before the "3rd" require. This would lead to an unpredictable spec, especially on a system of lower CPU or higher load.

The "sleep" calls in concurrent.rb could probably be removed, but the same .rb is used by other specs so I didn't do that.

I think the other require specs are ok.
