### PR TITLE
Remove -DNDEBUG in cflags from llvm-config

### DIFF
--- a/rakelib/blueprint.rb
+++ b/rakelib/blueprint.rb
@@ -101,6 +101,7 @@ Daedalus.blueprint do |i|
       flags = `#{perl} #{conf} --cflags`.strip.split(/\s+/)
       flags.delete_if { |x| x.index("-O") == 0 || x.index("-I") == 0 }
       flags.delete_if { |x| x =~ /-D__STDC/ }
+      flags.delete_if { |x| x == "-DNDEBUG" }
       flags << "-Ivendor/llvm/include" << "-DENABLE_LLVM"
       l.cflags = flags
 
@@ -127,6 +128,7 @@ Daedalus.blueprint do |i|
     flags = `#{perl} #{conf} --cflags`.strip.split(/\s+/)
     flags.delete_if { |x| x.index("-O") == 0 }
     flags.delete_if { |x| x =~ /-D__STDC/ }
+    flags.delete_if { |x| x == "-DNDEBUG" }
     flags << "-DENABLE_LLVM"
     gcc.cflags.concat flags
     gcc.ldflags.concat `#{perl} #{conf} --ldflags --libfiles`.strip.split(/\s+/)


### PR DESCRIPTION
Assertion is disabled with the default build configuration at least on Ubuntu 11.10. This commit enables assertions.

By the default build configuration, llvm is enabled. Then, `-DNDEBUG` is contained in the output of `llvm-config --cflags` from `llvm-2.9` and `llvm-2.8` packages in Ubuntu 11.10. 

I'm not sure whether this is a platform problem or rubinius one...
