### PR TITLE
Remove redundant collect_mature_now initialization

### DIFF
--- a/vm/objectmemory.cpp
+++ b/vm/objectmemory.cpp
@@ -68,7 +68,6 @@ namespace rubinius {
       std::cout << "Watching for " << object_watch << "\n";
     }
 
-    collect_mature_now = false;
     last_object_id = 0;
 
     large_object_threshold = config.gc_large_object;


### PR DESCRIPTION
It's initialized in the initializer list. No need to initialize it in the constructor body.

Well, this is a nano-scale clean up. Sorry if this bothers you... I'm just becoming too picky..
