### PR TITLE
Fix two 1.9 YAML specs by calling #to_time on DateTime objects

### DIFF
--- a/lib/19/yaml/syck.rb
+++ b/lib/19/yaml/syck.rb
@@ -45,7 +45,7 @@ module Syck
   def self.mktime(str)
     require "date"
     begin
-      DateTime.parse str
+      DateTime.parse(str).to_time
     rescue ArgumentError
       # nothing
     end

--- a/spec/tags/19/ruby/library/yaml/load_tags.txt
+++ b/spec/tags/19/ruby/library/yaml/load_tags.txt
@@ -1,2 +1,0 @@
-fails:YAML.load with iso8601 timestamp computes the microseconds
-fails:YAML.load with iso8601 timestamp rounds values smaller than 1 usec to 0 


### PR DESCRIPTION
When trying to replicate the functionality that the specs were testing on MRI, the result of calling `YAML.load` is a `Time` object, not a `DateTime` object like in Rbx. The `DateTime` class doesn't implement `#usec`, so naturally the specs were failing. Making `YAML.load` return a `Time` object fixes the failing specs without breaking any of the others.

I don't know the inner workings of YAML well enough to know if this is a sensible change, so I'm hoping someone who does will review this pull request.
