### PR TITLE
guard 1.8-specific vm test

### DIFF
--- a/vm/test/test_fixnum.hpp
+++ b/vm/test/test_fixnum.hpp
@@ -315,8 +315,12 @@ class TestFixnum : public CxxTest::TestSuite, public VMTest {
     TS_ASSERT_EQUALS(Fixnum::from(-1)->pow(state, Fixnum::from(1)), Fixnum::from(-1));
     TS_ASSERT_EQUALS(Fixnum::from(-1)->pow(state, Fixnum::from(2)), Fixnum::from(1));
     TS_ASSERT_EQUALS(Fixnum::from(7)->pow(state, Fixnum::from(5)), Fixnum::from(16807));
-    check_float(as<Float>(Fixnum::from(100)->pow(state, Fixnum::from(-1))),
-        Float::create(state,.01));
+    if(LANGUAGE_18_ENABLED(state)) {
+      check_float(as<Float>(Fixnum::from(100)->pow(state, Fixnum::from(-1))),
+          Float::create(state,.01));
+    } else {
+      TS_ASSERT_EQUALS(Fixnum::from(100)->pow(state, Fixnum::from(-1)), Primitives::failure());
+    }
   }
 
   void test_pow_overflows_to_bignum() {


### PR DESCRIPTION
Afrer rubinius is `configure`'d with `--default-version=19`, `rake`'ing is interrupted in middle of `vm:test` by SEGV.

A commit (07859e456192e455d09a27f8414b4e6dd351c8ab Don't use alias chains to implement {Fixnum,Bignum}#*\* returning Rational in 1.9) introduced 1.8 specific behaviour in Fixnum::pow. But, an affected vm test hasn't been updated. This commit does the missed update to the vm test.

The cause of SEGV is like this:

Since that comimt, Fixnum::pow became to return Primitives::failure in a corner case in 1.9 mode. Primitives::failure is just a special integer constant `reinterpret_cast`ed into `Object *`. So, in general it shouldn't be dereferenced. Yet, the vm test tries to do anyway and `SEGV`es.
