### PR TITLE
assert regexp equality by content not pointer

### DIFF
--- a/vm/test/test_regexp.hpp
+++ b/vm/test/test_regexp.hpp
@@ -32,7 +32,7 @@ public:
     Regexp* re = Regexp::create(state);
     re->initialize(state, pat, Fixnum::from(0));
 
-    TS_ASSERT_EQUALS(re->source(), pat);
+    TS_ASSERT_EQUALS(re->source()->c_str(state), pat->c_str(state));
     TS_ASSERT_EQUALS(re->names(),  cNil);
   }
 
@@ -48,7 +48,7 @@ public:
     Regexp* re = Regexp::create(state);
     re->initialize(state, pat, Fixnum::from(0));
 
-    TS_ASSERT_EQUALS(re->source(), pat);
+    TS_ASSERT_EQUALS(re->source()->c_str(state), pat->c_str(state));
     TS_ASSERT(re->names()->kind_of_p(state, G(lookuptable)));
   }
 


### PR DESCRIPTION
Currently, `Regexp::initialize` copies a pattern `String` object to support encoding in 1.9 mode. Yet, some tests in `vm:test` wrongly assert that the patten obtained from `Regexp::source` is equal to the passed pattern pointer-wise.

For 1.8 mode, this assertion is fine, because a pattern is passed by reference (pointer). For 1.9 mode, this isn't, because it is passed by value (by means of `String::string_dup`).

In this commit, I changed to always assert by content not by pointer to correctly test regardless of 1.8 or 1.9.
