### PR TITLE
Remove unused ObjectMark::remember_object

### DIFF
--- a/vm/gc/object_mark.cpp
+++ b/vm/gc/object_mark.cpp
@@ -56,11 +56,5 @@ namespace rubinius {
       gc->object_memory_->write_barrier(target, val);
     }
   }
-
-  void ObjectMark::remember_object(Object* target) {
-    if(!target->young_object_p() && !target->remembered_p()) {
-      state()->om->remember_object(target);
-    }
-  }
 }
 

--- a/vm/gc/object_mark.hpp
+++ b/vm/gc/object_mark.hpp
@@ -28,7 +28,6 @@ namespace rubinius {
     Object* call(Object*);
     void set(Object* target, Object** pos, Object* val);
     void just_set(Object* target, Object* val);
-    void remember_object(Object* target);
   };
 
 }


### PR DESCRIPTION
Its sole user was Fiber. But it no longer uses that method.
