### PR TITLE
use delete[] to fix mismatch of delete with new[]

### DIFF
--- a/vm/test/test_arguments.hpp
+++ b/vm/test/test_arguments.hpp
@@ -28,7 +28,7 @@ public:
   }
 
   void tearDown() {
-    delete static_args;
+    delete[] static_args;
     destroy();
   }
 


### PR DESCRIPTION
This is a minor fix. This suppresses an error message from valgrind, possibly fixing a potential memory bug. 

Without this patch, when vm/test/runner is run via valgrind, the following error message is shown:

> ==9165== Mismatched free() / delete / delete []
> ==9165==    at 0x4C27FF2: operator delete(void*) (vg_replace_malloc.c:387)
> ==9165==    by 0x876B8F: TestArguments::tearDown() (test_arguments.hpp:31)
> ==9165==    by 0x869587: CxxTest::RealTestDescription::tearDown() (RealDescriptions.cpp:66)
> ==9165==    by 0x89AD61: CxxTest::TestRunner::runWorld() (TestRunner.h:87)
> ==9165==    by 0x89FB41: CxxTest::TestRunner::runAllTests(CxxTest::TestListener&) (TestRunner.h:23)
> ==9165==    by 0x60C070: main (ErrorFormatter.h:49)
> ==9165==  Address 0x6557b50 is 0 bytes inside a block of size 16 alloc'd
> ==9165==    at 0x4C2864B: operator new[](unsigned long) (vg_replace_malloc.c:305)
> ==9165==    by 0x878709: TestArguments::setUp() (test_arguments.hpp:25)
> ==9165==    by 0x869740: CxxTest::RealTestDescription::setUp() (RealDescriptions.cpp:53)
> ==9165==    by 0x89AD4B: CxxTest::TestRunner::runWorld() (TestRunner.h:85)
> ==9165==    by 0x89FB41: CxxTest::TestRunner::runAllTests(CxxTest::TestListener&) (TestRunner.h:23)
> ==9165==    by 0x60C070: main (ErrorFormatter.h:49)

See also, http://www.network-theory.co.uk/docs/valgrind/valgrind_47.html

Thanks for reviewing!
