### PR TITLE
versionize vm:test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -139,19 +139,19 @@ end
 # These tasks run the specs in the specified mode regardless of
 # the default mode with which Rubinius was configured.
 desc "Run CI in 1.8 mode"
-task :ci18 => %w[build vm:test] do
+task :ci18 => %w[build vm:test18] do
   ENV['CI_MODE_FLAG'] = "-T -X18"
   run_ci
 end
 
 desc "Run CI in 1.9 mode"
-task :ci19 => %w[build vm:test] do
+task :ci19 => %w[build vm:test19] do
   ENV['CI_MODE_FLAG'] = "-T -X19"
   run_ci
 end
 
 desc "Run CI in 2.0 mode"
-task :ci20 => %w[build vm:test] do
+task :ci20 => %w[build vm:test20] do
   ENV['CI_MODE_FLAG'] = "-T -X20"
   run_ci
 end
@@ -202,17 +202,17 @@ task :docs do
 end
 
 desc "Run the CI specs in 1.8 mode but do not rebuild on failure"
-task :spec18 => %w[build vm:test] do
+task :spec18 => %w[build vm:test18] do
   run_specs "-T -X18"
 end
 
 desc "Run the CI specs in 1.9 mode but do not rebuild on failure"
-task :spec19 => %w[build vm:test] do
+task :spec19 => %w[build vm:test19] do
   run_specs "-T -X19"
 end
 
 desc "Run the CI specs in 2.0 mode but do not rebuild on failure"
-task :spec20 => %w[build vm:test] do
+task :spec20 => %w[build vm:test20] do
   run_specs "-T -X20"
 end
 

--- a/rakelib/vm.rake
+++ b/rakelib/vm.rake
@@ -301,11 +301,28 @@ file "web/_includes/instructions.markdown" => insn_deps do |t|
 end
 
 namespace :vm do
-  desc 'Run all VM tests.  Uses its argument as a filter of tests to run.'
-  task :test, :filter do |task, args|
+  def run_test(args)
     ENV['SUITE'] = args[:filter] if args[:filter]
+    ENV['TEST_MODE'] = args[:test_mode] if args[:test_mode]
     ENV['VERBOSE'] = '1' if $verbose
     sh 'vm/test/runner', :verbose => $verbose
+  end
+
+  desc 'Run all VM tests.  Uses its argument as a filter of tests to run.'
+  task :test, :filter do |task, args|
+    run_test(args)
+  end
+
+  task :test18, :filter do |task, args|
+    run_test({:test_mode => "18"}.merge(args))
+  end
+
+  task :test19, :filter do |task, args|
+    run_test({:test_mode => "19"}.merge(args))
+  end
+
+  task :test20, :filter do |task, args|
+    run_test({:test_mode => "20"}.merge(args))
   end
 
   task :test => %w[ vm/test/runner ]

--- a/vm/test/test.hpp
+++ b/vm/test/test.hpp
@@ -21,6 +21,10 @@ public:
 
   void create() {
     config_parser = new ConfigParser;
+    const char *test_mode = getenv("TEST_MODE");
+    if (test_mode) {
+      config.version.set(test_mode);
+    }
     shared = new SharedState(0, config, *config_parser);
     VM* vm = shared->new_vm();
     vm->initialize_as_root();


### PR DESCRIPTION
In the course of fixing some tests only surfacing under 1.9, I thought it'd be useful to be able to run `vm:test` in different versions side-by-side.

Previously, even if `--default-version=19` is used, `vm:test` is run in 1.8 mode, not in 1.9, when building rubinius with just the `rake` command. This situation is also fixed.

As `ci` is run under 1.8 and 1.9 mode when buidling, `vm:test` is now run under 1.8 and 1.9 mode too.

So here is the patch!

Thanks for reviewing :) Any comments are greatly appreciated.
