### PR TITLE
Remove 1.9 failing tag for a DateTime spec that was passing all along

### DIFF
--- a/spec/tags/19/ruby/library/datetime/now_tags.txt
+++ b/spec/tags/19/ruby/library/datetime/now_tags.txt
@@ -1,1 +1,0 @@
-fails:DateTime.now creates an instance of DateTime


### PR DESCRIPTION
The 1.9 spec "`DateTime.now` creates an instance of `DateTime`" was tagged as failing despite actually passing. This pull request removes the tag.
