### PR TITLE
Use GC zone predicates wherever possible

### DIFF
--- a/vm/builtin/object.cpp
+++ b/vm/builtin/object.cpp
@@ -121,7 +121,7 @@ namespace rubinius {
     // then remember other. The up side to just remembering it like
     // this is that other is rarely mature, and the remember_set is
     // flushed on each collection anyway.
-    if(zone() == MatureObjectZone) {
+    if(mature_object_p()) {
       state->memory()->remember_object(this);
     }
 

--- a/vm/builtin/object.hpp
+++ b/vm/builtin/object.hpp
@@ -23,7 +23,7 @@ namespace rubinius {
   template <class T> \
   void name(T state, type* obj) { \
     name ## _ = obj; \
-    if(zone() == MatureObjectZone) this->write_barrier(state, obj); \
+    if(mature_object_p()) this->write_barrier(state, obj); \
   }
 
 /**

--- a/vm/builtin/string.hpp
+++ b/vm/builtin/string.hpp
@@ -66,7 +66,7 @@ namespace rubinius {
     template <class T>
       void data(T state, ByteArray* obj) {
         data_ = obj;
-        if(zone() == MatureObjectZone) this->write_barrier(state, obj);
+        if(mature_object_p()) this->write_barrier(state, obj);
 
         update_handle();
       }

--- a/vm/gc/baker.cpp
+++ b/vm/gc/baker.cpp
@@ -68,7 +68,7 @@ namespace rubinius {
 
     if(!obj->reference_p()) return obj;
 
-    if(obj->zone() != YoungObjectZone) return obj;
+    if(!obj->young_object_p()) return obj;
 
     if(obj->forwarded_p()) return obj->forward();
 
@@ -107,7 +107,7 @@ namespace rubinius {
     Object* iobj = next->next_unscanned(object_memory_->state());
 
     while(iobj) {
-      assert(iobj->zone() == YoungObjectZone);
+      assert(iobj->young_object_p());
       if(!iobj->forwarded_p()) scan_object(iobj);
       iobj = next->next_unscanned(object_memory_->state());
     }
@@ -153,7 +153,7 @@ namespace rubinius {
       // unremember_object throws a NULL in to remove an object
       // so we don't have to compact the set in unremember
       if(tmp) {
-        // assert(tmp->zone == MatureObjectZone);
+        // assert(tmp->mature_object_p());
         // assert(!tmp->forwarded_p());
 
         // Remove the Remember bit, since we're clearing the set.

--- a/vm/gc/object_mark.cpp
+++ b/vm/gc/object_mark.cpp
@@ -58,7 +58,7 @@ namespace rubinius {
   }
 
   void ObjectMark::remember_object(Object* target) {
-    if(target->zone() != YoungObjectZone && !target->remembered_p()) {
+    if(!target->young_object_p() && !target->remembered_p()) {
       state()->om->remember_object(target);
     }
   }

--- a/vm/gc/write_barrier.cpp
+++ b/vm/gc/write_barrier.cpp
@@ -28,7 +28,7 @@ namespace gc {
   void WriteBarrier::remember_object(Object* target) {
     thread::SpinLock::LockGuard lg(lock_);
 
-    assert(target->zone() == MatureObjectZone);
+    assert(target->mature_object_p());
 
     // If it's already remembered, ignore this request
     if(target->remembered_p()) return;
@@ -83,7 +83,7 @@ namespace gc {
       // unremember_object throws a NULL in to remove an object
       // so we don't have to compact the set in unremember
       if(tmp) {
-        assert(tmp->zone() == MatureObjectZone);
+        assert(tmp->mature_object_p());
         assert(!tmp->forwarded_p());
 
         if(!tmp->marked_p(mark)) {

--- a/vm/gc/write_barrier.hpp
+++ b/vm/gc/write_barrier.hpp
@@ -71,8 +71,8 @@ namespace gc {
     void write_barrier(Object* target, Object* val) {
       if(target->remembered_p()) return;
       if(!val->reference_p()) return;
-      if(target->zone() == YoungObjectZone) return;
-      if(val->zone() != YoungObjectZone) return;
+      if(target->young_object_p()) return;
+      if(!val->young_object_p()) return;
 
       remember_object(target);
     }

--- a/vm/test/test_vm.hpp
+++ b/vm/test/test_vm.hpp
@@ -46,7 +46,7 @@ class TestVM : public CxxTest::TestSuite, public VMTest {
     Root* root = static_cast<Root*>(state->globals().roots.head());
     while(root) {
       Object* tmp = root->get();
-      if(tmp->reference_p() && tmp->zone() == YoungObjectZone) {
+      if(tmp->reference_p() && tmp->young_object_p()) {
         objs[index] = tmp;
       }
       index++;


### PR DESCRIPTION
This is a minor clean-up.

In some places, GC zone predicates are used. In others, they aren't for no apparent reason. I think this isn't very good in the consistency and clean-code-base standpoint.

It's clearer to use predicates rather than in-place equality expressions. So, I changed to use GC zone predicates wherever possible.
