### PR TITLE
regards named parameters in procs as optional

### DIFF
--- a/kernel/common/proc.rb
+++ b/kernel/common/proc.rb
@@ -100,7 +100,7 @@ class Proc
       elsif i < o
         [:opt, name]
       elsif code.splat == i
-        [:rest, name]
+        name == :@unnamed_splat ? [:rest] : [:rest, name]
       elsif i < p
         [required_status, name]
       else

--- a/spec/tags/19/ruby/core/proc/parameters_tags.txt
+++ b/spec/tags/19/ruby/core/proc/parameters_tags.txt
@@ -1,1 +1,0 @@
-fails:Proc#parameters adds nameless rest arg for "star" argument


### PR DESCRIPTION
Fix Proc#parameters to mark arguments without default values as optional.

rubinius before commit:
`Proc.new{|a| }.parameters #=> [[:req, :a]]`
`Proc.new{|a, b = 1, c| }.parameters #=>  [[:req, :a], [:opt, :b], [:req, :c]]`

1.9.2, 1.9.3, rubinius after commit:
`Proc.new{|a| }.parameters #=> [[:opt, :a]]`
`Proc.new{|a, b = 1, c| }.parameters #=>  [[:opt, :a], [:opt, :b], [:opt, :c]]`
