### PR TITLE
Clean up changes introduced in 9e0c903 by removing duplication

### DIFF
--- a/kernel/bootstrap/rubinius.rb
+++ b/kernel/bootstrap/rubinius.rb
@@ -1,11 +1,6 @@
 # -*- encoding: us-ascii -*-
 
 module Rubinius
-  # Ruby 1.8 returns strings for method and constant names
-  def self.convert_to_names(list)
-    list.map! { |x| x.to_s }
-  end
-
   def self.watch_signal(sig, ignored)
     Rubinius.primitive :vm_watch_signal
     watch_signal(sig.to_signal, ignored)

--- a/kernel/bootstrap/rubinius18.rb
+++ b/kernel/bootstrap/rubinius18.rb
@@ -6,6 +6,10 @@ module Rubinius
     list.map { |x| x.to_s }
   end
 
+  def self.convert_to_name(sym)
+    sym.to_s
+  end
+
   def self.binary_string(string)
     string
   end

--- a/kernel/bootstrap/rubinius19.rb
+++ b/kernel/bootstrap/rubinius19.rb
@@ -5,6 +5,10 @@ module Rubinius
     list
   end
 
+  def self.convert_to_name(sym)
+    sym
+  end
+
   def self.binary_string(string)
     string.force_encoding(Encoding::BINARY)
   end

--- a/kernel/common/exception.rb
+++ b/kernel/common/exception.rb
@@ -12,6 +12,16 @@ class Exception
     @custom_backtrace = nil
   end
 
+  # This is here rather than in yaml.rb because it contains "private"
+  # information, ie, the list of ivars. Putting it over in the yaml
+  # source means it's easy to forget about.
+  def to_yaml_properties
+    list = super
+    list.delete Rubinius.convert_to_name(:@backtrace)
+    list.delete Rubinius.convert_to_name(:@custom_backtrace)
+    return list
+  end
+
   def message
     @reason_message
   end

--- a/kernel/common/exception18.rb
+++ b/kernel/common/exception18.rb
@@ -6,14 +6,4 @@ class Exception
   def to_s
     @reason_message || self.class.to_s
   end
-
-  # This is here rather than in yaml.rb because it contains "private"
-  # information, ie, the list of ivars. Putting it over in the yaml
-  # source means it's easy to forget about.
-  def to_yaml_properties
-    list = super
-    list.delete "@backtrace"
-    list.delete "@custom_backtrace"
-    return list
-  end
 end

--- a/kernel/common/exception19.rb
+++ b/kernel/common/exception19.rb
@@ -14,14 +14,4 @@ class Exception
       self.class.to_s
     end
   end
-
-  # This is here rather than in yaml.rb because it contains "private"
-  # information, ie, the list of ivars. Putting it over in the yaml
-  # source means it's easy to forget about.
-  def to_yaml_properties
-    list = super
-    list.delete :@backtrace
-    list.delete :@custom_backtrace
-    return list
-  end
 end


### PR DESCRIPTION
Following @jfirebaugh's comments on 9e0c903, this commit adds a version-dependent `Rubinius.convert_to_name` method and uses it to unify the definitions of `Exception#to_yaml_properties`. It also removes the implementation of `Rubinius.convert_to_names` from `kernel/bootstrap/rubinius.rb`, since there seems to be no reason for it to exist.

Unfortunately `Rubinius.convert_to_name` duplicates the knowledge of how method and constant names are represented under 1.8 and 1.9, since `Rubinius.convert_to_names` hasn't been changed to delegate to `convert_to_name`. However I believe this is the right choice, especially if we factor in the performance hit of potentially calling `Rubinius.convert_to_name` thousands of times inside the `map!` block.
