### PR TITLE
Fix Arguments::use_array when the array has been shifted.

### DIFF
--- a/vm/arguments.hpp
+++ b/vm/arguments.hpp
@@ -111,13 +111,17 @@ namespace rubinius {
     }
 
     void use_array(Array* ary) {
-      use_tuple(ary->tuple(), ary->size());
+      use_tuple(ary->tuple(), ary->size(), ary->offset());
     }
 
-    void use_tuple(Tuple* tup, int size) {
+    void use_tuple(Tuple* tup, uint32_t size, uint32_t offset) {
       total_ = size;
-      arguments_ = tup->field;
+      arguments_ = tup->field + offset;
       argument_container_ = tup;
+    }
+
+    void use_tuple(Tuple* tup, uint32_t size) {
+      use_tuple(tup, size, 0);
     }
 
     Tuple*& argument_container_location() {

--- a/vm/builtin/array.cpp
+++ b/vm/builtin/array.cpp
@@ -33,6 +33,10 @@ namespace rubinius {
     return total_->to_native();
   }
 
+  size_t Array::offset() {
+    return start_->to_native();
+  }
+
   Array* Array::create(STATE, size_t idx) {
     Array* ary;
     ary = state->new_object<Array>(G(array));

--- a/vm/builtin/array.hpp
+++ b/vm/builtin/array.hpp
@@ -27,6 +27,7 @@ namespace rubinius {
     /* interface */
 
     size_t size();
+    size_t offset();
     static void init(STATE);
     static Array* create(STATE, size_t size);
     static Array* from_tuple(STATE, Tuple* tup);

--- a/vm/test/test_arguments.hpp
+++ b/vm/test/test_arguments.hpp
@@ -207,4 +207,18 @@ public:
     TS_ASSERT_EQUALS(ary->get(state, 0), three);
 
   }
+
+  void test_use_array_with_shifted_array() {
+    Arguments args(state->symbol("blah"), 1, static_args);
+
+    Array *ary = Array::create(state, 3);
+    ary->set(state, 0, Fixnum::from(1));
+    ary->set(state, 1, Fixnum::from(2));
+    ary->set(state, 2, Fixnum::from(3));
+    ary->shift(state);
+
+    args.use_array(ary);
+    TS_ASSERT_EQUALS(args.get_argument(0), Fixnum::from(2));
+    TS_ASSERT_EQUALS(args.get_argument(1), Fixnum::from(3));
+  }
 };


### PR DESCRIPTION
When shifting an array, the underlying tuple doesn't shrink, but the
start offset is increased. Arguments::use_array disregarded this, which
caused some odd errors when passing a shifted array to a block taking
several arguments (see #1488).
