### PR TITLE
Assert stack_ after status_

### DIFF
--- a/vm/fiber_data.cpp
+++ b/vm/fiber_data.cpp
@@ -115,11 +115,11 @@ namespace rubinius {
   }
 
   void FiberData::take_stack(STATE) {
-    assert(stack_);
-
     assert(status_ != eDead);
 
     if(status_ == eOnStack || status_ == eRunning) return;
+
+    assert(stack_);
 
     if(stack_->shared_p()) stack_->flush(state);
     stack_->set_user(this);


### PR DESCRIPTION
`FiberData::take_stack()` incorrectly asserts that stack_ isn't `NULL` before checking `status_`.

If `status_` is `eOnStack` or `eRunning`, `stack_` legitimately can be `NULL`.
