### PR TITLE
Add marshal _dump and _load to Encoding

### DIFF
--- a/kernel/common/encoding.rb
+++ b/kernel/common/encoding.rb
@@ -118,6 +118,14 @@ class Encoding
     end
     names
   end
+
+  def _dump(depth)
+    name
+  end
+
+  def self._load(name)
+    find name
+  end
 end
 
 # TODO: This psuedo variable should represent a scripts encoding.


### PR DESCRIPTION
Compatible with MRI 1.9.3.

rdoc 3.12 seems to use this, as without it, ri breaks.
