### PR TITLE
Guard LLVM-dependant gc code with ENABLE_LLVM

### DIFF
--- a/vm/gc/baker.cpp
+++ b/vm/gc/baker.cpp
@@ -16,7 +16,9 @@
 #include "capi/handle.hpp"
 #include "capi/tag.hpp"
 
+#ifdef ENABLE_LLVM
 #include "llvm/state.hpp"
+#endif
 
 namespace rubinius {
 
@@ -252,7 +254,9 @@ namespace rubinius {
       }
     }
 
+#ifdef ENABLE_LLVM
     if(LLVMState* ls = data.llvm_state()) ls->gc_scan(this);
+#endif
 
     // Handle all promotions to non-young space that occurred.
     handle_promotions();

--- a/vm/gc/gc.cpp
+++ b/vm/gc/gc.cpp
@@ -18,7 +18,9 @@
 #include "builtin/block_environment.hpp"
 #include "capi/handle.hpp"
 
+#ifdef ENABLE_LLVM
 #include "llvm/state.hpp"
+#endif
 
 #include "instruments/tooling.hpp"
 
@@ -36,7 +38,9 @@ namespace rubinius {
     , threads_(state->shared.threads())
     , global_handle_locations_(state->shared.global_handle_locations())
     , gc_token_(0)
+#ifdef ENABLE_LLVM
     , llvm_state_(LLVMState::get_if_set(state))
+#endif
   {}
 
   GCData::GCData(VM* state, GCToken gct)
@@ -47,7 +51,9 @@ namespace rubinius {
     , threads_(state->shared.threads())
     , global_handle_locations_(state->shared.global_handle_locations())
     , gc_token_(&gct)
+#ifdef ENABLE_LLVM
     , llvm_state_(LLVMState::get_if_set(state))
+#endif
   {}
 
   GarbageCollector::GarbageCollector(ObjectMemory *om)

--- a/vm/gc/gc.hpp
+++ b/vm/gc/gc.hpp
@@ -44,7 +44,9 @@ namespace rubinius {
     std::list<ManagedThread*>* threads_;
     std::list<capi::Handle**>* global_handle_locations_;
     GCTokenImpl* gc_token_;
+#ifdef ENABLE_LLVM
     LLVMState* llvm_state_;
+#endif
 
   public:
     GCData(VM*, GCToken gct);
@@ -60,7 +62,9 @@ namespace rubinius {
       , global_cache_(cache)
       , threads_(ths)
       , global_handle_locations_(global_handle_locations)
+#ifdef ENABLE_LLVM
       , llvm_state_(0)
+#endif
     {}
 
     Roots& roots() {
@@ -91,9 +95,11 @@ namespace rubinius {
       return gc_token_;
     }
 
+#ifdef ENABLE_LLVM
     LLVMState* llvm_state() {
       return llvm_state_;
     }
+#endif
   };
 
   class AddressDisplacement {

--- a/vm/gc/immix.cpp
+++ b/vm/gc/immix.cpp
@@ -9,7 +9,9 @@
 
 #include "configuration.hpp"
 
+#ifdef ENABLE_LLVM
 #include "llvm/state.hpp"
+#endif
 
 namespace rubinius {
   void ImmixGC::ObjectDescriber::added_chunk(int count) {
@@ -204,7 +206,9 @@ namespace rubinius {
       }
     }
 
+#ifdef ENABLE_LLVM
     if(LLVMState* ls = data.llvm_state()) ls->gc_scan(this);
+#endif
 
     gc_.process_mark_stack(allocator_);
 


### PR DESCRIPTION
Currently, rubinius can't be built with `--disable-llvm`.

By correctly guarding LLVM-dependant code with `ENABLE_LLVM`, this commit make it possible to do it again.
