### PR TITLE
Fix Array#shuffle! after shifting

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -1084,7 +1084,7 @@ class Array
 
     size.times do |i|
       r = i + Kernel.rand(size - i)
-      @tuple.swap(i, r)
+      @tuple.swap(@start + i, @start + r)
     end
     self
   end


### PR DESCRIPTION
shuffle! ignored a shifted start of the array, so the following code
would sometimes result in a nil getting swapped into the array:

a = [0,1,2]; a.shift; a.shuffle!

Fix it by adding the proper offset.
