### PR TITLE
Fix infinite loop when parsing RBXOPT

### DIFF
--- a/vm/environment.cpp
+++ b/vm/environment.cpp
@@ -327,7 +327,7 @@ namespace rubinius {
       char *s = b + strlen(rbxopt);
 
       while(b < s) {
-        while(*b && isspace(*b)) s++;
+        while(*b && isspace(*b)) b++;
 
         e = b;
         while(*e && !isspace(*e)) e++;


### PR DESCRIPTION
The VM goes into infinite loop when parsing RBXOPT that contains spaces.

Here's how to reproduce:

```
RBXOPT=" -X19" irb
# ..irb prompt never appears
```

Sorry there's no spec for this but I wasn't sure how to write one when the VM just hangs :)
