### PR TITLE
Use #__send__ rather than #send when calling methods on an AST visitor

### DIFF
--- a/lib/compiler/ast/node.rb
+++ b/lib/compiler/ast/node.rb
@@ -163,7 +163,7 @@ module Rubinius
       # The #visit implements a read-only traversal of the tree. To modify the
       # tree, see the #transform methed.
       def visit(visitor, parent=nil)
-        visitor.send self.node_name, self, parent
+        visitor.__send__ self.node_name, self, parent
         children { |c| c.visit visitor, self }
       end
 


### PR DESCRIPTION
This is because the visitor already has to implement/override `#send` to visit
Send nodes -- by using `#__send__`, the visitor is free to override `#send`
without causing trouble.
