### PR TITLE
Using Rubinius.single_block_arg in some Enumarable and Enumerator methods

### DIFF
--- a/kernel/common/enumerable.rb
+++ b/kernel/common/enumerable.rb
@@ -199,7 +199,8 @@ module Enumerable
 
       sym = sym.to_sym
 
-      each do |o|
+      each do 
+        o = Rubinius.single_block_arg
         if initial.equal? undefined
           initial = o
         else
@@ -209,7 +210,8 @@ module Enumerable
 
       # Block version
     else
-      each do |o|
+      each do
+        o = Rubinius.single_block_arg        
         if initial.equal? undefined
           initial = o
         else

--- a/kernel/common/enumerator.rb
+++ b/kernel/common/enumerator.rb
@@ -35,7 +35,8 @@ module Enumerable
 
       idx = 0
 
-      each do |o|
+      each do
+        o = Rubinius.single_block_arg        
         val = yield(o, idx)
         idx += 1
         val

--- a/kernel/common/enumerator19.rb
+++ b/kernel/common/enumerator19.rb
@@ -25,7 +25,8 @@ module Enumerable
 
       return to_enum(:with_index, offset) unless block_given?
 
-      each do |o|
+      each do
+        o = Rubinius.single_block_arg
         val = yield(o, offset)
         offset += 1
         val

--- a/spec/ruby/core/enumerable/inject_spec.rb
+++ b/spec/ruby/core/enumerable/inject_spec.rb
@@ -3,5 +3,5 @@ require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/inject', __FILE__)
 
 describe "Enumerable#inject" do
-  it_behaves_like :enumerable_inject, :inject
+  it_behaves_like :enumerable_inject, :inject  
 end

--- a/spec/ruby/core/enumerator/each_with_index_spec.rb
+++ b/spec/ruby/core/enumerator/each_with_index_spec.rb
@@ -23,3 +23,10 @@ ruby_version_is "1.8.7" do
     end
   end
 end
+
+describe "Enumerator#each_with_index" do
+  it "should return the correct value if chained with itself" do
+    [:a].each_with_index.each_with_index.to_a.should == [[[:a,0],0]]
+    [:a].each.with_index.with_index.to_a.should == [[[:a,0],0]]
+  end
+end

--- a/spec/ruby/core/enumerator/inject_spec.rb
+++ b/spec/ruby/core/enumerator/inject_spec.rb
@@ -1,0 +1,15 @@
+require File.expand_path('../../../shared/enumerator/each', __FILE__)
+
+describe "Enumerator#inject" do
+  it_behaves_like(:enum_each, :each)
+  
+  it "should work when chained against each_with_index" do
+    passed_values = []
+    [:a].each_with_index.inject(0) do |accumulator,value|
+      passed_values << value
+      accumulator + 1
+    end.should == 1
+    passed_values.should == [[:a,0]]
+  end
+  
+end


### PR DESCRIPTION
Changed Enumerable#inject, Enumerator#each_with_index and Enumerator#with_index to use Rubinius.single_block_arg, which should fix #1457

This is a reopened pull request, that merges my changes into a single commit. 

In 1.9 mode, if each_with_index was followed by inject or by each_with_index again, Rubinius gave a different answer to MRI 1.9, MRI 1.8 and Rubinius 1.8 mode. Reported as issue #1457.

To fix this, I changed Enumerable#inject, Enumerator#each_with_index and Enumerator#with_index to use `Rubinius.single_block_arg` 

Thanks

Tom
