### PR TITLE
Make Error#to_yaml produce expected output under 1.9

### DIFF
--- a/kernel/common/exception.rb
+++ b/kernel/common/exception.rb
@@ -12,16 +12,6 @@ class Exception
     @custom_backtrace = nil
   end
 
-  # This is here rather than in yaml.rb because it contains "private"
-  # information, ie, the list of ivars. Putting it over in the yaml
-  # sounce means it's easy to forget about.
-  def to_yaml_properties
-    list = super
-    list.delete "@backtrace"
-    list.delete "@custom_backtrace"
-    return list
-  end
-
   def message
     @reason_message
   end

--- a/kernel/common/exception18.rb
+++ b/kernel/common/exception18.rb
@@ -6,4 +6,14 @@ class Exception
   def to_s
     @reason_message || self.class.to_s
   end
+
+  # This is here rather than in yaml.rb because it contains "private"
+  # information, ie, the list of ivars. Putting it over in the yaml
+  # source means it's easy to forget about.
+  def to_yaml_properties
+    list = super
+    list.delete "@backtrace"
+    list.delete "@custom_backtrace"
+    return list
+  end
 end

--- a/kernel/common/exception19.rb
+++ b/kernel/common/exception19.rb
@@ -14,4 +14,14 @@ class Exception
       self.class.to_s
     end
   end
+
+  # This is here rather than in yaml.rb because it contains "private"
+  # information, ie, the list of ivars. Putting it over in the yaml
+  # source means it's easy to forget about.
+  def to_yaml_properties
+    list = super
+    list.delete :@backtrace
+    list.delete :@custom_backtrace
+    return list
+  end
 end

--- a/spec/tags/19/ruby/library/yaml/to_yaml_tags.txt
+++ b/spec/tags/19/ruby/library/yaml/to_yaml_tags.txt
@@ -1,1 +1,0 @@
-fails:Object#to_yaml returns the YAML representation of a Error object


### PR DESCRIPTION
`Exception#to_yaml_properties` specifically removes the `@backtrace` and `@custom_backtrace` instance variables so as not to pollute the YAML output. However, under 1.9 instance variables are represented as symbols rather than strings, so those two variables were not being removed under 1.9, causing them to appear in the output of `Error#to_yaml`, which in turn made the relevant RubySpec fail.

Separating the implementations of the method under 1.8 and 1.9 fixes the spec.
