### PR TITLE
Update to use the touch helper, as per brixens recommendation

### DIFF
--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -102,7 +102,7 @@ describe "Dir.glob" do
   end
 
   it "ignores non-dirs when traversing recursively" do
-    File.open("spec", 'w') { }
+    touch "spec"
     Dir.glob("spec/**/*.rb").should == []
   end
 


### PR DESCRIPTION
There was some discussion about not taking this approach, as the specs shouldn't rely on being chdir'd.

This keeps inline with the other tests in this file, but brixen recommends the pattern is altered in future.
