### PR TITLE
made alloca.h includes only for solaris

### DIFF
--- a/lib/ext/melbourne/grammar18.cpp
+++ b/lib/ext/melbourne/grammar18.cpp
@@ -1,24 +1,22 @@
-/* A Bison parser, made by GNU Bison 2.3.  */
+/* A Bison parser, made by GNU Bison 2.4.3.  */
 
 /* Skeleton implementation for Bison's Yacc-like parsers in C
-
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
-   Free Software Foundation, Inc.
-
-   This program is free software; you can redistribute it and/or modify
+   
+      Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006,
+   2009, 2010 Free Software Foundation, Inc.
+   
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
-
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-
+   
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1301, USA.  */
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -29,7 +27,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-
+   
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -47,7 +45,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.3"
+#define YYBISON_VERSION "2.4.3"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -55,231 +53,20 @@
 /* Pure parsers.  */
 #define YYPURE 1
 
+/* Push parsers.  */
+#define YYPUSH 0
+
+/* Pull parsers.  */
+#define YYPULL 1
+
 /* Using locations.  */
 #define YYLSP_NEEDED 0
 
 
 
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     kCLASS = 258,
-     kMODULE = 259,
-     kDEF = 260,
-     kUNDEF = 261,
-     kBEGIN = 262,
-     kRESCUE = 263,
-     kENSURE = 264,
-     kEND = 265,
-     kIF = 266,
-     kUNLESS = 267,
-     kTHEN = 268,
-     kELSIF = 269,
-     kELSE = 270,
-     kCASE = 271,
-     kWHEN = 272,
-     kWHILE = 273,
-     kUNTIL = 274,
-     kFOR = 275,
-     kBREAK = 276,
-     kNEXT = 277,
-     kREDO = 278,
-     kRETRY = 279,
-     kIN = 280,
-     kDO = 281,
-     kDO_COND = 282,
-     kDO_BLOCK = 283,
-     kRETURN = 284,
-     kYIELD = 285,
-     kSUPER = 286,
-     kSELF = 287,
-     kNIL = 288,
-     kTRUE = 289,
-     kFALSE = 290,
-     kAND = 291,
-     kOR = 292,
-     kNOT = 293,
-     kIF_MOD = 294,
-     kUNLESS_MOD = 295,
-     kWHILE_MOD = 296,
-     kUNTIL_MOD = 297,
-     kRESCUE_MOD = 298,
-     kALIAS = 299,
-     kDEFINED = 300,
-     klBEGIN = 301,
-     klEND = 302,
-     k__LINE__ = 303,
-     k__FILE__ = 304,
-     tIDENTIFIER = 305,
-     tFID = 306,
-     tGVAR = 307,
-     tIVAR = 308,
-     tCONSTANT = 309,
-     tCVAR = 310,
-     tXSTRING_BEG = 311,
-     tINTEGER = 312,
-     tFLOAT = 313,
-     tSTRING_CONTENT = 314,
-     tNTH_REF = 315,
-     tBACK_REF = 316,
-     tREGEXP_END = 317,
-     tUPLUS = 318,
-     tUMINUS = 319,
-     tUBS = 320,
-     tPOW = 321,
-     tCMP = 322,
-     tEQ = 323,
-     tEQQ = 324,
-     tNEQ = 325,
-     tGEQ = 326,
-     tLEQ = 327,
-     tANDOP = 328,
-     tOROP = 329,
-     tMATCH = 330,
-     tNMATCH = 331,
-     tDOT2 = 332,
-     tDOT3 = 333,
-     tAREF = 334,
-     tASET = 335,
-     tLSHFT = 336,
-     tRSHFT = 337,
-     tCOLON2 = 338,
-     tCOLON3 = 339,
-     tOP_ASGN = 340,
-     tASSOC = 341,
-     tLPAREN = 342,
-     tLPAREN_ARG = 343,
-     tRPAREN = 344,
-     tLBRACK = 345,
-     tLBRACE = 346,
-     tLBRACE_ARG = 347,
-     tSTAR = 348,
-     tAMPER = 349,
-     tSYMBEG = 350,
-     tSTRING_BEG = 351,
-     tREGEXP_BEG = 352,
-     tWORDS_BEG = 353,
-     tQWORDS_BEG = 354,
-     tSTRING_DBEG = 355,
-     tSTRING_DVAR = 356,
-     tSTRING_END = 357,
-     tLOWEST = 358,
-     tUMINUS_NUM = 359,
-     tLAST_TOKEN = 360
-   };
-#endif
-/* Tokens.  */
-#define kCLASS 258
-#define kMODULE 259
-#define kDEF 260
-#define kUNDEF 261
-#define kBEGIN 262
-#define kRESCUE 263
-#define kENSURE 264
-#define kEND 265
-#define kIF 266
-#define kUNLESS 267
-#define kTHEN 268
-#define kELSIF 269
-#define kELSE 270
-#define kCASE 271
-#define kWHEN 272
-#define kWHILE 273
-#define kUNTIL 274
-#define kFOR 275
-#define kBREAK 276
-#define kNEXT 277
-#define kREDO 278
-#define kRETRY 279
-#define kIN 280
-#define kDO 281
-#define kDO_COND 282
-#define kDO_BLOCK 283
-#define kRETURN 284
-#define kYIELD 285
-#define kSUPER 286
-#define kSELF 287
-#define kNIL 288
-#define kTRUE 289
-#define kFALSE 290
-#define kAND 291
-#define kOR 292
-#define kNOT 293
-#define kIF_MOD 294
-#define kUNLESS_MOD 295
-#define kWHILE_MOD 296
-#define kUNTIL_MOD 297
-#define kRESCUE_MOD 298
-#define kALIAS 299
-#define kDEFINED 300
-#define klBEGIN 301
-#define klEND 302
-#define k__LINE__ 303
-#define k__FILE__ 304
-#define tIDENTIFIER 305
-#define tFID 306
-#define tGVAR 307
-#define tIVAR 308
-#define tCONSTANT 309
-#define tCVAR 310
-#define tXSTRING_BEG 311
-#define tINTEGER 312
-#define tFLOAT 313
-#define tSTRING_CONTENT 314
-#define tNTH_REF 315
-#define tBACK_REF 316
-#define tREGEXP_END 317
-#define tUPLUS 318
-#define tUMINUS 319
-#define tUBS 320
-#define tPOW 321
-#define tCMP 322
-#define tEQ 323
-#define tEQQ 324
-#define tNEQ 325
-#define tGEQ 326
-#define tLEQ 327
-#define tANDOP 328
-#define tOROP 329
-#define tMATCH 330
-#define tNMATCH 331
-#define tDOT2 332
-#define tDOT3 333
-#define tAREF 334
-#define tASET 335
-#define tLSHFT 336
-#define tRSHFT 337
-#define tCOLON2 338
-#define tCOLON3 339
-#define tOP_ASGN 340
-#define tASSOC 341
-#define tLPAREN 342
-#define tLPAREN_ARG 343
-#define tRPAREN 344
-#define tLBRACK 345
-#define tLBRACE 346
-#define tLBRACE_ARG 347
-#define tSTAR 348
-#define tAMPER 349
-#define tSYMBEG 350
-#define tSTRING_BEG 351
-#define tREGEXP_BEG 352
-#define tWORDS_BEG 353
-#define tQWORDS_BEG 354
-#define tSTRING_DBEG 355
-#define tSTRING_DVAR 356
-#define tSTRING_END 357
-#define tLOWEST 358
-#define tUMINUS_NUM 359
-#define tLAST_TOKEN 360
-
-
-
-
 /* Copy the first part of user declarations.  */
+
+/* Line 189 of yacc.c  */
 #line 13 "grammar18.y"
 
 
@@ -651,6 +438,9 @@ static NODE *extract_block_vars(rb_parser_state *parser_state, NODE* node, var_t
 
 
 
+/* Line 189 of yacc.c  */
+#line 443 "grammar18.cpp"
+
 /* Enabling traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
@@ -669,31 +459,150 @@ static NODE *extract_block_vars(rb_parser_state *parser_state, NODE* node, var_t
 # define YYTOKEN_TABLE 0
 #endif
 
+
+/* Tokens.  */
+#ifndef YYTOKENTYPE
+# define YYTOKENTYPE
+   /* Put the tokens into the symbol table, so that GDB and other debuggers
+      know about them.  */
+   enum yytokentype {
+     kCLASS = 258,
+     kMODULE = 259,
+     kDEF = 260,
+     kUNDEF = 261,
+     kBEGIN = 262,
+     kRESCUE = 263,
+     kENSURE = 264,
+     kEND = 265,
+     kIF = 266,
+     kUNLESS = 267,
+     kTHEN = 268,
+     kELSIF = 269,
+     kELSE = 270,
+     kCASE = 271,
+     kWHEN = 272,
+     kWHILE = 273,
+     kUNTIL = 274,
+     kFOR = 275,
+     kBREAK = 276,
+     kNEXT = 277,
+     kREDO = 278,
+     kRETRY = 279,
+     kIN = 280,
+     kDO = 281,
+     kDO_COND = 282,
+     kDO_BLOCK = 283,
+     kRETURN = 284,
+     kYIELD = 285,
+     kSUPER = 286,
+     kSELF = 287,
+     kNIL = 288,
+     kTRUE = 289,
+     kFALSE = 290,
+     kAND = 291,
+     kOR = 292,
+     kNOT = 293,
+     kIF_MOD = 294,
+     kUNLESS_MOD = 295,
+     kWHILE_MOD = 296,
+     kUNTIL_MOD = 297,
+     kRESCUE_MOD = 298,
+     kALIAS = 299,
+     kDEFINED = 300,
+     klBEGIN = 301,
+     klEND = 302,
+     k__LINE__ = 303,
+     k__FILE__ = 304,
+     tIDENTIFIER = 305,
+     tFID = 306,
+     tGVAR = 307,
+     tIVAR = 308,
+     tCONSTANT = 309,
+     tCVAR = 310,
+     tXSTRING_BEG = 311,
+     tINTEGER = 312,
+     tFLOAT = 313,
+     tSTRING_CONTENT = 314,
+     tNTH_REF = 315,
+     tBACK_REF = 316,
+     tREGEXP_END = 317,
+     tUPLUS = 318,
+     tUMINUS = 319,
+     tUBS = 320,
+     tPOW = 321,
+     tCMP = 322,
+     tEQ = 323,
+     tEQQ = 324,
+     tNEQ = 325,
+     tGEQ = 326,
+     tLEQ = 327,
+     tANDOP = 328,
+     tOROP = 329,
+     tMATCH = 330,
+     tNMATCH = 331,
+     tDOT2 = 332,
+     tDOT3 = 333,
+     tAREF = 334,
+     tASET = 335,
+     tLSHFT = 336,
+     tRSHFT = 337,
+     tCOLON2 = 338,
+     tCOLON3 = 339,
+     tOP_ASGN = 340,
+     tASSOC = 341,
+     tLPAREN = 342,
+     tLPAREN_ARG = 343,
+     tRPAREN = 344,
+     tLBRACK = 345,
+     tLBRACE = 346,
+     tLBRACE_ARG = 347,
+     tSTAR = 348,
+     tAMPER = 349,
+     tSYMBEG = 350,
+     tSTRING_BEG = 351,
+     tREGEXP_BEG = 352,
+     tWORDS_BEG = 353,
+     tQWORDS_BEG = 354,
+     tSTRING_DBEG = 355,
+     tSTRING_DVAR = 356,
+     tSTRING_END = 357,
+     tLOWEST = 358,
+     tUMINUS_NUM = 359,
+     tLAST_TOKEN = 360
+   };
+#endif
+
+
+
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 typedef union YYSTYPE
-#line 385 "grammar18.y"
 {
+
+/* Line 214 of yacc.c  */
+#line 385 "grammar18.y"
+
     VALUE val;
     NODE *node;
     QUID id;
     int num;
     var_table vars;
-}
-/* Line 193 of yacc.c.  */
-#line 684 "grammar18.cpp"
-	YYSTYPE;
+
+
+
+/* Line 214 of yacc.c  */
+#line 594 "grammar18.cpp"
+} YYSTYPE;
+# define YYSTYPE_IS_TRIVIAL 1
 # define yystype YYSTYPE /* obsolescent; will be withdrawn */
 # define YYSTYPE_IS_DECLARED 1
-# define YYSTYPE_IS_TRIVIAL 1
 #endif
-
 
 
 /* Copy the second part of user declarations.  */
 
 
-/* Line 216 of yacc.c.  */
-#line 697 "grammar18.cpp"
+/* Line 264 of yacc.c  */
+#line 606 "grammar18.cpp"
 
 #ifdef short
 # undef short
@@ -768,14 +677,14 @@ typedef short int yytype_int16;
 #if (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 static int
-YYID (int i)
+YYID (int yyi)
 #else
 static int
-YYID (i)
-    int i;
+YYID (yyi)
+    int yyi;
 #endif
 {
-  return i;
+  return yyi;
 }
 #endif
 
@@ -856,9 +765,9 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss;
-  YYSTYPE yyvs;
-  };
+  yytype_int16 yyss_alloc;
+  YYSTYPE yyvs_alloc;
+};
 
 /* The size of the maximum gap between one aligned stack and the next.  */
 # define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
@@ -892,12 +801,12 @@ union yyalloc
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack)					\
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)				\
     do									\
       {									\
 	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack, Stack, yysize);				\
-	Stack = &yyptr->Stack;						\
+	YYCOPY (&yyptr->Stack_alloc, Stack, yysize);			\
+	Stack = &yyptr->Stack_alloc;					\
 	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
 	yyptr += yynewbytes / sizeof (*yyptr);				\
       }									\
@@ -1279,30 +1188,31 @@ static const char *const yytname[] =
   "'='", "'?'", "':'", "'>'", "'<'", "'|'", "'^'", "'&'", "'+'", "'-'",
   "'*'", "'/'", "'%'", "tUMINUS_NUM", "'!'", "'~'", "tLAST_TOKEN", "'{'",
   "'}'", "'['", "']'", "'.'", "')'", "','", "'`'", "'('", "'\\\\'", "' '",
-  "'\\n'", "';'", "$accept", "program", "@1", "bodystmt", "compstmt",
-  "stmts", "stmt", "@2", "@3", "expr", "expr_value", "command_call",
-  "block_command", "cmd_brace_block", "@4", "@5", "command", "mlhs",
+  "'\\n'", "';'", "$accept", "program", "$@1", "bodystmt", "compstmt",
+  "stmts", "stmt", "$@2", "$@3", "expr", "expr_value", "command_call",
+  "block_command", "cmd_brace_block", "$@4", "@5", "command", "mlhs",
   "mlhs_entry", "mlhs_basic", "mlhs_item", "mlhs_head", "mlhs_node", "lhs",
-  "cname", "cpath", "fname", "fsym", "fitem", "undef_list", "@6", "op",
-  "reswords", "arg", "@7", "@8", "arg_value", "aref_args", "paren_args",
+  "cname", "cpath", "fname", "fsym", "fitem", "undef_list", "$@6", "op",
+  "reswords", "arg", "$@7", "$@8", "arg_value", "aref_args", "paren_args",
   "opt_paren_args", "call_args", "call_args2", "command_args", "@9",
-  "open_args", "@10", "@11", "block_arg", "opt_block_arg", "args", "mrhs",
-  "primary", "@12", "@13", "@14", "@15", "@16", "@17", "@18", "@19", "@20",
-  "@21", "@22", "@23", "@24", "@25", "@26", "@27", "@28", "@29", "@30",
-  "@31", "@32", "@33", "primary_value", "then", "do", "if_tail",
-  "opt_else", "for_var", "block_par", "block_var", "opt_block_var",
-  "do_block", "@34", "@35", "block_call", "method_call", "brace_block",
-  "@36", "@37", "@38", "@39", "case_body", "when_args", "cases",
-  "opt_rescue", "exc_list", "exc_var", "opt_ensure", "literal", "strings",
-  "string", "string1", "xstring", "regexp", "words", "word_list", "word",
-  "qwords", "qword_list", "string_contents", "xstring_contents",
-  "string_content", "@40", "@41", "string_dvar", "symbol", "sym", "dsym",
-  "numeric", "variable", "var_ref", "var_lhs", "backref", "superclass",
-  "@42", "f_arglist", "f_args", "f_norm_arg", "f_arg", "f_opt", "f_optarg",
-  "restarg_mark", "f_rest_arg", "blkarg_mark", "f_block_arg",
-  "opt_f_block_arg", "singleton", "@43", "assoc_list", "assocs", "assoc",
-  "operation", "operation2", "operation3", "dot_or_colon", "opt_terms",
-  "opt_nl", "trailer", "term", "terms", "none", 0
+  "open_args", "$@10", "$@11", "block_arg", "opt_block_arg", "args",
+  "mrhs", "primary", "$@12", "$@13", "$@14", "$@15", "$@16", "$@17",
+  "$@18", "$@19", "$@20", "$@21", "$@22", "$@23", "$@24", "$@25", "$@26",
+  "@27", "@28", "@29", "@30", "@31", "$@32", "$@33", "primary_value",
+  "then", "do", "if_tail", "opt_else", "for_var", "block_par", "block_var",
+  "opt_block_var", "do_block", "$@34", "@35", "block_call", "method_call",
+  "brace_block", "$@36", "@37", "$@38", "@39", "case_body", "when_args",
+  "cases", "opt_rescue", "exc_list", "exc_var", "opt_ensure", "literal",
+  "strings", "string", "string1", "xstring", "regexp", "words",
+  "word_list", "word", "qwords", "qword_list", "string_contents",
+  "xstring_contents", "string_content", "@40", "@41", "string_dvar",
+  "symbol", "sym", "dsym", "numeric", "variable", "var_ref", "var_lhs",
+  "backref", "superclass", "$@42", "f_arglist", "f_args", "f_norm_arg",
+  "f_arg", "f_opt", "f_optarg", "restarg_mark", "f_rest_arg",
+  "blkarg_mark", "f_block_arg", "opt_f_block_arg", "singleton", "$@43",
+  "assoc_list", "assocs", "assoc", "operation", "operation2", "operation3",
+  "dot_or_colon", "opt_terms", "opt_nl", "trailer", "term", "terms",
+  "none", 0
 };
 #endif
 
@@ -3819,9 +3729,18 @@ static const yytype_uint16 yystos[] =
 
 /* Like YYERROR except do call yyerror.  This remains here temporarily
    to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  */
+   Once GCC version 2 has supplanted version 1, this can go.  However,
+   YYFAIL appears to be in use.  Nevertheless, it is formally deprecated
+   in Bison 2.4.2's NEWS entry, where a plan to phase it out is
+   discussed.  */
 
 #define YYFAIL		goto yyerrlab
+#if defined YYFAIL
+  /* This is here to suppress warnings from the GCC cpp's
+     -Wunused-macros.  Normally we don't worry about that warning, but
+     some users do, and we want to make it easy for users to remove
+     YYFAIL uses, which will produce warnings from Bison 2.5.  */
+#endif
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
@@ -3989,17 +3908,20 @@ yy_symbol_print (yyoutput, yytype, yyvaluep)
 #if (defined __STDC__ || defined __C99__FUNC__ \
      || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *bottom, yytype_int16 *top)
+yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
 #else
 static void
-yy_stack_print (bottom, top)
-    yytype_int16 *bottom;
-    yytype_int16 *top;
+yy_stack_print (yybottom, yytop)
+    yytype_int16 *yybottom;
+    yytype_int16 *yytop;
 #endif
 {
   YYFPRINTF (stderr, "Stack now");
-  for (; bottom <= top; ++bottom)
-    YYFPRINTF (stderr, " %d", *bottom);
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
   YYFPRINTF (stderr, "\n");
 }
 
@@ -4033,11 +3955,11 @@ yy_reduce_print (yyvsp, yyrule)
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
-      fprintf (stderr, "   $%d = ", yyi + 1);
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
 		       &(yyvsp[(yyi + 1) - (yynrhs)])
 		       		       );
-      fprintf (stderr, "\n");
+      YYFPRINTF (stderr, "\n");
     }
 }
 
@@ -4317,10 +4239,8 @@ yydestruct (yymsg, yytype, yyvaluep)
 	break;
     }
 }
-
 
 /* Prevent warnings from -Wmissing-prototypes.  */
-
 #ifdef YYPARSE_PARAM
 #if defined __STDC__ || defined __cplusplus
 int yyparse (void *YYPARSE_PARAM);
@@ -4339,10 +4259,9 @@ int yyparse ();
 
 
 
-
-/*----------.
-| yyparse.  |
-`----------*/
+/*-------------------------.
+| yyparse or yypush_parse.  |
+`-------------------------*/
 
 #ifdef YYPARSE_PARAM
 #if (defined __STDC__ || defined __C99__FUNC__ \
@@ -4366,22 +4285,46 @@ yyparse ()
 #endif
 #endif
 {
-  /* The look-ahead symbol.  */
+/* The lookahead symbol.  */
 int yychar;
 
-/* The semantic value of the look-ahead symbol.  */
+/* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
 
-/* Number of syntax errors so far.  */
-int yynerrs;
+    /* Number of syntax errors so far.  */
+    int yynerrs;
 
-  int yystate;
+    int yystate;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus;
+
+    /* The stacks and their tools:
+       `yyss': related to states.
+       `yyvs': related to semantic values.
+
+       Refer to the stacks thru separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* The state stack.  */
+    yytype_int16 yyssa[YYINITDEPTH];
+    yytype_int16 *yyss;
+    yytype_int16 *yyssp;
+
+    /* The semantic value stack.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs;
+    YYSTYPE *yyvsp;
+
+    YYSIZE_T yystacksize;
+
   int yyn;
   int yyresult;
-  /* Number of tokens to shift before error messages enabled.  */
-  int yyerrstatus;
-  /* Look-ahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead token as an internal (translated) token number.  */
+  int yytoken;
+  /* The variables used to return semantic value and location from the
+     action routines.  */
+  YYSTYPE yyval;
+
 #if YYERROR_VERBOSE
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
@@ -4389,51 +4332,28 @@ int yynerrs;
   YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
-  /* Three stacks and their tools:
-     `yyss': related to states,
-     `yyvs': related to semantic values,
-     `yyls': related to locations.
-
-     Refer to the stacks thru separate pointers, to allow yyoverflow
-     to reallocate them elsewhere.  */
-
-  /* The state stack.  */
-  yytype_int16 yyssa[YYINITDEPTH];
-  yytype_int16 *yyss = yyssa;
-  yytype_int16 *yyssp;
-
-  /* The semantic value stack.  */
-  YYSTYPE yyvsa[YYINITDEPTH];
-  YYSTYPE *yyvs = yyvsa;
-  YYSTYPE *yyvsp;
-
-
-
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
-
-  YYSIZE_T yystacksize = YYINITDEPTH;
-
-  /* The variables used to return semantic value and location from the
-     action routines.  */
-  YYSTYPE yyval;
-
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
+
+  yytoken = 0;
+  yyss = yyssa;
+  yyvs = yyvsa;
+  yystacksize = YYINITDEPTH;
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
   yystate = 0;
   yyerrstatus = 0;
   yynerrs = 0;
-  yychar = YYEMPTY;		/* Cause a token to be read.  */
+  yychar = YYEMPTY; /* Cause a token to be read.  */
 
   /* Initialize stack pointers.
      Waste one element of value and location stack
      so that they stay on the same level as the state stack.
      The wasted elements are never initialized.  */
-
   yyssp = yyss;
   yyvsp = yyvs;
 
@@ -4463,7 +4383,6 @@ int yynerrs;
 	YYSTYPE *yyvs1 = yyvs;
 	yytype_int16 *yyss1 = yyss;
 
-
 	/* Each stack pointer address is followed by the size of the
 	   data in use in that stack, in bytes.  This used to be a
 	   conditional around just the two extra args, but that might
@@ -4471,7 +4390,6 @@ int yynerrs;
 	yyoverflow (YY_("memory exhausted"),
 		    &yyss1, yysize * sizeof (*yyssp),
 		    &yyvs1, yysize * sizeof (*yyvsp),
-
 		    &yystacksize);
 
 	yyss = yyss1;
@@ -4494,9 +4412,8 @@ int yynerrs;
 	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
 	if (! yyptr)
 	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss);
-	YYSTACK_RELOCATE (yyvs);
-
+	YYSTACK_RELOCATE (yyss_alloc, yyss);
+	YYSTACK_RELOCATE (yyvs_alloc, yyvs);
 #  undef YYSTACK_RELOCATE
 	if (yyss1 != yyssa)
 	  YYSTACK_FREE (yyss1);
@@ -4507,7 +4424,6 @@ int yynerrs;
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-
       YYDPRINTF ((stderr, "Stack size increased to %lu\n",
 		  (unsigned long int) yystacksize));
 
@@ -4517,6 +4433,9 @@ int yynerrs;
 
   YYDPRINTF ((stderr, "Entering state %d\n", yystate));
 
+  if (yystate == YYFINAL)
+    YYACCEPT;
+
   goto yybackup;
 
 /*-----------.
@@ -4525,16 +4444,16 @@ int yynerrs;
 yybackup:
 
   /* Do appropriate processing given the current state.  Read a
-     look-ahead token if we need one and don't already have one.  */
+     lookahead token if we need one and don't already have one.  */
 
-  /* First try to decide what to do without reference to look-ahead token.  */
+  /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
   if (yyn == YYPACT_NINF)
     goto yydefault;
 
-  /* Not known => get a look-ahead token if don't already have one.  */
+  /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid look-ahead symbol.  */
+  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token: "));
@@ -4566,20 +4485,16 @@ yybackup:
       goto yyreduce;
     }
 
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
   /* Count tokens shifted since error; after three, turn off error
      status.  */
   if (yyerrstatus)
     yyerrstatus--;
 
-  /* Shift the look-ahead token.  */
+  /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
 
-  /* Discard the shifted token unless it is eof.  */
-  if (yychar != YYEOF)
-    yychar = YYEMPTY;
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
 
   yystate = yyn;
   *++yyvsp = yylval;
@@ -4619,6 +4534,8 @@ yyreduce:
   switch (yyn)
     {
         case 2:
+
+/* Line 1464 of yacc.c  */
 #line 524 "grammar18.y"
     {
                         lex_state = EXPR_BEG;
@@ -4628,6 +4545,8 @@ yyreduce:
     break;
 
   case 3:
+
+/* Line 1464 of yacc.c  */
 #line 530 "grammar18.y"
     {
                         if ((yyvsp[(2) - (2)].node) && !compile_for_eval) {
@@ -4647,6 +4566,8 @@ yyreduce:
     break;
 
   case 4:
+
+/* Line 1464 of yacc.c  */
 #line 551 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(1) - (4)].node);
@@ -4665,6 +4586,8 @@ yyreduce:
     break;
 
   case 5:
+
+/* Line 1464 of yacc.c  */
 #line 568 "grammar18.y"
     {
                         void_stmts((yyvsp[(1) - (2)].node), vps);
@@ -4673,6 +4596,8 @@ yyreduce:
     break;
 
   case 7:
+
+/* Line 1464 of yacc.c  */
 #line 576 "grammar18.y"
     {
                         (yyval.node) = newline_node(vps, (yyvsp[(1) - (1)].node));
@@ -4680,6 +4605,8 @@ yyreduce:
     break;
 
   case 8:
+
+/* Line 1464 of yacc.c  */
 #line 580 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, (yyvsp[(1) - (3)].node), newline_node(vps, (yyvsp[(3) - (3)].node)));
@@ -4687,6 +4614,8 @@ yyreduce:
     break;
 
   case 9:
+
+/* Line 1464 of yacc.c  */
 #line 584 "grammar18.y"
     {
                         (yyval.node) = remove_begin((yyvsp[(2) - (2)].node), vps);
@@ -4694,11 +4623,15 @@ yyreduce:
     break;
 
   case 10:
+
+/* Line 1464 of yacc.c  */
 #line 589 "grammar18.y"
     {lex_state = EXPR_FNAME;;}
     break;
 
   case 11:
+
+/* Line 1464 of yacc.c  */
 #line 590 "grammar18.y"
     {
                         (yyval.node) = NEW_ALIAS((yyvsp[(2) - (4)].node), (yyvsp[(4) - (4)].node));
@@ -4706,6 +4639,8 @@ yyreduce:
     break;
 
   case 12:
+
+/* Line 1464 of yacc.c  */
 #line 594 "grammar18.y"
     {
                         (yyval.node) = NEW_VALIAS((yyvsp[(2) - (3)].id), (yyvsp[(3) - (3)].id));
@@ -4713,6 +4648,8 @@ yyreduce:
     break;
 
   case 13:
+
+/* Line 1464 of yacc.c  */
 #line 598 "grammar18.y"
     {
                         char buf[3];
@@ -4723,6 +4660,8 @@ yyreduce:
     break;
 
   case 14:
+
+/* Line 1464 of yacc.c  */
 #line 605 "grammar18.y"
     {
                         yyerror("can't make alias for the number variables");
@@ -4731,6 +4670,8 @@ yyreduce:
     break;
 
   case 15:
+
+/* Line 1464 of yacc.c  */
 #line 610 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (2)].node);
@@ -4738,6 +4679,8 @@ yyreduce:
     break;
 
   case 16:
+
+/* Line 1464 of yacc.c  */
 #line 614 "grammar18.y"
     {
                         (yyval.node) = NEW_IF(cond((yyvsp[(3) - (3)].node), vps), remove_begin((yyvsp[(1) - (3)].node), vps), 0);
@@ -4750,6 +4693,8 @@ yyreduce:
     break;
 
   case 17:
+
+/* Line 1464 of yacc.c  */
 #line 623 "grammar18.y"
     {
                         (yyval.node) = NEW_UNLESS(cond((yyvsp[(3) - (3)].node), vps), remove_begin((yyvsp[(1) - (3)].node), vps), 0);
@@ -4762,6 +4707,8 @@ yyreduce:
     break;
 
   case 18:
+
+/* Line 1464 of yacc.c  */
 #line 632 "grammar18.y"
     {
                         if ((yyvsp[(1) - (3)].node) && nd_type((yyvsp[(1) - (3)].node)) == NODE_BEGIN) {
@@ -4777,6 +4724,8 @@ yyreduce:
     break;
 
   case 19:
+
+/* Line 1464 of yacc.c  */
 #line 644 "grammar18.y"
     {
                         if ((yyvsp[(1) - (3)].node) && nd_type((yyvsp[(1) - (3)].node)) == NODE_BEGIN) {
@@ -4792,6 +4741,8 @@ yyreduce:
     break;
 
   case 20:
+
+/* Line 1464 of yacc.c  */
 #line 656 "grammar18.y"
     {
                         NODE *resq = NEW_RESBODY(0, remove_begin((yyvsp[(3) - (3)].node), vps), 0);
@@ -4800,6 +4751,8 @@ yyreduce:
     break;
 
   case 21:
+
+/* Line 1464 of yacc.c  */
 #line 661 "grammar18.y"
     {
                         if (in_def || in_single) {
@@ -4810,6 +4763,8 @@ yyreduce:
     break;
 
   case 22:
+
+/* Line 1464 of yacc.c  */
 #line 668 "grammar18.y"
     {
                         /*
@@ -4822,6 +4777,8 @@ yyreduce:
     break;
 
   case 23:
+
+/* Line 1464 of yacc.c  */
 #line 677 "grammar18.y"
     {
                         if (in_def || in_single) {
@@ -4833,6 +4790,8 @@ yyreduce:
     break;
 
   case 24:
+
+/* Line 1464 of yacc.c  */
 #line 685 "grammar18.y"
     {
                         (yyval.node) = node_assign((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -4840,6 +4799,8 @@ yyreduce:
     break;
 
   case 25:
+
+/* Line 1464 of yacc.c  */
 #line 689 "grammar18.y"
     {
                         value_expr((yyvsp[(3) - (3)].node));
@@ -4849,6 +4810,8 @@ yyreduce:
     break;
 
   case 26:
+
+/* Line 1464 of yacc.c  */
 #line 695 "grammar18.y"
     {
                         value_expr((yyvsp[(3) - (3)].node));
@@ -4877,6 +4840,8 @@ yyreduce:
     break;
 
   case 27:
+
+/* Line 1464 of yacc.c  */
 #line 720 "grammar18.y"
     {
                         NODE *args;
@@ -4896,6 +4861,8 @@ yyreduce:
     break;
 
   case 28:
+
+/* Line 1464 of yacc.c  */
 #line 736 "grammar18.y"
     {
                         value_expr((yyvsp[(5) - (5)].node));
@@ -4911,6 +4878,8 @@ yyreduce:
     break;
 
   case 29:
+
+/* Line 1464 of yacc.c  */
 #line 748 "grammar18.y"
     {
                         value_expr((yyvsp[(5) - (5)].node));
@@ -4926,6 +4895,8 @@ yyreduce:
     break;
 
   case 30:
+
+/* Line 1464 of yacc.c  */
 #line 760 "grammar18.y"
     {
                         value_expr((yyvsp[(5) - (5)].node));
@@ -4941,6 +4912,8 @@ yyreduce:
     break;
 
   case 31:
+
+/* Line 1464 of yacc.c  */
 #line 772 "grammar18.y"
     {
                         rb_backref_error((yyvsp[(1) - (3)].node), vps);
@@ -4949,6 +4922,8 @@ yyreduce:
     break;
 
   case 32:
+
+/* Line 1464 of yacc.c  */
 #line 777 "grammar18.y"
     {
                         (yyval.node) = node_assign((yyvsp[(1) - (3)].node), NEW_SVALUE((yyvsp[(3) - (3)].node)), vps);
@@ -4956,6 +4931,8 @@ yyreduce:
     break;
 
   case 33:
+
+/* Line 1464 of yacc.c  */
 #line 781 "grammar18.y"
     {
                         (yyvsp[(1) - (3)].node)->nd_value = ((yyvsp[(1) - (3)].node)->nd_head) ? NEW_TO_ARY((yyvsp[(3) - (3)].node)) : NEW_ARRAY((yyvsp[(3) - (3)].node));
@@ -4964,6 +4941,8 @@ yyreduce:
     break;
 
   case 34:
+
+/* Line 1464 of yacc.c  */
 #line 786 "grammar18.y"
     {
                         (yyvsp[(1) - (3)].node)->nd_value = (yyvsp[(3) - (3)].node);
@@ -4972,6 +4951,8 @@ yyreduce:
     break;
 
   case 37:
+
+/* Line 1464 of yacc.c  */
 #line 795 "grammar18.y"
     {
                         (yyval.node) = logop(NODE_AND, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -4979,6 +4960,8 @@ yyreduce:
     break;
 
   case 38:
+
+/* Line 1464 of yacc.c  */
 #line 799 "grammar18.y"
     {
                         (yyval.node) = logop(NODE_OR, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -4986,6 +4969,8 @@ yyreduce:
     break;
 
   case 39:
+
+/* Line 1464 of yacc.c  */
 #line 803 "grammar18.y"
     {
                         (yyval.node) = NEW_NOT(cond((yyvsp[(2) - (2)].node), vps));
@@ -4993,6 +4978,8 @@ yyreduce:
     break;
 
   case 40:
+
+/* Line 1464 of yacc.c  */
 #line 807 "grammar18.y"
     {
                         (yyval.node) = NEW_NOT(cond((yyvsp[(2) - (2)].node), vps));
@@ -5000,6 +4987,8 @@ yyreduce:
     break;
 
   case 42:
+
+/* Line 1464 of yacc.c  */
 #line 814 "grammar18.y"
     {
                         value_expr((yyval.node));
@@ -5008,6 +4997,8 @@ yyreduce:
     break;
 
   case 45:
+
+/* Line 1464 of yacc.c  */
 #line 823 "grammar18.y"
     {
                         (yyval.node) = NEW_RETURN(ret_args(vps, (yyvsp[(2) - (2)].node)));
@@ -5015,6 +5006,8 @@ yyreduce:
     break;
 
   case 46:
+
+/* Line 1464 of yacc.c  */
 #line 827 "grammar18.y"
     {
                         (yyval.node) = NEW_BREAK(ret_args(vps, (yyvsp[(2) - (2)].node)));
@@ -5022,6 +5015,8 @@ yyreduce:
     break;
 
   case 47:
+
+/* Line 1464 of yacc.c  */
 #line 831 "grammar18.y"
     {
                         (yyval.node) = NEW_NEXT(ret_args(vps, (yyvsp[(2) - (2)].node)));
@@ -5029,6 +5024,8 @@ yyreduce:
     break;
 
   case 49:
+
+/* Line 1464 of yacc.c  */
 #line 838 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -5036,6 +5033,8 @@ yyreduce:
     break;
 
   case 50:
+
+/* Line 1464 of yacc.c  */
 #line 842 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -5043,6 +5042,8 @@ yyreduce:
     break;
 
   case 51:
+
+/* Line 1464 of yacc.c  */
 #line 848 "grammar18.y"
     {
                         (yyvsp[(1) - (1)].num) = ruby_sourceline;
@@ -5051,11 +5052,15 @@ yyreduce:
     break;
 
   case 52:
+
+/* Line 1464 of yacc.c  */
 #line 852 "grammar18.y"
     { (yyval.vars) = variables->block_vars; ;}
     break;
 
   case 53:
+
+/* Line 1464 of yacc.c  */
 #line 855 "grammar18.y"
     {
                         (yyval.node) = NEW_ITER((yyvsp[(3) - (6)].node), 0, extract_block_vars(vps, (yyvsp[(5) - (6)].node), (yyvsp[(4) - (6)].vars)));
@@ -5064,6 +5069,8 @@ yyreduce:
     break;
 
   case 54:
+
+/* Line 1464 of yacc.c  */
 #line 862 "grammar18.y"
     {
                         (yyval.node) = new_fcall(vps, (yyvsp[(1) - (2)].id), (yyvsp[(2) - (2)].node));
@@ -5072,6 +5079,8 @@ yyreduce:
     break;
 
   case 55:
+
+/* Line 1464 of yacc.c  */
 #line 867 "grammar18.y"
     {
                         (yyval.node) = new_fcall(vps, (yyvsp[(1) - (3)].id), (yyvsp[(2) - (3)].node));
@@ -5087,6 +5096,8 @@ yyreduce:
     break;
 
   case 56:
+
+/* Line 1464 of yacc.c  */
 #line 879 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -5095,6 +5106,8 @@ yyreduce:
     break;
 
   case 57:
+
+/* Line 1464 of yacc.c  */
 #line 884 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (5)].node), (yyvsp[(3) - (5)].id), (yyvsp[(4) - (5)].node));
@@ -5110,6 +5123,8 @@ yyreduce:
     break;
 
   case 58:
+
+/* Line 1464 of yacc.c  */
 #line 896 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -5118,6 +5133,8 @@ yyreduce:
     break;
 
   case 59:
+
+/* Line 1464 of yacc.c  */
 #line 901 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (5)].node), (yyvsp[(3) - (5)].id), (yyvsp[(4) - (5)].node));
@@ -5133,6 +5150,8 @@ yyreduce:
     break;
 
   case 60:
+
+/* Line 1464 of yacc.c  */
 #line 913 "grammar18.y"
     {
                         (yyval.node) = new_super(vps, (yyvsp[(2) - (2)].node));
@@ -5141,6 +5160,8 @@ yyreduce:
     break;
 
   case 61:
+
+/* Line 1464 of yacc.c  */
 #line 918 "grammar18.y"
     {
                         (yyval.node) = new_yield(vps, (yyvsp[(2) - (2)].node));
@@ -5149,6 +5170,8 @@ yyreduce:
     break;
 
   case 63:
+
+/* Line 1464 of yacc.c  */
 #line 926 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -5156,6 +5179,8 @@ yyreduce:
     break;
 
   case 65:
+
+/* Line 1464 of yacc.c  */
 #line 933 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN(NEW_LIST((yyvsp[(2) - (3)].node)), 0);
@@ -5163,6 +5188,8 @@ yyreduce:
     break;
 
   case 66:
+
+/* Line 1464 of yacc.c  */
 #line 939 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN((yyvsp[(1) - (1)].node), 0);
@@ -5170,6 +5197,8 @@ yyreduce:
     break;
 
   case 67:
+
+/* Line 1464 of yacc.c  */
 #line 943 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN(list_append(vps, (yyvsp[(1) - (2)].node),(yyvsp[(2) - (2)].node)), 0);
@@ -5177,6 +5206,8 @@ yyreduce:
     break;
 
   case 68:
+
+/* Line 1464 of yacc.c  */
 #line 947 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -5184,6 +5215,8 @@ yyreduce:
     break;
 
   case 69:
+
+/* Line 1464 of yacc.c  */
 #line 951 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN((yyvsp[(1) - (2)].node), -1);
@@ -5191,6 +5224,8 @@ yyreduce:
     break;
 
   case 70:
+
+/* Line 1464 of yacc.c  */
 #line 955 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN(0, (yyvsp[(2) - (2)].node));
@@ -5198,6 +5233,8 @@ yyreduce:
     break;
 
   case 71:
+
+/* Line 1464 of yacc.c  */
 #line 959 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN(0, -1);
@@ -5205,6 +5242,8 @@ yyreduce:
     break;
 
   case 73:
+
+/* Line 1464 of yacc.c  */
 #line 966 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -5212,6 +5251,8 @@ yyreduce:
     break;
 
   case 74:
+
+/* Line 1464 of yacc.c  */
 #line 972 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST((yyvsp[(1) - (2)].node));
@@ -5219,6 +5260,8 @@ yyreduce:
     break;
 
   case 75:
+
+/* Line 1464 of yacc.c  */
 #line 976 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (3)].node), (yyvsp[(2) - (3)].node));
@@ -5226,6 +5269,8 @@ yyreduce:
     break;
 
   case 76:
+
+/* Line 1464 of yacc.c  */
 #line 982 "grammar18.y"
     {
                         (yyval.node) = assignable((yyvsp[(1) - (1)].id), 0, vps);
@@ -5233,6 +5278,8 @@ yyreduce:
     break;
 
   case 77:
+
+/* Line 1464 of yacc.c  */
 #line 986 "grammar18.y"
     {
                         (yyval.node) = aryset((yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].node), vps);
@@ -5240,6 +5287,8 @@ yyreduce:
     break;
 
   case 78:
+
+/* Line 1464 of yacc.c  */
 #line 990 "grammar18.y"
     {
                         (yyval.node) = attrset((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), vps);
@@ -5247,6 +5296,8 @@ yyreduce:
     break;
 
   case 79:
+
+/* Line 1464 of yacc.c  */
 #line 994 "grammar18.y"
     {
                         (yyval.node) = attrset((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), vps);
@@ -5254,6 +5305,8 @@ yyreduce:
     break;
 
   case 80:
+
+/* Line 1464 of yacc.c  */
 #line 998 "grammar18.y"
     {
                         (yyval.node) = attrset((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), vps);
@@ -5261,6 +5314,8 @@ yyreduce:
     break;
 
   case 81:
+
+/* Line 1464 of yacc.c  */
 #line 1002 "grammar18.y"
     {
                         if (in_def || in_single)
@@ -5270,6 +5325,8 @@ yyreduce:
     break;
 
   case 82:
+
+/* Line 1464 of yacc.c  */
 #line 1008 "grammar18.y"
     {
                         if (in_def || in_single)
@@ -5279,6 +5336,8 @@ yyreduce:
     break;
 
   case 83:
+
+/* Line 1464 of yacc.c  */
 #line 1014 "grammar18.y"
     {
                         rb_backref_error((yyvsp[(1) - (1)].node), vps);
@@ -5287,6 +5346,8 @@ yyreduce:
     break;
 
   case 84:
+
+/* Line 1464 of yacc.c  */
 #line 1021 "grammar18.y"
     {
                         (yyval.node) = assignable((yyvsp[(1) - (1)].id), 0, vps);
@@ -5294,6 +5355,8 @@ yyreduce:
     break;
 
   case 85:
+
+/* Line 1464 of yacc.c  */
 #line 1025 "grammar18.y"
     {
                         (yyval.node) = aryset((yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].node), vps);
@@ -5301,6 +5364,8 @@ yyreduce:
     break;
 
   case 86:
+
+/* Line 1464 of yacc.c  */
 #line 1029 "grammar18.y"
     {
                         (yyval.node) = attrset((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), vps);
@@ -5308,6 +5373,8 @@ yyreduce:
     break;
 
   case 87:
+
+/* Line 1464 of yacc.c  */
 #line 1033 "grammar18.y"
     {
                         (yyval.node) = attrset((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), vps);
@@ -5315,6 +5382,8 @@ yyreduce:
     break;
 
   case 88:
+
+/* Line 1464 of yacc.c  */
 #line 1037 "grammar18.y"
     {
                         (yyval.node) = attrset((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), vps);
@@ -5322,6 +5391,8 @@ yyreduce:
     break;
 
   case 89:
+
+/* Line 1464 of yacc.c  */
 #line 1041 "grammar18.y"
     {
                         if (in_def || in_single)
@@ -5331,6 +5402,8 @@ yyreduce:
     break;
 
   case 90:
+
+/* Line 1464 of yacc.c  */
 #line 1047 "grammar18.y"
     {
                         if (in_def || in_single)
@@ -5340,6 +5413,8 @@ yyreduce:
     break;
 
   case 91:
+
+/* Line 1464 of yacc.c  */
 #line 1053 "grammar18.y"
     {
                         rb_backref_error((yyvsp[(1) - (1)].node), vps);
@@ -5348,6 +5423,8 @@ yyreduce:
     break;
 
   case 92:
+
+/* Line 1464 of yacc.c  */
 #line 1060 "grammar18.y"
     {
                         yyerror("class/module name must be CONSTANT");
@@ -5355,6 +5432,8 @@ yyreduce:
     break;
 
   case 94:
+
+/* Line 1464 of yacc.c  */
 #line 1067 "grammar18.y"
     {
                         (yyval.node) = NEW_COLON3((yyvsp[(2) - (2)].id));
@@ -5362,6 +5441,8 @@ yyreduce:
     break;
 
   case 95:
+
+/* Line 1464 of yacc.c  */
 #line 1071 "grammar18.y"
     {
                         (yyval.node) = NEW_COLON2(0, (yyval.node));
@@ -5369,6 +5450,8 @@ yyreduce:
     break;
 
   case 96:
+
+/* Line 1464 of yacc.c  */
 #line 1075 "grammar18.y"
     {
                         (yyval.node) = NEW_COLON2((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id));
@@ -5376,6 +5459,8 @@ yyreduce:
     break;
 
   case 100:
+
+/* Line 1464 of yacc.c  */
 #line 1084 "grammar18.y"
     {
                         lex_state = EXPR_END;
@@ -5384,6 +5469,8 @@ yyreduce:
     break;
 
   case 101:
+
+/* Line 1464 of yacc.c  */
 #line 1089 "grammar18.y"
     {
                         lex_state = EXPR_END;
@@ -5392,6 +5479,8 @@ yyreduce:
     break;
 
   case 104:
+
+/* Line 1464 of yacc.c  */
 #line 1100 "grammar18.y"
     {
                         (yyval.node) = NEW_LIT(QUID2SYM((yyvsp[(1) - (1)].id)));
@@ -5399,6 +5488,8 @@ yyreduce:
     break;
 
   case 106:
+
+/* Line 1464 of yacc.c  */
 #line 1107 "grammar18.y"
     {
                         (yyval.node) = NEW_UNDEF((yyvsp[(1) - (1)].node));
@@ -5406,11 +5497,15 @@ yyreduce:
     break;
 
   case 107:
+
+/* Line 1464 of yacc.c  */
 #line 1110 "grammar18.y"
     {lex_state = EXPR_FNAME;;}
     break;
 
   case 108:
+
+/* Line 1464 of yacc.c  */
 #line 1111 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, (yyvsp[(1) - (4)].node), NEW_UNDEF((yyvsp[(4) - (4)].node)));
@@ -5418,136 +5513,190 @@ yyreduce:
     break;
 
   case 109:
+
+/* Line 1464 of yacc.c  */
 #line 1116 "grammar18.y"
     { (yyval.id) = '|'; ;}
     break;
 
   case 110:
+
+/* Line 1464 of yacc.c  */
 #line 1117 "grammar18.y"
     { (yyval.id) = '^'; ;}
     break;
 
   case 111:
+
+/* Line 1464 of yacc.c  */
 #line 1118 "grammar18.y"
     { (yyval.id) = '&'; ;}
     break;
 
   case 112:
+
+/* Line 1464 of yacc.c  */
 #line 1119 "grammar18.y"
     { (yyval.id) = tCMP; ;}
     break;
 
   case 113:
+
+/* Line 1464 of yacc.c  */
 #line 1120 "grammar18.y"
     { (yyval.id) = tEQ; ;}
     break;
 
   case 114:
+
+/* Line 1464 of yacc.c  */
 #line 1121 "grammar18.y"
     { (yyval.id) = tEQQ; ;}
     break;
 
   case 115:
+
+/* Line 1464 of yacc.c  */
 #line 1122 "grammar18.y"
     { (yyval.id) = tMATCH; ;}
     break;
 
   case 116:
+
+/* Line 1464 of yacc.c  */
 #line 1123 "grammar18.y"
     { (yyval.id) = '>'; ;}
     break;
 
   case 117:
+
+/* Line 1464 of yacc.c  */
 #line 1124 "grammar18.y"
     { (yyval.id) = tGEQ; ;}
     break;
 
   case 118:
+
+/* Line 1464 of yacc.c  */
 #line 1125 "grammar18.y"
     { (yyval.id) = '<'; ;}
     break;
 
   case 119:
+
+/* Line 1464 of yacc.c  */
 #line 1126 "grammar18.y"
     { (yyval.id) = tLEQ; ;}
     break;
 
   case 120:
+
+/* Line 1464 of yacc.c  */
 #line 1127 "grammar18.y"
     { (yyval.id) = tLSHFT; ;}
     break;
 
   case 121:
+
+/* Line 1464 of yacc.c  */
 #line 1128 "grammar18.y"
     { (yyval.id) = tRSHFT; ;}
     break;
 
   case 122:
+
+/* Line 1464 of yacc.c  */
 #line 1129 "grammar18.y"
     { (yyval.id) = '+'; ;}
     break;
 
   case 123:
+
+/* Line 1464 of yacc.c  */
 #line 1130 "grammar18.y"
     { (yyval.id) = '-'; ;}
     break;
 
   case 124:
+
+/* Line 1464 of yacc.c  */
 #line 1131 "grammar18.y"
     { (yyval.id) = '*'; ;}
     break;
 
   case 125:
+
+/* Line 1464 of yacc.c  */
 #line 1132 "grammar18.y"
     { (yyval.id) = '*'; ;}
     break;
 
   case 126:
+
+/* Line 1464 of yacc.c  */
 #line 1133 "grammar18.y"
     { (yyval.id) = '/'; ;}
     break;
 
   case 127:
+
+/* Line 1464 of yacc.c  */
 #line 1134 "grammar18.y"
     { (yyval.id) = '%'; ;}
     break;
 
   case 128:
+
+/* Line 1464 of yacc.c  */
 #line 1135 "grammar18.y"
     { (yyval.id) = tPOW; ;}
     break;
 
   case 129:
+
+/* Line 1464 of yacc.c  */
 #line 1136 "grammar18.y"
     { (yyval.id) = '~'; ;}
     break;
 
   case 130:
+
+/* Line 1464 of yacc.c  */
 #line 1137 "grammar18.y"
     { (yyval.id) = tUPLUS; ;}
     break;
 
   case 131:
+
+/* Line 1464 of yacc.c  */
 #line 1138 "grammar18.y"
     { (yyval.id) = tUMINUS; ;}
     break;
 
   case 132:
+
+/* Line 1464 of yacc.c  */
 #line 1139 "grammar18.y"
     { (yyval.id) = tAREF; ;}
     break;
 
   case 133:
+
+/* Line 1464 of yacc.c  */
 #line 1140 "grammar18.y"
     { (yyval.id) = tASET; ;}
     break;
 
   case 134:
+
+/* Line 1464 of yacc.c  */
 #line 1141 "grammar18.y"
     { (yyval.id) = '`'; ;}
     break;
 
   case 176:
+
+/* Line 1464 of yacc.c  */
 #line 1154 "grammar18.y"
     {
                         (yyval.node) = node_assign((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -5555,6 +5704,8 @@ yyreduce:
     break;
 
   case 177:
+
+/* Line 1464 of yacc.c  */
 #line 1158 "grammar18.y"
     {
                         (yyval.node) = node_assign((yyvsp[(1) - (5)].node), NEW_RESCUE((yyvsp[(3) - (5)].node), NEW_RESBODY(0,(yyvsp[(5) - (5)].node),0), 0), vps);
@@ -5562,6 +5713,8 @@ yyreduce:
     break;
 
   case 178:
+
+/* Line 1464 of yacc.c  */
 #line 1162 "grammar18.y"
     {
                         value_expr((yyvsp[(3) - (3)].node));
@@ -5590,6 +5743,8 @@ yyreduce:
     break;
 
   case 179:
+
+/* Line 1464 of yacc.c  */
 #line 1187 "grammar18.y"
     {
                         NODE *args;
@@ -5609,6 +5764,8 @@ yyreduce:
     break;
 
   case 180:
+
+/* Line 1464 of yacc.c  */
 #line 1203 "grammar18.y"
     {
                         value_expr((yyvsp[(5) - (5)].node));
@@ -5624,6 +5781,8 @@ yyreduce:
     break;
 
   case 181:
+
+/* Line 1464 of yacc.c  */
 #line 1215 "grammar18.y"
     {
                         value_expr((yyvsp[(5) - (5)].node));
@@ -5639,6 +5798,8 @@ yyreduce:
     break;
 
   case 182:
+
+/* Line 1464 of yacc.c  */
 #line 1227 "grammar18.y"
     {
                         value_expr((yyvsp[(5) - (5)].node));
@@ -5654,6 +5815,8 @@ yyreduce:
     break;
 
   case 183:
+
+/* Line 1464 of yacc.c  */
 #line 1239 "grammar18.y"
     {
                         yyerror("constant re-assignment");
@@ -5662,6 +5825,8 @@ yyreduce:
     break;
 
   case 184:
+
+/* Line 1464 of yacc.c  */
 #line 1244 "grammar18.y"
     {
                         yyerror("constant re-assignment");
@@ -5670,6 +5835,8 @@ yyreduce:
     break;
 
   case 185:
+
+/* Line 1464 of yacc.c  */
 #line 1249 "grammar18.y"
     {
                         rb_backref_error((yyvsp[(1) - (3)].node), vps);
@@ -5678,6 +5845,8 @@ yyreduce:
     break;
 
   case 186:
+
+/* Line 1464 of yacc.c  */
 #line 1254 "grammar18.y"
     {
                         value_expr((yyvsp[(1) - (3)].node));
@@ -5687,6 +5856,8 @@ yyreduce:
     break;
 
   case 187:
+
+/* Line 1464 of yacc.c  */
 #line 1260 "grammar18.y"
     {
                         value_expr((yyvsp[(1) - (3)].node));
@@ -5696,6 +5867,8 @@ yyreduce:
     break;
 
   case 188:
+
+/* Line 1464 of yacc.c  */
 #line 1266 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '+', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5703,6 +5876,8 @@ yyreduce:
     break;
 
   case 189:
+
+/* Line 1464 of yacc.c  */
 #line 1270 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '-', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5710,6 +5885,8 @@ yyreduce:
     break;
 
   case 190:
+
+/* Line 1464 of yacc.c  */
 #line 1274 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '*', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5717,6 +5894,8 @@ yyreduce:
     break;
 
   case 191:
+
+/* Line 1464 of yacc.c  */
 #line 1278 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '/', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5724,6 +5903,8 @@ yyreduce:
     break;
 
   case 192:
+
+/* Line 1464 of yacc.c  */
 #line 1282 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '%', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5731,6 +5912,8 @@ yyreduce:
     break;
 
   case 193:
+
+/* Line 1464 of yacc.c  */
 #line 1286 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tPOW, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5738,6 +5921,8 @@ yyreduce:
     break;
 
   case 194:
+
+/* Line 1464 of yacc.c  */
 #line 1290 "grammar18.y"
     {
                         (yyval.node) = call_op(call_op((yyvsp[(2) - (4)].node), tPOW, 1, (yyvsp[(4) - (4)].node), vps), tUMINUS, 0, 0, vps);
@@ -5745,6 +5930,8 @@ yyreduce:
     break;
 
   case 195:
+
+/* Line 1464 of yacc.c  */
 #line 1294 "grammar18.y"
     {
                         (yyval.node) = call_op(call_op((yyvsp[(2) - (4)].node), tPOW, 1, (yyvsp[(4) - (4)].node), vps), tUMINUS, 0, 0, vps);
@@ -5752,6 +5939,8 @@ yyreduce:
     break;
 
   case 196:
+
+/* Line 1464 of yacc.c  */
 #line 1298 "grammar18.y"
     {
                         if ((yyvsp[(2) - (2)].node) && nd_type((yyvsp[(2) - (2)].node)) == NODE_LIT) {
@@ -5764,6 +5953,8 @@ yyreduce:
     break;
 
   case 197:
+
+/* Line 1464 of yacc.c  */
 #line 1307 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(2) - (2)].node), tUMINUS, 0, 0, vps);
@@ -5771,6 +5962,8 @@ yyreduce:
     break;
 
   case 198:
+
+/* Line 1464 of yacc.c  */
 #line 1311 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '|', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5778,6 +5971,8 @@ yyreduce:
     break;
 
   case 199:
+
+/* Line 1464 of yacc.c  */
 #line 1315 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '^', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5785,6 +5980,8 @@ yyreduce:
     break;
 
   case 200:
+
+/* Line 1464 of yacc.c  */
 #line 1319 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '&', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5792,6 +5989,8 @@ yyreduce:
     break;
 
   case 201:
+
+/* Line 1464 of yacc.c  */
 #line 1323 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tCMP, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5799,6 +5998,8 @@ yyreduce:
     break;
 
   case 202:
+
+/* Line 1464 of yacc.c  */
 #line 1327 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '>', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5806,6 +6007,8 @@ yyreduce:
     break;
 
   case 203:
+
+/* Line 1464 of yacc.c  */
 #line 1331 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tGEQ, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5813,6 +6016,8 @@ yyreduce:
     break;
 
   case 204:
+
+/* Line 1464 of yacc.c  */
 #line 1335 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), '<', 1, (yyvsp[(3) - (3)].node), vps);
@@ -5820,6 +6025,8 @@ yyreduce:
     break;
 
   case 205:
+
+/* Line 1464 of yacc.c  */
 #line 1339 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tLEQ, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5827,6 +6034,8 @@ yyreduce:
     break;
 
   case 206:
+
+/* Line 1464 of yacc.c  */
 #line 1343 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tEQ, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5834,6 +6043,8 @@ yyreduce:
     break;
 
   case 207:
+
+/* Line 1464 of yacc.c  */
 #line 1347 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tEQQ, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5841,6 +6052,8 @@ yyreduce:
     break;
 
   case 208:
+
+/* Line 1464 of yacc.c  */
 #line 1351 "grammar18.y"
     {
                         (yyval.node) = NEW_NOT(call_op((yyvsp[(1) - (3)].node), tEQ, 1, (yyvsp[(3) - (3)].node), vps));
@@ -5848,6 +6061,8 @@ yyreduce:
     break;
 
   case 209:
+
+/* Line 1464 of yacc.c  */
 #line 1355 "grammar18.y"
     {
                         (yyval.node) = match_gen((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -5855,6 +6070,8 @@ yyreduce:
     break;
 
   case 210:
+
+/* Line 1464 of yacc.c  */
 #line 1359 "grammar18.y"
     {
                         (yyval.node) = NEW_NOT(match_gen((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps));
@@ -5862,6 +6079,8 @@ yyreduce:
     break;
 
   case 211:
+
+/* Line 1464 of yacc.c  */
 #line 1363 "grammar18.y"
     {
                         (yyval.node) = NEW_NOT(cond((yyvsp[(2) - (2)].node), vps));
@@ -5869,6 +6088,8 @@ yyreduce:
     break;
 
   case 212:
+
+/* Line 1464 of yacc.c  */
 #line 1367 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(2) - (2)].node), '~', 0, 0, vps);
@@ -5876,6 +6097,8 @@ yyreduce:
     break;
 
   case 213:
+
+/* Line 1464 of yacc.c  */
 #line 1371 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tLSHFT, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5883,6 +6106,8 @@ yyreduce:
     break;
 
   case 214:
+
+/* Line 1464 of yacc.c  */
 #line 1375 "grammar18.y"
     {
                         (yyval.node) = call_op((yyvsp[(1) - (3)].node), tRSHFT, 1, (yyvsp[(3) - (3)].node), vps);
@@ -5890,6 +6115,8 @@ yyreduce:
     break;
 
   case 215:
+
+/* Line 1464 of yacc.c  */
 #line 1379 "grammar18.y"
     {
                         (yyval.node) = logop(NODE_AND, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -5897,6 +6124,8 @@ yyreduce:
     break;
 
   case 216:
+
+/* Line 1464 of yacc.c  */
 #line 1383 "grammar18.y"
     {
                         (yyval.node) = logop(NODE_OR, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node), vps);
@@ -5904,11 +6133,15 @@ yyreduce:
     break;
 
   case 217:
+
+/* Line 1464 of yacc.c  */
 #line 1386 "grammar18.y"
     {in_defined = 1;;}
     break;
 
   case 218:
+
+/* Line 1464 of yacc.c  */
 #line 1387 "grammar18.y"
     {
                         in_defined = 0;
@@ -5917,11 +6150,15 @@ yyreduce:
     break;
 
   case 219:
+
+/* Line 1464 of yacc.c  */
 #line 1391 "grammar18.y"
     {ternary_colon++;;}
     break;
 
   case 220:
+
+/* Line 1464 of yacc.c  */
 #line 1392 "grammar18.y"
     {
                         (yyval.node) = NEW_IF(cond((yyvsp[(1) - (6)].node), vps), (yyvsp[(4) - (6)].node), (yyvsp[(6) - (6)].node));
@@ -5931,6 +6168,8 @@ yyreduce:
     break;
 
   case 221:
+
+/* Line 1464 of yacc.c  */
 #line 1398 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(1) - (1)].node);
@@ -5938,6 +6177,8 @@ yyreduce:
     break;
 
   case 222:
+
+/* Line 1464 of yacc.c  */
 #line 1404 "grammar18.y"
     {
                         value_expr((yyvsp[(1) - (1)].node));
@@ -5946,6 +6187,8 @@ yyreduce:
     break;
 
   case 224:
+
+/* Line 1464 of yacc.c  */
 #line 1412 "grammar18.y"
     {
                         rb_warn("parenthesize argument(s) for future version");
@@ -5954,6 +6197,8 @@ yyreduce:
     break;
 
   case 225:
+
+/* Line 1464 of yacc.c  */
 #line 1417 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(1) - (2)].node);
@@ -5961,6 +6206,8 @@ yyreduce:
     break;
 
   case 226:
+
+/* Line 1464 of yacc.c  */
 #line 1421 "grammar18.y"
     {
                         value_expr((yyvsp[(4) - (5)].node));
@@ -5969,6 +6216,8 @@ yyreduce:
     break;
 
   case 227:
+
+/* Line 1464 of yacc.c  */
 #line 1426 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST(NEW_HASH((yyvsp[(1) - (2)].node)));
@@ -5976,6 +6225,8 @@ yyreduce:
     break;
 
   case 228:
+
+/* Line 1464 of yacc.c  */
 #line 1430 "grammar18.y"
     {
                         value_expr((yyvsp[(2) - (3)].node));
@@ -5984,6 +6235,8 @@ yyreduce:
     break;
 
   case 229:
+
+/* Line 1464 of yacc.c  */
 #line 1437 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -5991,6 +6244,8 @@ yyreduce:
     break;
 
   case 230:
+
+/* Line 1464 of yacc.c  */
 #line 1441 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (4)].node);
@@ -5998,6 +6253,8 @@ yyreduce:
     break;
 
   case 231:
+
+/* Line 1464 of yacc.c  */
 #line 1445 "grammar18.y"
     {
                         rb_warn("parenthesize argument for future version");
@@ -6006,6 +6263,8 @@ yyreduce:
     break;
 
   case 232:
+
+/* Line 1464 of yacc.c  */
 #line 1450 "grammar18.y"
     {
                         rb_warn("parenthesize argument for future version");
@@ -6014,6 +6273,8 @@ yyreduce:
     break;
 
   case 235:
+
+/* Line 1464 of yacc.c  */
 #line 1461 "grammar18.y"
     {
                         rb_warn("parenthesize argument(s) for future version");
@@ -6022,6 +6283,8 @@ yyreduce:
     break;
 
   case 236:
+
+/* Line 1464 of yacc.c  */
 #line 1466 "grammar18.y"
     {
                         (yyval.node) = arg_blk_pass((yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node));
@@ -6029,6 +6292,8 @@ yyreduce:
     break;
 
   case 237:
+
+/* Line 1464 of yacc.c  */
 #line 1470 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, (yyvsp[(1) - (5)].node), (yyvsp[(4) - (5)].node));
@@ -6037,6 +6302,8 @@ yyreduce:
     break;
 
   case 238:
+
+/* Line 1464 of yacc.c  */
 #line 1475 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST(NEW_HASH((yyvsp[(1) - (2)].node)));
@@ -6045,6 +6312,8 @@ yyreduce:
     break;
 
   case 239:
+
+/* Line 1464 of yacc.c  */
 #line 1480 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, NEW_LIST(NEW_HASH((yyvsp[(1) - (5)].node))), (yyvsp[(4) - (5)].node));
@@ -6053,6 +6322,8 @@ yyreduce:
     break;
 
   case 240:
+
+/* Line 1464 of yacc.c  */
 #line 1485 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (4)].node), NEW_HASH((yyvsp[(3) - (4)].node)));
@@ -6061,6 +6332,8 @@ yyreduce:
     break;
 
   case 241:
+
+/* Line 1464 of yacc.c  */
 #line 1490 "grammar18.y"
     {
                         value_expr((yyvsp[(6) - (7)].node));
@@ -6070,6 +6343,8 @@ yyreduce:
     break;
 
   case 242:
+
+/* Line 1464 of yacc.c  */
 #line 1496 "grammar18.y"
     {
                         (yyval.node) = arg_blk_pass(NEW_SPLAT((yyvsp[(2) - (3)].node)), (yyvsp[(3) - (3)].node));
@@ -6077,6 +6352,8 @@ yyreduce:
     break;
 
   case 244:
+
+/* Line 1464 of yacc.c  */
 #line 1503 "grammar18.y"
     {
                         (yyval.node) = arg_blk_pass(list_concat(NEW_LIST((yyvsp[(1) - (4)].node)),(yyvsp[(3) - (4)].node)), (yyvsp[(4) - (4)].node));
@@ -6084,6 +6361,8 @@ yyreduce:
     break;
 
   case 245:
+
+/* Line 1464 of yacc.c  */
 #line 1507 "grammar18.y"
     {
                         (yyval.node) = arg_blk_pass((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -6091,6 +6370,8 @@ yyreduce:
     break;
 
   case 246:
+
+/* Line 1464 of yacc.c  */
 #line 1511 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, NEW_LIST((yyvsp[(1) - (5)].node)), (yyvsp[(4) - (5)].node));
@@ -6099,6 +6380,8 @@ yyreduce:
     break;
 
   case 247:
+
+/* Line 1464 of yacc.c  */
 #line 1516 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, list_concat(NEW_LIST((yyvsp[(1) - (7)].node)),(yyvsp[(3) - (7)].node)), (yyvsp[(6) - (7)].node));
@@ -6107,6 +6390,8 @@ yyreduce:
     break;
 
   case 248:
+
+/* Line 1464 of yacc.c  */
 #line 1521 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST(NEW_HASH((yyvsp[(1) - (2)].node)));
@@ -6115,6 +6400,8 @@ yyreduce:
     break;
 
   case 249:
+
+/* Line 1464 of yacc.c  */
 #line 1526 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, NEW_LIST(NEW_HASH((yyvsp[(1) - (5)].node))), (yyvsp[(4) - (5)].node));
@@ -6123,6 +6410,8 @@ yyreduce:
     break;
 
   case 250:
+
+/* Line 1464 of yacc.c  */
 #line 1531 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, NEW_LIST((yyvsp[(1) - (4)].node)), NEW_HASH((yyvsp[(3) - (4)].node)));
@@ -6131,6 +6420,8 @@ yyreduce:
     break;
 
   case 251:
+
+/* Line 1464 of yacc.c  */
 #line 1536 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, list_concat(NEW_LIST((yyvsp[(1) - (6)].node)),(yyvsp[(3) - (6)].node)), NEW_HASH((yyvsp[(5) - (6)].node)));
@@ -6139,6 +6430,8 @@ yyreduce:
     break;
 
   case 252:
+
+/* Line 1464 of yacc.c  */
 #line 1541 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, list_append(vps, NEW_LIST((yyvsp[(1) - (7)].node)), NEW_HASH((yyvsp[(3) - (7)].node))), (yyvsp[(6) - (7)].node));
@@ -6147,6 +6440,8 @@ yyreduce:
     break;
 
   case 253:
+
+/* Line 1464 of yacc.c  */
 #line 1546 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, list_append(vps,
@@ -6156,6 +6451,8 @@ yyreduce:
     break;
 
   case 254:
+
+/* Line 1464 of yacc.c  */
 #line 1552 "grammar18.y"
     {
                         (yyval.node) = arg_blk_pass(NEW_SPLAT((yyvsp[(2) - (3)].node)), (yyvsp[(3) - (3)].node));
@@ -6163,6 +6460,8 @@ yyreduce:
     break;
 
   case 256:
+
+/* Line 1464 of yacc.c  */
 #line 1558 "grammar18.y"
     {
                         (yyval.val) = cmdarg_stack;
@@ -6171,6 +6470,8 @@ yyreduce:
     break;
 
   case 257:
+
+/* Line 1464 of yacc.c  */
 #line 1563 "grammar18.y"
     {
                         /* CMDARG_POP() */
@@ -6180,11 +6481,15 @@ yyreduce:
     break;
 
   case 259:
+
+/* Line 1464 of yacc.c  */
 #line 1571 "grammar18.y"
     {lex_state = EXPR_ENDARG;;}
     break;
 
   case 260:
+
+/* Line 1464 of yacc.c  */
 #line 1572 "grammar18.y"
     {
                         rb_warn("don't put space before argument parentheses");
@@ -6193,11 +6498,15 @@ yyreduce:
     break;
 
   case 261:
+
+/* Line 1464 of yacc.c  */
 #line 1576 "grammar18.y"
     {lex_state = EXPR_ENDARG;;}
     break;
 
   case 262:
+
+/* Line 1464 of yacc.c  */
 #line 1577 "grammar18.y"
     {
                         rb_warn("don't put space before argument parentheses");
@@ -6206,6 +6515,8 @@ yyreduce:
     break;
 
   case 263:
+
+/* Line 1464 of yacc.c  */
 #line 1584 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_PASS((yyvsp[(2) - (2)].node));
@@ -6213,6 +6524,8 @@ yyreduce:
     break;
 
   case 264:
+
+/* Line 1464 of yacc.c  */
 #line 1590 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (2)].node);
@@ -6220,6 +6533,8 @@ yyreduce:
     break;
 
   case 266:
+
+/* Line 1464 of yacc.c  */
 #line 1597 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST((yyvsp[(1) - (1)].node));
@@ -6227,6 +6542,8 @@ yyreduce:
     break;
 
   case 267:
+
+/* Line 1464 of yacc.c  */
 #line 1601 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -6234,6 +6551,8 @@ yyreduce:
     break;
 
   case 268:
+
+/* Line 1464 of yacc.c  */
 #line 1607 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -6241,6 +6560,8 @@ yyreduce:
     break;
 
   case 269:
+
+/* Line 1464 of yacc.c  */
 #line 1611 "grammar18.y"
     {
                         (yyval.node) = arg_concat(vps, (yyvsp[(1) - (4)].node), (yyvsp[(4) - (4)].node));
@@ -6248,6 +6569,8 @@ yyreduce:
     break;
 
   case 270:
+
+/* Line 1464 of yacc.c  */
 #line 1615 "grammar18.y"
     {
                         (yyval.node) = NEW_SPLAT((yyvsp[(2) - (2)].node));
@@ -6255,6 +6578,8 @@ yyreduce:
     break;
 
   case 279:
+
+/* Line 1464 of yacc.c  */
 #line 1629 "grammar18.y"
     {
                         (yyval.node) = NEW_FCALL((yyvsp[(1) - (1)].id), 0);
@@ -6262,6 +6587,8 @@ yyreduce:
     break;
 
   case 280:
+
+/* Line 1464 of yacc.c  */
 #line 1633 "grammar18.y"
     {
                         (yyvsp[(1) - (1)].num) = ruby_sourceline;
@@ -6270,6 +6597,8 @@ yyreduce:
     break;
 
   case 281:
+
+/* Line 1464 of yacc.c  */
 #line 1639 "grammar18.y"
     {
                         POP_LINE();
@@ -6282,11 +6611,15 @@ yyreduce:
     break;
 
   case 282:
+
+/* Line 1464 of yacc.c  */
 #line 1647 "grammar18.y"
     {lex_state = EXPR_ENDARG;;}
     break;
 
   case 283:
+
+/* Line 1464 of yacc.c  */
 #line 1648 "grammar18.y"
     {
                         rb_warning("(...) interpreted as grouped expression");
@@ -6295,6 +6628,8 @@ yyreduce:
     break;
 
   case 284:
+
+/* Line 1464 of yacc.c  */
 #line 1653 "grammar18.y"
     {
                         if (!(yyvsp[(2) - (3)].node)) (yyval.node) = NEW_NIL();
@@ -6303,6 +6638,8 @@ yyreduce:
     break;
 
   case 285:
+
+/* Line 1464 of yacc.c  */
 #line 1658 "grammar18.y"
     {
                         (yyval.node) = NEW_COLON2((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id));
@@ -6310,6 +6647,8 @@ yyreduce:
     break;
 
   case 286:
+
+/* Line 1464 of yacc.c  */
 #line 1662 "grammar18.y"
     {
                         (yyval.node) = NEW_COLON3((yyvsp[(2) - (2)].id));
@@ -6317,6 +6656,8 @@ yyreduce:
     break;
 
   case 287:
+
+/* Line 1464 of yacc.c  */
 #line 1666 "grammar18.y"
     {
                         if ((yyvsp[(1) - (4)].node) && nd_type((yyvsp[(1) - (4)].node)) == NODE_SELF) {
@@ -6329,6 +6670,8 @@ yyreduce:
     break;
 
   case 288:
+
+/* Line 1464 of yacc.c  */
 #line 1675 "grammar18.y"
     {
                         if ((yyvsp[(2) - (3)].node) == 0) {
@@ -6341,6 +6684,8 @@ yyreduce:
     break;
 
   case 289:
+
+/* Line 1464 of yacc.c  */
 #line 1684 "grammar18.y"
     {
                         (yyval.node) = NEW_HASH((yyvsp[(2) - (3)].node));
@@ -6348,6 +6693,8 @@ yyreduce:
     break;
 
   case 290:
+
+/* Line 1464 of yacc.c  */
 #line 1688 "grammar18.y"
     {
                         (yyval.node) = NEW_RETURN(0);
@@ -6355,6 +6702,8 @@ yyreduce:
     break;
 
   case 291:
+
+/* Line 1464 of yacc.c  */
 #line 1692 "grammar18.y"
     {
                         (yyval.node) = new_yield(vps, (yyvsp[(3) - (4)].node));
@@ -6362,6 +6711,8 @@ yyreduce:
     break;
 
   case 292:
+
+/* Line 1464 of yacc.c  */
 #line 1696 "grammar18.y"
     {
                         (yyval.node) = NEW_YIELD(0, Qfalse);
@@ -6369,6 +6720,8 @@ yyreduce:
     break;
 
   case 293:
+
+/* Line 1464 of yacc.c  */
 #line 1700 "grammar18.y"
     {
                         (yyval.node) = NEW_YIELD(0, Qfalse);
@@ -6376,11 +6729,15 @@ yyreduce:
     break;
 
   case 294:
+
+/* Line 1464 of yacc.c  */
 #line 1703 "grammar18.y"
     {in_defined = 1;;}
     break;
 
   case 295:
+
+/* Line 1464 of yacc.c  */
 #line 1704 "grammar18.y"
     {
                         in_defined = 0;
@@ -6389,6 +6746,8 @@ yyreduce:
     break;
 
   case 296:
+
+/* Line 1464 of yacc.c  */
 #line 1709 "grammar18.y"
     {
                         (yyvsp[(2) - (2)].node)->nd_iter = NEW_FCALL((yyvsp[(1) - (2)].id), 0);
@@ -6398,6 +6757,8 @@ yyreduce:
     break;
 
   case 298:
+
+/* Line 1464 of yacc.c  */
 #line 1716 "grammar18.y"
     {
                         if ((yyvsp[(1) - (2)].node) && nd_type((yyvsp[(1) - (2)].node)) == NODE_BLOCK_PASS) {
@@ -6410,6 +6771,8 @@ yyreduce:
     break;
 
   case 299:
+
+/* Line 1464 of yacc.c  */
 #line 1724 "grammar18.y"
     {
                     PUSH_LINE("if");
@@ -6417,6 +6780,8 @@ yyreduce:
     break;
 
   case 300:
+
+/* Line 1464 of yacc.c  */
 #line 1730 "grammar18.y"
     {
                         POP_LINE();
@@ -6431,6 +6796,8 @@ yyreduce:
     break;
 
   case 301:
+
+/* Line 1464 of yacc.c  */
 #line 1740 "grammar18.y"
     {
                     PUSH_LINE("unless");
@@ -6438,6 +6805,8 @@ yyreduce:
     break;
 
   case 302:
+
+/* Line 1464 of yacc.c  */
 #line 1746 "grammar18.y"
     {
                         POP_LINE();
@@ -6452,6 +6821,8 @@ yyreduce:
     break;
 
   case 303:
+
+/* Line 1464 of yacc.c  */
 #line 1756 "grammar18.y"
     {
                     PUSH_LINE("while");
@@ -6460,11 +6831,15 @@ yyreduce:
     break;
 
   case 304:
+
+/* Line 1464 of yacc.c  */
 #line 1759 "grammar18.y"
     {COND_POP();;}
     break;
 
   case 305:
+
+/* Line 1464 of yacc.c  */
 #line 1762 "grammar18.y"
     {
                         POP_LINE();
@@ -6477,6 +6852,8 @@ yyreduce:
     break;
 
   case 306:
+
+/* Line 1464 of yacc.c  */
 #line 1770 "grammar18.y"
     {
                     PUSH_LINE("until");
@@ -6485,11 +6862,15 @@ yyreduce:
     break;
 
   case 307:
+
+/* Line 1464 of yacc.c  */
 #line 1773 "grammar18.y"
     {COND_POP();;}
     break;
 
   case 308:
+
+/* Line 1464 of yacc.c  */
 #line 1776 "grammar18.y"
     {
                         POP_LINE();
@@ -6502,6 +6883,8 @@ yyreduce:
     break;
 
   case 309:
+
+/* Line 1464 of yacc.c  */
 #line 1784 "grammar18.y"
     {
                     PUSH_LINE("case");
@@ -6509,6 +6892,8 @@ yyreduce:
     break;
 
   case 310:
+
+/* Line 1464 of yacc.c  */
 #line 1789 "grammar18.y"
     {
                         POP_LINE();
@@ -6518,6 +6903,8 @@ yyreduce:
     break;
 
   case 311:
+
+/* Line 1464 of yacc.c  */
 #line 1794 "grammar18.y"
     { 
                     push_start_line((rb_parser_state*)parser_state, ruby_sourceline - 1, "case");
@@ -6525,6 +6912,8 @@ yyreduce:
     break;
 
   case 312:
+
+/* Line 1464 of yacc.c  */
 #line 1797 "grammar18.y"
     {
                         POP_LINE();
@@ -6533,6 +6922,8 @@ yyreduce:
     break;
 
   case 313:
+
+/* Line 1464 of yacc.c  */
 #line 1801 "grammar18.y"
     {
                     push_start_line((rb_parser_state*)parser_state, ruby_sourceline - 1, "case");
@@ -6540,6 +6931,8 @@ yyreduce:
     break;
 
   case 314:
+
+/* Line 1464 of yacc.c  */
 #line 1804 "grammar18.y"
     {
                         POP_LINE();
@@ -6548,6 +6941,8 @@ yyreduce:
     break;
 
   case 315:
+
+/* Line 1464 of yacc.c  */
 #line 1808 "grammar18.y"
     {
                     PUSH_LINE("for");
@@ -6555,16 +6950,22 @@ yyreduce:
     break;
 
   case 316:
+
+/* Line 1464 of yacc.c  */
 #line 1810 "grammar18.y"
     {COND_PUSH(1);;}
     break;
 
   case 317:
+
+/* Line 1464 of yacc.c  */
 #line 1810 "grammar18.y"
     {COND_POP();;}
     break;
 
   case 318:
+
+/* Line 1464 of yacc.c  */
 #line 1813 "grammar18.y"
     {
                         POP_LINE();
@@ -6574,6 +6975,8 @@ yyreduce:
     break;
 
   case 319:
+
+/* Line 1464 of yacc.c  */
 #line 1819 "grammar18.y"
     {
                         PUSH_LINE("class");
@@ -6586,6 +6989,8 @@ yyreduce:
     break;
 
   case 320:
+
+/* Line 1464 of yacc.c  */
 #line 1829 "grammar18.y"
     {
                         POP_LINE();
@@ -6597,6 +7002,8 @@ yyreduce:
     break;
 
   case 321:
+
+/* Line 1464 of yacc.c  */
 #line 1837 "grammar18.y"
     {
                         PUSH_LINE("class");
@@ -6606,6 +7013,8 @@ yyreduce:
     break;
 
   case 322:
+
+/* Line 1464 of yacc.c  */
 #line 1843 "grammar18.y"
     {
                         (yyval.num) = in_single;
@@ -6616,6 +7025,8 @@ yyreduce:
     break;
 
   case 323:
+
+/* Line 1464 of yacc.c  */
 #line 1851 "grammar18.y"
     {
                         POP_LINE();
@@ -6629,6 +7040,8 @@ yyreduce:
     break;
 
   case 324:
+
+/* Line 1464 of yacc.c  */
 #line 1861 "grammar18.y"
     {
                         PUSH_LINE("module");
@@ -6641,6 +7054,8 @@ yyreduce:
     break;
 
   case 325:
+
+/* Line 1464 of yacc.c  */
 #line 1871 "grammar18.y"
     {
                         POP_LINE();
@@ -6652,6 +7067,8 @@ yyreduce:
     break;
 
   case 326:
+
+/* Line 1464 of yacc.c  */
 #line 1879 "grammar18.y"
     {
                         PUSH_LINE("def");
@@ -6663,6 +7080,8 @@ yyreduce:
     break;
 
   case 327:
+
+/* Line 1464 of yacc.c  */
 #line 1889 "grammar18.y"
     {
                         POP_LINE();
@@ -6676,11 +7095,15 @@ yyreduce:
     break;
 
   case 328:
+
+/* Line 1464 of yacc.c  */
 #line 1898 "grammar18.y"
     {lex_state = EXPR_FNAME;;}
     break;
 
   case 329:
+
+/* Line 1464 of yacc.c  */
 #line 1899 "grammar18.y"
     {
                         PUSH_LINE("def");
@@ -6691,6 +7114,8 @@ yyreduce:
     break;
 
   case 330:
+
+/* Line 1464 of yacc.c  */
 #line 1908 "grammar18.y"
     {
                         POP_LINE();
@@ -6702,6 +7127,8 @@ yyreduce:
     break;
 
   case 331:
+
+/* Line 1464 of yacc.c  */
 #line 1916 "grammar18.y"
     {
                         (yyval.node) = NEW_BREAK(0);
@@ -6709,6 +7136,8 @@ yyreduce:
     break;
 
   case 332:
+
+/* Line 1464 of yacc.c  */
 #line 1920 "grammar18.y"
     {
                         (yyval.node) = NEW_NEXT(0);
@@ -6716,6 +7145,8 @@ yyreduce:
     break;
 
   case 333:
+
+/* Line 1464 of yacc.c  */
 #line 1924 "grammar18.y"
     {
                         (yyval.node) = NEW_REDO();
@@ -6723,6 +7154,8 @@ yyreduce:
     break;
 
   case 334:
+
+/* Line 1464 of yacc.c  */
 #line 1928 "grammar18.y"
     {
                         (yyval.node) = NEW_RETRY();
@@ -6730,6 +7163,8 @@ yyreduce:
     break;
 
   case 335:
+
+/* Line 1464 of yacc.c  */
 #line 1934 "grammar18.y"
     {
                         value_expr((yyvsp[(1) - (1)].node));
@@ -6738,6 +7173,8 @@ yyreduce:
     break;
 
   case 344:
+
+/* Line 1464 of yacc.c  */
 #line 1955 "grammar18.y"
     {
                         (yyval.node) = NEW_IF(cond((yyvsp[(2) - (5)].node), vps), (yyvsp[(4) - (5)].node), (yyvsp[(5) - (5)].node));
@@ -6746,6 +7183,8 @@ yyreduce:
     break;
 
   case 346:
+
+/* Line 1464 of yacc.c  */
 #line 1963 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (2)].node);
@@ -6753,6 +7192,8 @@ yyreduce:
     break;
 
   case 349:
+
+/* Line 1464 of yacc.c  */
 #line 1973 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST((yyvsp[(1) - (1)].node));
@@ -6760,6 +7201,8 @@ yyreduce:
     break;
 
   case 350:
+
+/* Line 1464 of yacc.c  */
 #line 1977 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -6767,6 +7210,8 @@ yyreduce:
     break;
 
   case 351:
+
+/* Line 1464 of yacc.c  */
 #line 1983 "grammar18.y"
     {
                         if ((yyvsp[(1) - (1)].node)->nd_alen == 1) {
@@ -6779,6 +7224,8 @@ yyreduce:
     break;
 
   case 352:
+
+/* Line 1464 of yacc.c  */
 #line 1992 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN((yyvsp[(1) - (2)].node), 0);
@@ -6786,6 +7233,8 @@ yyreduce:
     break;
 
   case 353:
+
+/* Line 1464 of yacc.c  */
 #line 1996 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_VAR((yyvsp[(4) - (4)].node), NEW_MASGN((yyvsp[(1) - (4)].node), 0));
@@ -6793,6 +7242,8 @@ yyreduce:
     break;
 
   case 354:
+
+/* Line 1464 of yacc.c  */
 #line 2000 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_VAR((yyvsp[(7) - (7)].node), NEW_MASGN((yyvsp[(1) - (7)].node), (yyvsp[(4) - (7)].node)));
@@ -6800,6 +7251,8 @@ yyreduce:
     break;
 
   case 355:
+
+/* Line 1464 of yacc.c  */
 #line 2004 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_VAR((yyvsp[(6) - (6)].node), NEW_MASGN((yyvsp[(1) - (6)].node), -1));
@@ -6807,6 +7260,8 @@ yyreduce:
     break;
 
   case 356:
+
+/* Line 1464 of yacc.c  */
 #line 2008 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN((yyvsp[(1) - (4)].node), (yyvsp[(4) - (4)].node));
@@ -6814,6 +7269,8 @@ yyreduce:
     break;
 
   case 357:
+
+/* Line 1464 of yacc.c  */
 #line 2012 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN((yyvsp[(1) - (3)].node), -1);
@@ -6821,6 +7278,8 @@ yyreduce:
     break;
 
   case 358:
+
+/* Line 1464 of yacc.c  */
 #line 2016 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_VAR((yyvsp[(5) - (5)].node), NEW_MASGN(0, (yyvsp[(2) - (5)].node)));
@@ -6828,6 +7287,8 @@ yyreduce:
     break;
 
   case 359:
+
+/* Line 1464 of yacc.c  */
 #line 2020 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_VAR((yyvsp[(4) - (4)].node), NEW_MASGN(0, -1));
@@ -6835,6 +7296,8 @@ yyreduce:
     break;
 
   case 360:
+
+/* Line 1464 of yacc.c  */
 #line 2024 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN(0, (yyvsp[(2) - (2)].node));
@@ -6842,6 +7305,8 @@ yyreduce:
     break;
 
   case 361:
+
+/* Line 1464 of yacc.c  */
 #line 2028 "grammar18.y"
     {
                         (yyval.node) = NEW_MASGN(0, -1);
@@ -6849,6 +7314,8 @@ yyreduce:
     break;
 
   case 362:
+
+/* Line 1464 of yacc.c  */
 #line 2032 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK_VAR((yyvsp[(2) - (2)].node), (NODE*)1);
@@ -6856,6 +7323,8 @@ yyreduce:
     break;
 
   case 364:
+
+/* Line 1464 of yacc.c  */
 #line 2039 "grammar18.y"
     {
                         (yyval.node) = (NODE*)1;
@@ -6863,6 +7332,8 @@ yyreduce:
     break;
 
   case 365:
+
+/* Line 1464 of yacc.c  */
 #line 2043 "grammar18.y"
     {
                         (yyval.node) = (NODE*)1;
@@ -6870,6 +7341,8 @@ yyreduce:
     break;
 
   case 366:
+
+/* Line 1464 of yacc.c  */
 #line 2047 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -6877,6 +7350,8 @@ yyreduce:
     break;
 
   case 367:
+
+/* Line 1464 of yacc.c  */
 #line 2053 "grammar18.y"
     {
                         PUSH_LINE("do");
@@ -6886,6 +7361,8 @@ yyreduce:
     break;
 
   case 368:
+
+/* Line 1464 of yacc.c  */
 #line 2059 "grammar18.y"
     {
                       (yyval.vars) = variables->block_vars;
@@ -6893,6 +7370,8 @@ yyreduce:
     break;
 
   case 369:
+
+/* Line 1464 of yacc.c  */
 #line 2064 "grammar18.y"
     {
                         POP_LINE();
@@ -6902,6 +7381,8 @@ yyreduce:
     break;
 
   case 370:
+
+/* Line 1464 of yacc.c  */
 #line 2072 "grammar18.y"
     {
                         if ((yyvsp[(1) - (2)].node) && nd_type((yyvsp[(1) - (2)].node)) == NODE_BLOCK_PASS) {
@@ -6914,6 +7395,8 @@ yyreduce:
     break;
 
   case 371:
+
+/* Line 1464 of yacc.c  */
 #line 2081 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -6921,6 +7404,8 @@ yyreduce:
     break;
 
   case 372:
+
+/* Line 1464 of yacc.c  */
 #line 2085 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -6928,6 +7413,8 @@ yyreduce:
     break;
 
   case 373:
+
+/* Line 1464 of yacc.c  */
 #line 2091 "grammar18.y"
     {
                         (yyval.node) = new_fcall(vps, (yyvsp[(1) - (2)].id), (yyvsp[(2) - (2)].node));
@@ -6936,6 +7423,8 @@ yyreduce:
     break;
 
   case 374:
+
+/* Line 1464 of yacc.c  */
 #line 2096 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -6944,6 +7433,8 @@ yyreduce:
     break;
 
   case 375:
+
+/* Line 1464 of yacc.c  */
 #line 2101 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id), (yyvsp[(4) - (4)].node));
@@ -6952,6 +7443,8 @@ yyreduce:
     break;
 
   case 376:
+
+/* Line 1464 of yacc.c  */
 #line 2106 "grammar18.y"
     {
                         (yyval.node) = new_call(vps, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].id), 0);
@@ -6959,6 +7452,8 @@ yyreduce:
     break;
 
   case 377:
+
+/* Line 1464 of yacc.c  */
 #line 2110 "grammar18.y"
     {
                         (yyval.node) = NEW_CALL((yyvsp[(1) - (3)].node), rb_parser_sym((rb_parser_state*) parser_state, "get_reference"),
@@ -6967,6 +7462,8 @@ yyreduce:
     break;
 
   case 378:
+
+/* Line 1464 of yacc.c  */
 #line 2115 "grammar18.y"
     {
                         (yyval.node) = NEW_FCALL(rb_parser_sym((rb_parser_state*) parser_state, "get_reference"),
@@ -6975,6 +7472,8 @@ yyreduce:
     break;
 
   case 379:
+
+/* Line 1464 of yacc.c  */
 #line 2120 "grammar18.y"
     {
                         (yyval.node) = new_super(vps, (yyvsp[(2) - (2)].node));
@@ -6982,6 +7481,8 @@ yyreduce:
     break;
 
   case 380:
+
+/* Line 1464 of yacc.c  */
 #line 2124 "grammar18.y"
     {
                         (yyval.node) = NEW_ZSUPER();
@@ -6989,6 +7490,8 @@ yyreduce:
     break;
 
   case 381:
+
+/* Line 1464 of yacc.c  */
 #line 2130 "grammar18.y"
     {
                         (yyvsp[(1) - (1)].num) = ruby_sourceline;
@@ -6997,11 +7500,15 @@ yyreduce:
     break;
 
   case 382:
+
+/* Line 1464 of yacc.c  */
 #line 2134 "grammar18.y"
     { (yyval.vars) = variables->block_vars; ;}
     break;
 
   case 383:
+
+/* Line 1464 of yacc.c  */
 #line 2136 "grammar18.y"
     {
                         (yyval.node) = NEW_ITER((yyvsp[(3) - (6)].node), 0, extract_block_vars(vps, (yyvsp[(5) - (6)].node), (yyvsp[(4) - (6)].vars)));
@@ -7010,6 +7517,8 @@ yyreduce:
     break;
 
   case 384:
+
+/* Line 1464 of yacc.c  */
 #line 2141 "grammar18.y"
     {
                         PUSH_LINE("do");
@@ -7019,11 +7528,15 @@ yyreduce:
     break;
 
   case 385:
+
+/* Line 1464 of yacc.c  */
 #line 2146 "grammar18.y"
     { (yyval.vars) = variables->block_vars; ;}
     break;
 
   case 386:
+
+/* Line 1464 of yacc.c  */
 #line 2148 "grammar18.y"
     {
                         POP_LINE();
@@ -7033,6 +7546,8 @@ yyreduce:
     break;
 
   case 387:
+
+/* Line 1464 of yacc.c  */
 #line 2158 "grammar18.y"
     {
                         (yyval.node) = NEW_WHEN((yyvsp[(2) - (5)].node), (yyvsp[(4) - (5)].node), (yyvsp[(5) - (5)].node));
@@ -7040,6 +7555,8 @@ yyreduce:
     break;
 
   case 389:
+
+/* Line 1464 of yacc.c  */
 #line 2164 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (4)].node), NEW_WHEN((yyvsp[(4) - (4)].node), 0, 0));
@@ -7047,6 +7564,8 @@ yyreduce:
     break;
 
   case 390:
+
+/* Line 1464 of yacc.c  */
 #line 2168 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST(NEW_WHEN((yyvsp[(2) - (2)].node), 0, 0));
@@ -7054,6 +7573,8 @@ yyreduce:
     break;
 
   case 393:
+
+/* Line 1464 of yacc.c  */
 #line 2180 "grammar18.y"
     {
                         if ((yyvsp[(3) - (6)].node)) {
@@ -7066,6 +7587,8 @@ yyreduce:
     break;
 
   case 395:
+
+/* Line 1464 of yacc.c  */
 #line 2192 "grammar18.y"
     {
                         (yyval.node) = NEW_LIST((yyvsp[(1) - (1)].node));
@@ -7073,6 +7596,8 @@ yyreduce:
     break;
 
   case 398:
+
+/* Line 1464 of yacc.c  */
 #line 2200 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (2)].node);
@@ -7080,6 +7605,8 @@ yyreduce:
     break;
 
   case 400:
+
+/* Line 1464 of yacc.c  */
 #line 2207 "grammar18.y"
     {
                         if ((yyvsp[(2) - (2)].node))
@@ -7091,6 +7618,8 @@ yyreduce:
     break;
 
   case 403:
+
+/* Line 1464 of yacc.c  */
 #line 2219 "grammar18.y"
     {
                         (yyval.node) = NEW_LIT(QUID2SYM((yyvsp[(1) - (1)].id)));
@@ -7098,6 +7627,8 @@ yyreduce:
     break;
 
   case 405:
+
+/* Line 1464 of yacc.c  */
 #line 2226 "grammar18.y"
     {
                         NODE *node = (yyvsp[(1) - (1)].node);
@@ -7112,6 +7643,8 @@ yyreduce:
     break;
 
   case 407:
+
+/* Line 1464 of yacc.c  */
 #line 2240 "grammar18.y"
     {
                         (yyval.node) = literal_concat(vps, (yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node));
@@ -7119,6 +7652,8 @@ yyreduce:
     break;
 
   case 408:
+
+/* Line 1464 of yacc.c  */
 #line 2246 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -7126,6 +7661,8 @@ yyreduce:
     break;
 
   case 409:
+
+/* Line 1464 of yacc.c  */
 #line 2252 "grammar18.y"
     {
                         NODE *node = (yyvsp[(2) - (3)].node);
@@ -7150,6 +7687,8 @@ yyreduce:
     break;
 
   case 410:
+
+/* Line 1464 of yacc.c  */
 #line 2275 "grammar18.y"
     {
                         intptr_t options = (yyvsp[(3) - (3)].num);
@@ -7181,6 +7720,8 @@ yyreduce:
     break;
 
   case 411:
+
+/* Line 1464 of yacc.c  */
 #line 2305 "grammar18.y"
     {
                         (yyval.node) = NEW_ZARRAY();
@@ -7188,6 +7729,8 @@ yyreduce:
     break;
 
   case 412:
+
+/* Line 1464 of yacc.c  */
 #line 2309 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -7195,6 +7738,8 @@ yyreduce:
     break;
 
   case 413:
+
+/* Line 1464 of yacc.c  */
 #line 2315 "grammar18.y"
     {
                         (yyval.node) = 0;
@@ -7202,6 +7747,8 @@ yyreduce:
     break;
 
   case 414:
+
+/* Line 1464 of yacc.c  */
 #line 2319 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (3)].node), evstr2dstr(vps, (yyvsp[(2) - (3)].node)));
@@ -7209,6 +7756,8 @@ yyreduce:
     break;
 
   case 416:
+
+/* Line 1464 of yacc.c  */
 #line 2326 "grammar18.y"
     {
                         (yyval.node) = literal_concat(vps, (yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node));
@@ -7216,6 +7765,8 @@ yyreduce:
     break;
 
   case 417:
+
+/* Line 1464 of yacc.c  */
 #line 2332 "grammar18.y"
     {
                         (yyval.node) = NEW_ZARRAY();
@@ -7223,6 +7774,8 @@ yyreduce:
     break;
 
   case 418:
+
+/* Line 1464 of yacc.c  */
 #line 2336 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (3)].node);
@@ -7230,6 +7783,8 @@ yyreduce:
     break;
 
   case 419:
+
+/* Line 1464 of yacc.c  */
 #line 2342 "grammar18.y"
     {
                         (yyval.node) = 0;
@@ -7237,6 +7792,8 @@ yyreduce:
     break;
 
   case 420:
+
+/* Line 1464 of yacc.c  */
 #line 2346 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, (yyvsp[(1) - (3)].node), (yyvsp[(2) - (3)].node));
@@ -7244,6 +7801,8 @@ yyreduce:
     break;
 
   case 421:
+
+/* Line 1464 of yacc.c  */
 #line 2352 "grammar18.y"
     {
                         (yyval.node) = 0;
@@ -7251,6 +7810,8 @@ yyreduce:
     break;
 
   case 422:
+
+/* Line 1464 of yacc.c  */
 #line 2356 "grammar18.y"
     {
                         (yyval.node) = literal_concat(vps, (yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node));
@@ -7258,6 +7819,8 @@ yyreduce:
     break;
 
   case 423:
+
+/* Line 1464 of yacc.c  */
 #line 2362 "grammar18.y"
     {
                         (yyval.node) = 0;
@@ -7265,6 +7828,8 @@ yyreduce:
     break;
 
   case 424:
+
+/* Line 1464 of yacc.c  */
 #line 2366 "grammar18.y"
     {
                         (yyval.node) = literal_concat(vps, (yyvsp[(1) - (2)].node), (yyvsp[(2) - (2)].node));
@@ -7272,6 +7837,8 @@ yyreduce:
     break;
 
   case 426:
+
+/* Line 1464 of yacc.c  */
 #line 2373 "grammar18.y"
     {
                         (yyval.node) = lex_strterm;
@@ -7281,6 +7848,8 @@ yyreduce:
     break;
 
   case 427:
+
+/* Line 1464 of yacc.c  */
 #line 2379 "grammar18.y"
     {
                         lex_strterm = (yyvsp[(2) - (3)].node);
@@ -7289,6 +7858,8 @@ yyreduce:
     break;
 
   case 428:
+
+/* Line 1464 of yacc.c  */
 #line 2384 "grammar18.y"
     {
                         (yyval.node) = lex_strterm;
@@ -7300,6 +7871,8 @@ yyreduce:
     break;
 
   case 429:
+
+/* Line 1464 of yacc.c  */
 #line 2392 "grammar18.y"
     {
                         lex_strterm = (yyvsp[(2) - (4)].node);
@@ -7313,21 +7886,29 @@ yyreduce:
     break;
 
   case 430:
+
+/* Line 1464 of yacc.c  */
 #line 2403 "grammar18.y"
     {(yyval.node) = NEW_GVAR((yyvsp[(1) - (1)].id));;}
     break;
 
   case 431:
+
+/* Line 1464 of yacc.c  */
 #line 2404 "grammar18.y"
     {(yyval.node) = NEW_IVAR((yyvsp[(1) - (1)].id));;}
     break;
 
   case 432:
+
+/* Line 1464 of yacc.c  */
 #line 2405 "grammar18.y"
     {(yyval.node) = NEW_CVAR((yyvsp[(1) - (1)].id));;}
     break;
 
   case 434:
+
+/* Line 1464 of yacc.c  */
 #line 2410 "grammar18.y"
     {
                         lex_state = EXPR_END;
@@ -7336,6 +7917,8 @@ yyreduce:
     break;
 
   case 439:
+
+/* Line 1464 of yacc.c  */
 #line 2423 "grammar18.y"
     {
                         lex_state = EXPR_END;
@@ -7368,6 +7951,8 @@ yyreduce:
     break;
 
   case 442:
+
+/* Line 1464 of yacc.c  */
 #line 2456 "grammar18.y"
     {
                         (yyval.node) = NEW_NEGATE((yyvsp[(2) - (2)].node));
@@ -7375,6 +7960,8 @@ yyreduce:
     break;
 
   case 443:
+
+/* Line 1464 of yacc.c  */
 #line 2460 "grammar18.y"
     {
                         (yyval.node) = NEW_NEGATE((yyvsp[(2) - (2)].node));
@@ -7382,36 +7969,50 @@ yyreduce:
     break;
 
   case 449:
+
+/* Line 1464 of yacc.c  */
 #line 2470 "grammar18.y"
     {(yyval.id) = kNIL;;}
     break;
 
   case 450:
+
+/* Line 1464 of yacc.c  */
 #line 2471 "grammar18.y"
     {(yyval.id) = kSELF;;}
     break;
 
   case 451:
+
+/* Line 1464 of yacc.c  */
 #line 2472 "grammar18.y"
     {(yyval.id) = kTRUE;;}
     break;
 
   case 452:
+
+/* Line 1464 of yacc.c  */
 #line 2473 "grammar18.y"
     {(yyval.id) = kFALSE;;}
     break;
 
   case 453:
+
+/* Line 1464 of yacc.c  */
 #line 2474 "grammar18.y"
     {(yyval.id) = k__FILE__;;}
     break;
 
   case 454:
+
+/* Line 1464 of yacc.c  */
 #line 2475 "grammar18.y"
     {(yyval.id) = k__LINE__;;}
     break;
 
   case 455:
+
+/* Line 1464 of yacc.c  */
 #line 2479 "grammar18.y"
     {
                         (yyval.node) = gettable((yyvsp[(1) - (1)].id));
@@ -7419,6 +8020,8 @@ yyreduce:
     break;
 
   case 456:
+
+/* Line 1464 of yacc.c  */
 #line 2485 "grammar18.y"
     {
                         (yyval.node) = assignable((yyvsp[(1) - (1)].id), 0, vps);
@@ -7426,6 +8029,8 @@ yyreduce:
     break;
 
   case 459:
+
+/* Line 1464 of yacc.c  */
 #line 2495 "grammar18.y"
     {
                         (yyval.node) = 0;
@@ -7433,6 +8038,8 @@ yyreduce:
     break;
 
   case 460:
+
+/* Line 1464 of yacc.c  */
 #line 2499 "grammar18.y"
     {
                         lex_state = EXPR_BEG;
@@ -7440,6 +8047,8 @@ yyreduce:
     break;
 
   case 461:
+
+/* Line 1464 of yacc.c  */
 #line 2503 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(3) - (4)].node);
@@ -7447,11 +8056,15 @@ yyreduce:
     break;
 
   case 462:
+
+/* Line 1464 of yacc.c  */
 #line 2506 "grammar18.y"
     {yyerrok; (yyval.node) = 0;;}
     break;
 
   case 463:
+
+/* Line 1464 of yacc.c  */
 #line 2510 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (4)].node);
@@ -7461,6 +8074,8 @@ yyreduce:
     break;
 
   case 464:
+
+/* Line 1464 of yacc.c  */
 #line 2516 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(1) - (2)].node);
@@ -7468,6 +8083,8 @@ yyreduce:
     break;
 
   case 465:
+
+/* Line 1464 of yacc.c  */
 #line 2522 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS((intptr_t)(yyvsp[(1) - (6)].num), (yyvsp[(3) - (6)].node), (yyvsp[(5) - (6)].id)), (yyvsp[(6) - (6)].node));
@@ -7475,6 +8092,8 @@ yyreduce:
     break;
 
   case 466:
+
+/* Line 1464 of yacc.c  */
 #line 2526 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS((intptr_t)(yyvsp[(1) - (4)].num), (yyvsp[(3) - (4)].node), 0), (yyvsp[(4) - (4)].node));
@@ -7482,6 +8101,8 @@ yyreduce:
     break;
 
   case 467:
+
+/* Line 1464 of yacc.c  */
 #line 2530 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS((intptr_t)(yyvsp[(1) - (4)].num), 0, (yyvsp[(3) - (4)].id)), (yyvsp[(4) - (4)].node));
@@ -7489,6 +8110,8 @@ yyreduce:
     break;
 
   case 468:
+
+/* Line 1464 of yacc.c  */
 #line 2534 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS((intptr_t)(yyvsp[(1) - (2)].num), 0, 0), (yyvsp[(2) - (2)].node));
@@ -7496,6 +8119,8 @@ yyreduce:
     break;
 
   case 469:
+
+/* Line 1464 of yacc.c  */
 #line 2538 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS(0, (yyvsp[(1) - (4)].node), (yyvsp[(3) - (4)].id)), (yyvsp[(4) - (4)].node));
@@ -7503,6 +8128,8 @@ yyreduce:
     break;
 
   case 470:
+
+/* Line 1464 of yacc.c  */
 #line 2542 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS(0, (yyvsp[(1) - (2)].node), 0), (yyvsp[(2) - (2)].node));
@@ -7510,6 +8137,8 @@ yyreduce:
     break;
 
   case 471:
+
+/* Line 1464 of yacc.c  */
 #line 2546 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS(0, 0, (yyvsp[(1) - (2)].id)), (yyvsp[(2) - (2)].node));
@@ -7517,6 +8146,8 @@ yyreduce:
     break;
 
   case 472:
+
+/* Line 1464 of yacc.c  */
 #line 2550 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, NEW_ARGS(0, 0, 0), (yyvsp[(1) - (1)].node));
@@ -7524,6 +8155,8 @@ yyreduce:
     break;
 
   case 473:
+
+/* Line 1464 of yacc.c  */
 #line 2554 "grammar18.y"
     {
                         (yyval.node) = NEW_ARGS(0, 0, 0);
@@ -7531,6 +8164,8 @@ yyreduce:
     break;
 
   case 474:
+
+/* Line 1464 of yacc.c  */
 #line 2560 "grammar18.y"
     {
                         yyerror("formal argument cannot be a constant");
@@ -7538,6 +8173,8 @@ yyreduce:
     break;
 
   case 475:
+
+/* Line 1464 of yacc.c  */
 #line 2564 "grammar18.y"
     {
                         yyerror("formal argument cannot be an instance variable");
@@ -7545,6 +8182,8 @@ yyreduce:
     break;
 
   case 476:
+
+/* Line 1464 of yacc.c  */
 #line 2568 "grammar18.y"
     {
                         yyerror("formal argument cannot be a global variable");
@@ -7552,6 +8191,8 @@ yyreduce:
     break;
 
   case 477:
+
+/* Line 1464 of yacc.c  */
 #line 2572 "grammar18.y"
     {
                         yyerror("formal argument cannot be a class variable");
@@ -7559,6 +8200,8 @@ yyreduce:
     break;
 
   case 478:
+
+/* Line 1464 of yacc.c  */
 #line 2576 "grammar18.y"
     {
                         if (!is_local_id((yyvsp[(1) - (1)].id)))
@@ -7571,6 +8214,8 @@ yyreduce:
     break;
 
   case 480:
+
+/* Line 1464 of yacc.c  */
 #line 2588 "grammar18.y"
     {
                         (yyval.num) += 1;
@@ -7578,6 +8223,8 @@ yyreduce:
     break;
 
   case 481:
+
+/* Line 1464 of yacc.c  */
 #line 2594 "grammar18.y"
     {
                         if (!is_local_id((yyvsp[(1) - (3)].id)))
@@ -7589,6 +8236,8 @@ yyreduce:
     break;
 
   case 482:
+
+/* Line 1464 of yacc.c  */
 #line 2604 "grammar18.y"
     {
                         (yyval.node) = NEW_BLOCK((yyvsp[(1) - (1)].node));
@@ -7597,6 +8246,8 @@ yyreduce:
     break;
 
   case 483:
+
+/* Line 1464 of yacc.c  */
 #line 2609 "grammar18.y"
     {
                         (yyval.node) = block_append(vps, (yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -7604,6 +8255,8 @@ yyreduce:
     break;
 
   case 486:
+
+/* Line 1464 of yacc.c  */
 #line 2619 "grammar18.y"
     {
                         if (!is_local_id((yyvsp[(2) - (2)].id)))
@@ -7615,6 +8268,8 @@ yyreduce:
     break;
 
   case 487:
+
+/* Line 1464 of yacc.c  */
 #line 2627 "grammar18.y"
     {
                         (yyval.id) = -2;
@@ -7622,6 +8277,8 @@ yyreduce:
     break;
 
   case 490:
+
+/* Line 1464 of yacc.c  */
 #line 2637 "grammar18.y"
     {
                         if (!is_local_id((yyvsp[(2) - (2)].id)))
@@ -7633,6 +8290,8 @@ yyreduce:
     break;
 
   case 491:
+
+/* Line 1464 of yacc.c  */
 #line 2647 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(2) - (2)].node);
@@ -7640,6 +8299,8 @@ yyreduce:
     break;
 
   case 493:
+
+/* Line 1464 of yacc.c  */
 #line 2654 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(1) - (1)].node);
@@ -7648,11 +8309,15 @@ yyreduce:
     break;
 
   case 494:
+
+/* Line 1464 of yacc.c  */
 #line 2658 "grammar18.y"
     {lex_state = EXPR_BEG;;}
     break;
 
   case 495:
+
+/* Line 1464 of yacc.c  */
 #line 2659 "grammar18.y"
     {
                         if ((yyvsp[(3) - (5)].node) == 0) {
@@ -7679,6 +8344,8 @@ yyreduce:
     break;
 
   case 497:
+
+/* Line 1464 of yacc.c  */
 #line 2685 "grammar18.y"
     {
                         (yyval.node) = (yyvsp[(1) - (2)].node);
@@ -7686,6 +8353,8 @@ yyreduce:
     break;
 
   case 498:
+
+/* Line 1464 of yacc.c  */
 #line 2689 "grammar18.y"
     {
                         if ((yyvsp[(1) - (2)].node)->nd_alen%2 != 0) {
@@ -7696,6 +8365,8 @@ yyreduce:
     break;
 
   case 500:
+
+/* Line 1464 of yacc.c  */
 #line 2699 "grammar18.y"
     {
                         (yyval.node) = list_concat((yyvsp[(1) - (3)].node), (yyvsp[(3) - (3)].node));
@@ -7703,6 +8374,8 @@ yyreduce:
     break;
 
   case 501:
+
+/* Line 1464 of yacc.c  */
 #line 2705 "grammar18.y"
     {
                         (yyval.node) = list_append(vps, NEW_LIST((yyvsp[(1) - (3)].node)), (yyvsp[(3) - (3)].node));
@@ -7710,23 +8383,30 @@ yyreduce:
     break;
 
   case 521:
+
+/* Line 1464 of yacc.c  */
 #line 2743 "grammar18.y"
     {yyerrok;;}
     break;
 
   case 524:
+
+/* Line 1464 of yacc.c  */
 #line 2748 "grammar18.y"
     {yyerrok;;}
     break;
 
   case 525:
+
+/* Line 1464 of yacc.c  */
 #line 2751 "grammar18.y"
     {(yyval.node) = 0;;}
     break;
 
 
-/* Line 1267 of yacc.c.  */
-#line 7730 "grammar18.cpp"
+
+/* Line 1464 of yacc.c  */
+#line 8410 "grammar18.cpp"
       default: break;
     }
   YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
@@ -7736,7 +8416,6 @@ yyreduce:
   YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
-
 
   /* Now `shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
@@ -7802,7 +8481,7 @@ yyerrlab:
 
   if (yyerrstatus == 3)
     {
-      /* If just tried and failed to reuse look-ahead token after an
+      /* If just tried and failed to reuse lookahead token after an
 	 error, discard it.  */
 
       if (yychar <= YYEOF)
@@ -7819,7 +8498,7 @@ yyerrlab:
 	}
     }
 
-  /* Else will try to reuse look-ahead token after shifting the error
+  /* Else will try to reuse lookahead token after shifting the error
      token.  */
   goto yyerrlab1;
 
@@ -7876,9 +8555,6 @@ yyerrlab1:
       YY_STACK_PRINT (yyss, yyssp);
     }
 
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
   *++yyvsp = yylval;
 
 
@@ -7903,7 +8579,7 @@ yyabortlab:
   yyresult = 1;
   goto yyreturn;
 
-#ifndef yyoverflow
+#if !defined(yyoverflow) || YYERROR_VERBOSE
 /*-------------------------------------------------.
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
@@ -7914,7 +8590,7 @@ yyexhaustedlab:
 #endif
 
 yyreturn:
-  if (yychar != YYEOF && yychar != YYEMPTY)
+  if (yychar != YYEMPTY)
      yydestruct ("Cleanup: discarding lookahead",
 		 yytoken, &yylval);
   /* Do not reclaim the symbols of the rule which action triggered
@@ -7940,6 +8616,8 @@ yyreturn:
 }
 
 
+
+/* Line 1684 of yacc.c  */
 #line 2753 "grammar18.y"
 
 

--- a/lib/ext/melbourne/grammar19.cpp
+++ b/lib/ext/melbourne/grammar19.cpp
@@ -307,7 +307,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
+#ifdef __sun__
 #include <alloca.h>
+#endif
 
 #include "ruby.h"
 

--- a/vm/capi/18/include/ruby.h
+++ b/vm/capi/18/include/ruby.h
@@ -31,7 +31,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef __sun__
 #include <alloca.h>
+#endif
 
 #include "intern.h"
 #include "defines.h"

--- a/vm/capi/19/include/ruby/ruby.h
+++ b/vm/capi/19/include/ruby/ruby.h
@@ -36,7 +36,9 @@ extern "C" {
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef __sun__
 #include <alloca.h>
+#endif
 
 #include "intern.h"
 #include "defines.h"

--- a/vm/oop.hpp
+++ b/vm/oop.hpp
@@ -5,7 +5,9 @@
 #include <ctype.h>
 #include <stdint.h>
 #include <assert.h>
+#ifdef __sun__
 #include <alloca.h>
+#endif
 
 #include "config.h"
 #include "object_types.hpp"

--- a/vm/util/time.c
+++ b/vm/util/time.c
@@ -877,7 +877,7 @@ strftime_extended(char *s, size_t maxsize, const char *format, const struct tm *
 				tp = "UTC";
 				break;
 			}
-#ifdef HAVE_TZNAME
+#if defined(HAVE_TZNAME) && defined(HAVE_DAYLIGHT)
 			i = (daylight && timeptr->tm_isdst > 0); /* 0 or 1 */
 			tp = tzname[i];
 #else


### PR DESCRIPTION
In September alloca.h was added to build on solaris systems. The problem
there was, that alloca.h was not included through stdlib.h.

FreeBSD has no alloca.h which can be included, because everything is in
stdlib.h and therefore rubinius could not be built.

On Linux, it's no problem, as alloca.h gets included through stdlib.h.

So the include for alloca.h is now only for solaris systems.
