### PR TITLE
Don't raise after error in getnameinfo()

### DIFF
--- a/lib/18/socket.rb
+++ b/lib/18/socket.rb
@@ -337,11 +337,7 @@ class Socket < BasicSocket
               err = _getnameinfo(sockaddr_p, sockaddr.length,
                                  node, Socket::Constants::NI_MAXHOST, nil, 0, 0)
 
-              unless err == 0 then
-                raise SocketError, gai_strerror(err)
-              end
-
-              name_info[2] = node.read_string
+              name_info[2] = node.read_string if err == 0
             end
 
             err = _getnameinfo(sockaddr_p, sockaddr.length,

--- a/lib/19/socket.rb
+++ b/lib/19/socket.rb
@@ -346,11 +346,7 @@ class Socket < BasicSocket
               err = _getnameinfo(sockaddr_p, sockaddr.length,
                                  node, Socket::Constants::NI_MAXHOST, nil, 0, 0)
 
-              unless err == 0 then
-                raise SocketError, gai_strerror(err)
-              end
-
-              name_info[2] = node.read_string
+              name_info[2] = node.read_string if err == 0
             end
 
             err = _getnameinfo(sockaddr_p, sockaddr.length,


### PR DESCRIPTION
When the computer isn't connected to any network, some specs fail only on
Rubinius. They don't on MRI.

The cause was that Rubinius's getnameinfo() is slightly different from MRI's one
in the corner case of error handling.

So, Rubinius's getnameinfo() is changed to be aligned with MRI's.

One of the failing specs is this:

  Socket#getaddrinfo accepts empty addresses for IPv4 passive sockets ERROR
  SocketError: Temporary failure in name resolution

By the way, I'm not sure how to spec this behavior because I can only reproduce this by manually disabling my network. I'm not very familiar with these resolve-related functions... Hence, I'm requesting a pull request instead of a direct push.

FYI, the corresponding MRI's getnameinfo() is here:
  https://github.com/ruby/ruby/blob/5525d82134/ext/socket/raddrinfo.c#L404
