### PR TITLE
Fixes to Matrix#symmetric?  and Matrix#hermitian?

### DIFF
--- a/lib/19/matrix.rb
+++ b/lib/19/matrix.rb
@@ -614,7 +614,7 @@ class Matrix
   #
   def hermitian?
     Matrix.Raise ErrDimensionMismatch unless square?
-    each_with_index(:strict_upper).all? do |e, row, col|
+    each_with_index(:strict_upper).to_a.all? do |e, row, col|
       e == rows[col][row].conj
     end
   end


### PR DESCRIPTION
Fixes failures in
     bin/mspec -tx19 library/matrix/symmetric 
     bin/mspec -tx19 library/matrix/hermitian

Perhaps the issue is with Matrix#each_with_index but the following spec describes the issue:

```
 @m = Matrix[[1,2,3],[4,5,6],[7,8,9]]
 @m.each_with_index.all? { |e, i, j| i == nil }.should be_false  # FAILS (also for j == nil)
 @m.each_with_index.to_a.all? { |e, i, j| i == nil }.should be_false   # PASSES 
```

Without the coercion to an array, the block was getting `nil` for `row` and `col` 
