### PR TITLE
Apply the VM-to-State transition to the JIT code

### DIFF
--- a/vm/llvm/inline.cpp
+++ b/vm/llvm/inline.cpp
@@ -141,7 +141,7 @@ namespace rubinius {
           ops_.setup_out_args(count_);
 
           std::vector<Type*> ftypes;
-          ftypes.push_back(ops_.state()->ptr_type("VM"));
+          ftypes.push_back(ops_.state()->ptr_type("State"));
           ftypes.push_back(ops_.state()->ptr_type("CallFrame"));
           ftypes.push_back(ops_.state()->ptr_type("Executable"));
           ftypes.push_back(ops_.state()->ptr_type("Module"));
@@ -431,7 +431,7 @@ remember:
       ops_.set_object_slot(self, offset, val);
     } else {
       Signature sig2(ops_.state(), "Object");
-      sig2 << "VM";
+      sig2 << "State";
       sig2 << "CallFrame";
       sig2 << "Object";
       sig2 << "Object";
@@ -515,7 +515,7 @@ remember:
 
       if(!ivar) {
         Signature sig2(ops_.state(), "Object");
-        sig2 << "VM";
+        sig2 << "State";
         sig2 << "Object";
         sig2 << "Object";
 
@@ -739,7 +739,7 @@ remember:
       case RBX_FFI_TYPE_LONG:
       case RBX_FFI_TYPE_ULONG: {
         Signature sig(ops_.state(), ops_.NativeIntTy);
-        sig << "VM";
+        sig << "State";
         sig << "Object";
         sig << llvm::PointerType::getUnqual(ops_.state()->Int1Ty);
 
@@ -766,7 +766,7 @@ remember:
 
       case RBX_FFI_TYPE_FLOAT: {
         Signature sig(ops_.state(), ops_.state()->FloatTy);
-        sig << "VM";
+        sig << "State";
         sig << "Object";
         sig << llvm::PointerType::getUnqual(ops_.state()->Int1Ty);
 
@@ -787,7 +787,7 @@ remember:
 
       case RBX_FFI_TYPE_DOUBLE: {
         Signature sig(ops_.state(), ops_.state()->DoubleTy);
-        sig << "VM";
+        sig << "State";
         sig << "Object";
         sig << llvm::PointerType::getUnqual(ops_.state()->Int1Ty);
 
@@ -809,7 +809,7 @@ remember:
       case RBX_FFI_TYPE_LONG_LONG:
       case RBX_FFI_TYPE_ULONG_LONG: {
         Signature sig(ops_.state(), ops_.state()->Int64Ty);
-        sig << "VM";
+        sig << "State";
         sig << "Object";
         sig << llvm::PointerType::getUnqual(ops_.state()->Int1Ty);
 
@@ -842,7 +842,7 @@ remember:
         Type* type = llvm::PointerType::getUnqual(ops_.state()->Int8Ty);
 
         Signature sig(ops_.state(), type);
-        sig << "VM";
+        sig << "State";
         sig << "Object";
         sig << llvm::PointerType::getUnqual(ops_.state()->Int1Ty);
 
@@ -865,7 +865,7 @@ remember:
         Type* type = llvm::PointerType::getUnqual(ops_.state()->Int8Ty);
 
         Signature sig(ops_.state(), type);
-        sig << "VM";
+        sig << "State";
         sig << "Object";
         sig << llvm::PointerType::getUnqual(ops_.state()->Int1Ty);
 
@@ -890,7 +890,7 @@ remember:
     }
 
     Signature check(ops_.state(), ops_.NativeIntTy);
-    check << "VM";
+    check << "State";
     check << "CallFrame";
 
     Value* check_args[] = { ops_.vm(), ops_.call_frame() };
@@ -923,7 +923,7 @@ remember:
 #endif
     {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << ops_.state()->Int32Ty;
 
       res_args[1] = ops_.b().CreateSExtOrBitCast(res_args[1],
@@ -942,7 +942,7 @@ remember:
 #endif
     {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << ops_.state()->Int64Ty;
 
       result = sig.call("rbx_ffi_from_int64", res_args, 2, "to_obj",
@@ -952,7 +952,7 @@ remember:
 
     case RBX_FFI_TYPE_FLOAT: {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << ops_.state()->FloatTy;
 
       result = sig.call("rbx_ffi_from_float", res_args, 2, "to_obj",
@@ -962,7 +962,7 @@ remember:
 
     case RBX_FFI_TYPE_DOUBLE: {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << ops_.state()->DoubleTy;
 
       result = sig.call("rbx_ffi_from_double", res_args, 2, "to_obj",
@@ -972,7 +972,7 @@ remember:
 
     case RBX_FFI_TYPE_PTR: {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << llvm::PointerType::getUnqual(ops_.state()->Int8Ty);
 
       result = sig.call("rbx_ffi_from_ptr", res_args, 2, "to_obj",
@@ -986,7 +986,7 @@ remember:
 
     case RBX_FFI_TYPE_STRING: {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << llvm::PointerType::getUnqual(ops_.state()->Int8Ty);
 
       result = sig.call("rbx_ffi_from_string", res_args, 2, "to_obj",
@@ -996,7 +996,7 @@ remember:
 
     case RBX_FFI_TYPE_STRPTR: {
       Signature sig(ops_.state(), ops_.ObjType);
-      sig << "VM";
+      sig << "State";
       sig << llvm::PointerType::getUnqual(ops_.state()->Int8Ty);
 
       result = sig.call("rbx_ffi_from_string_with_pointer", res_args, 2, "to_obj",

--- a/vm/llvm/inline_primitive.cpp
+++ b/vm/llvm/inline_primitive.cpp
@@ -489,7 +489,7 @@ namespace rubinius {
       }
 
       Signature sig(ops.state(), ops.state()->ptr_type("Float"));
-      sig << "VM";
+      sig << "State";
 
       Function* func = sig.function("rbx_float_allocate");
       func->setDoesNotAlias(0, true); // return value
@@ -607,7 +607,7 @@ namespace rubinius {
       Value* V = i.recv();
 
       Signature sig(ops.state(), "Object");
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << "Object";
 
@@ -636,7 +636,7 @@ namespace rubinius {
       i.context().enter_inline();
 
       Signature sig(ops.state(), ops.state()->ptr_type("Object"));
-      sig << "VM";
+      sig << "State";
       sig << "Object";
 
       Value* call_args[] = { ops.vm(), i.recv() };
@@ -655,7 +655,7 @@ namespace rubinius {
        ops.check_class(self, klass, i.failure());
 
        Signature sig(ops.state(), "Class");
-       sig << "VM";
+       sig << "State";
        sig << "Object";
 
        Value* call_args[] = { ops.vm(), self };
@@ -774,7 +774,7 @@ namespace rubinius {
           std::vector<Value*> call_args;
 
           Signature sig(ops_.state(), "Object");
-          sig << "VM";
+          sig << "State";
           call_args.push_back(ops_.vm());
 
           if(stub_res.pass_callframe()) {

--- a/vm/llvm/jit_block.cpp
+++ b/vm/llvm/jit_block.cpp
@@ -18,7 +18,7 @@ namespace jit {
 
   void BlockBuilder::setup() {
     std::vector<Type*> ftypes;
-    ftypes.push_back(ls_->ptr_type("VM"));
+    ftypes.push_back(ls_->ptr_type("State"));
     ftypes.push_back(ls_->ptr_type("CallFrame"));
     ftypes.push_back(ls_->ptr_type("BlockEnvironment"));
     ftypes.push_back(ls_->ptr_type("Arguments"));
@@ -76,7 +76,7 @@ namespace jit {
       b().SetInsertPoint(setup_profiling);
 
       Signature sig(ls_, ls_->VoidTy);
-      sig << "VM";
+      sig << "State";
       sig << llvm::PointerType::getUnqual(ls_->Int8Ty);
       sig << "BlockEnvironment";
       sig << "Module";
@@ -224,7 +224,7 @@ namespace jit {
       b().SetInsertPoint(destruct);
 
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << "Arguments";
 
@@ -447,7 +447,7 @@ namespace jit {
     // Phase 4 - splat
     if(vmm_->splat_position >= 0) {
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "Arguments";
       sig << ls_->Int32Ty;
       sig << ls_->Int32Ty;

--- a/vm/llvm/jit_builder.cpp
+++ b/vm/llvm/jit_builder.cpp
@@ -180,7 +180,7 @@ namespace jit {
     Value* call_args[] = { info_.vm(), info_.previous(), exec, module, info_.args() };
 
     Signature sig(ls_, "Object");
-    sig << "VM";
+    sig << "State";
     sig << "CallFrame";
     sig << "Executable";
     sig << "Module";
@@ -548,7 +548,7 @@ namespace jit {
 
       b().SetInsertPoint(import_args_);
       Signature sig(ls_, obj_type);
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
 
       Function* func_ci = sig.function("rbx_check_interrupts");

--- a/vm/llvm/jit_inline_block.cpp
+++ b/vm/llvm/jit_inline_block.cpp
@@ -96,7 +96,7 @@ namespace jit {
 
       if(stack_args.size() == 1 && vmm_->total_args > 1) {
         Signature sig(ls_, "Object");
-        sig << "VM";
+        sig << "State";
         sig << "CallFrame";
         sig << "Object";
         sig << vars->getType();

--- a/vm/llvm/jit_method.cpp
+++ b/vm/llvm/jit_method.cpp
@@ -20,7 +20,7 @@ namespace jit {
 
   void MethodBuilder::setup() {
     std::vector<Type*> ftypes;
-    ftypes.push_back(ls_->ptr_type("VM"));
+    ftypes.push_back(ls_->ptr_type("State"));
     ftypes.push_back(ls_->ptr_type("CallFrame"));
     ftypes.push_back(ls_->ptr_type("Executable"));
     ftypes.push_back(ls_->ptr_type("Module"));
@@ -235,7 +235,7 @@ namespace jit {
     // Phase 4 - splat
     if(vmm_->splat_position >= 0) {
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "Arguments";
       sig << ls_->Int32Ty;
       sig << ls_->Int32Ty;
@@ -367,7 +367,7 @@ namespace jit {
     // Setup the splat.
     if(vmm_->splat_position >= 0) {
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "Arguments";
       sig << ls_->Int32Ty;
       sig << ls_->Int32Ty;
@@ -447,7 +447,7 @@ namespace jit {
     // Call our arg_error helper
     Signature sig(ls_, "Object");
 
-    sig << "VM";
+    sig << "State";
     sig << "CallFrame";
     sig << "Arguments";
     sig << ls_->Int32Ty;
@@ -576,7 +576,7 @@ namespace jit {
       b().SetInsertPoint(setup_profiling);
 
       Signature sig(ls_, ls_->VoidTy);
-      sig << "VM";
+      sig << "State";
       sig << llvm::PointerType::getUnqual(ls_->Int8Ty);
       sig << "Executable";
       sig << "Module";

--- a/vm/llvm/jit_operations.hpp
+++ b/vm/llvm/jit_operations.hpp
@@ -92,7 +92,7 @@ namespace rubinius {
     llvm::Type* ObjArrayTy;
 
     // Frequently used types
-    llvm::Type* VMTy;
+    llvm::Type* StateTy;
     llvm::Type* CallFrameTy;
 
     // Commonly used constants
@@ -130,7 +130,7 @@ namespace rubinius {
       ObjType = ptr_type("Object");
       ObjArrayTy = llvm::PointerType::getUnqual(ObjType);
 
-      VMTy = ptr_type("VM");
+      StateTy = ptr_type("State");
       CallFrameTy = ptr_type("CallFrame");
 
       Function::arg_iterator input = function_->arg_begin();
@@ -715,7 +715,7 @@ namespace rubinius {
       set_block(do_flush);
 
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "StackVariables";
 
       Value* call_args[] = { vm_, vars };
@@ -946,7 +946,7 @@ namespace rubinius {
 
     void write_barrier(Value* obj, Value* val) {
       Signature wb(ls_, ObjType);
-      wb << VMTy;
+      wb << StateTy;
       wb << ObjType;
       wb << ObjType;
 

--- a/vm/llvm/jit_visit.hpp
+++ b/vm/llvm/jit_visit.hpp
@@ -60,13 +60,13 @@ namespace rubinius {
       , clear_raise_value(ls)
     {
       return_to_here
-        << "VM"
+        << "State"
         << "CallFrame";
 
       return_to_here.resolve("rbx_return_to_here", ls->Int1Ty);
 
       clear_raise_value
-        << "VM";
+        << "State";
 
       clear_raise_value.resolve("rbx_clear_raise_value", ls->object());
     }
@@ -252,7 +252,7 @@ namespace rubinius {
       set_block(is_break);
 
       Signature brk(ls_, ls_->Int1Ty);
-      brk << VMTy;
+      brk << StateTy;
       brk << CallFrameTy;
 
       Value* call_args[] = {
@@ -278,7 +278,7 @@ namespace rubinius {
       set_block(push_break_val);
 
       Signature clear(ls_, ObjType);
-      clear << VMTy;
+      clear << StateTy;
       Value* crv = clear.call("rbx_clear_raise_value", &vm_, 1, "crv", b());
 
       b().CreateBr(cont);
@@ -343,7 +343,7 @@ namespace rubinius {
 
       Signature sig(ls_, "Object");
 
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << ls_->Int32Ty;
       sig << ls_->IntPtrTy;
@@ -427,7 +427,7 @@ namespace rubinius {
       // we're calling something that returns an Object
       Signature sig(ls_, ObjType);
       // given a system state and a 32bit int
-      sig << VMTy;
+      sig << StateTy;
       sig << ls_->Int32Ty;
 
       // the actual values of which are the calling arguments
@@ -578,7 +578,7 @@ namespace rubinius {
     void visit_check_frozen() {
       Signature sig(ls_, "Object");
 
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << "Object";
 
@@ -627,7 +627,7 @@ namespace rubinius {
     }
 
     void add_send_args(Signature& sig) {
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
       sig << ls_->IntPtrTy;
@@ -712,7 +712,7 @@ namespace rubinius {
       sends_done_++;
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
       sig << ls_->IntPtrTy;
@@ -739,7 +739,7 @@ namespace rubinius {
 
     Value* super_send(Symbol* name, int args, bool splat=false) {
       Signature sig(ls_, ObjType);
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
       sig << ls_->IntPtrTy;
@@ -773,7 +773,7 @@ namespace rubinius {
       Value* recv = stack_top();
 
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << "InlineCache";
       sig << "Object";
@@ -1097,7 +1097,7 @@ namespace rubinius {
     void visit_string_dup() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
 
@@ -1217,7 +1217,7 @@ namespace rubinius {
       JITStackArgs* inline_args = incoming_args();
       if(inline_args && current_hint() == cHintLazyBlockArgs) {
         std::vector<Type*> types;
-        types.push_back(ls_->ptr_type("VM"));
+        types.push_back(ls_->ptr_type("State"));
         types.push_back(ls_->Int32Ty);
 
         FunctionType* ft = FunctionType::get(ls_->ptr_type("Object"), types, true);
@@ -1329,7 +1329,7 @@ namespace rubinius {
 
       Signature sig(ls_, "Object");
 
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << ls_->Int32Ty;
       sig << ls_->IntPtrTy;
@@ -1412,7 +1412,7 @@ namespace rubinius {
       }
 
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << ObjArrayTy;
       sig << ls_->Int32Ty;
@@ -1573,7 +1573,7 @@ namespace rubinius {
           assert(creator);
 
           Signature sig(ls_, ObjType);
-          sig << VMTy;
+          sig << StateTy;
           sig << CallFrameTy;
           sig << ls_->Int32Ty;
 
@@ -1612,7 +1612,7 @@ namespace rubinius {
       emit_delayed_create_block();
 
       std::vector<Type*> types;
-      types.push_back(VMTy);
+      types.push_back(StateTy);
 
       // we use stack_set_top here because we always have a placeholder
       // on the stack that we're going to just replace.
@@ -1857,7 +1857,7 @@ use_send:
     void visit_cast_array() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
 
@@ -1879,7 +1879,7 @@ use_send:
     void visit_cast_multi_value() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
 
@@ -1929,7 +1929,7 @@ use_send:
       set_has_side_effects();
 
       Signature sig(ls_, ObjType);
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
 
       Value* args[] = {
@@ -1994,7 +1994,7 @@ use_send:
       InlineCache* cache = reinterpret_cast<InlineCache*>(which);
 
       Signature sig(ls_, ObjType);
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
       sig << ObjType;
@@ -2019,7 +2019,7 @@ use_send:
     void visit_add_scope() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
 
@@ -2086,7 +2086,7 @@ use_send:
 
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
       types.push_back(ls_->Int32Ty);
@@ -2133,7 +2133,7 @@ use_send:
     void visit_push_const(opcode name) {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
 
@@ -2159,7 +2159,7 @@ use_send:
 
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
       types.push_back(ObjType);
@@ -2183,7 +2183,7 @@ use_send:
 
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(ObjType);
       types.push_back(ObjType);
 
@@ -2209,7 +2209,7 @@ use_send:
 
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ls_->Int32Ty);
       types.push_back(ObjType);
@@ -2232,7 +2232,7 @@ use_send:
       set_has_side_effects();
 
       Signature sig(ls_, ObjType);
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
 
       Value* args[] = {
@@ -2283,7 +2283,7 @@ use_send:
           break;
         default: {
           std::vector<Type*> types;
-          types.push_back(ls_->ptr_type("VM"));
+          types.push_back(ls_->ptr_type("State"));
           types.push_back(ls_->Int32Ty);
 
           FunctionType* ft = FunctionType::get(ls_->ptr_type("Object"), types, true);
@@ -2306,7 +2306,7 @@ use_send:
       } else {
         std::vector<Type*> types;
 
-        types.push_back(VMTy);
+        types.push_back(StateTy);
         types.push_back(ptr_type("Arguments"));
 
         FunctionType* ft = FunctionType::get(ObjType, types, false);
@@ -2327,7 +2327,7 @@ use_send:
       if(inline_args) {
         if(inline_args->size() == 1) {
           std::vector<Type*> types;
-          types.push_back(ls_->ptr_type("VM"));
+          types.push_back(ls_->ptr_type("State"));
           types.push_back(CallFrameTy);
           types.push_back(ls_->Int32Ty);
 
@@ -2354,7 +2354,7 @@ use_send:
         }
       } else {
         Signature sig(ls_, ObjType);
-        sig << VMTy;
+        sig << StateTy;
         sig << CallFrameTy;
         sig << ptr_type("Arguments");
 
@@ -2378,7 +2378,7 @@ use_send:
         // back in the array before splatting them.
         if(inline_args->from_unboxed_array()) {
           std::vector<Type*> types;
-          types.push_back(ls_->ptr_type("VM"));
+          types.push_back(ls_->ptr_type("State"));
           types.push_back(ls_->Int32Ty);
 
           FunctionType* ft = FunctionType::get(ls_->ptr_type("Object"), types, true);
@@ -2406,7 +2406,7 @@ use_send:
           stack_push(wrapped);
         } else {
           std::vector<Type*> types;
-          types.push_back(ls_->ptr_type("VM"));
+          types.push_back(ls_->ptr_type("State"));
           types.push_back(CallFrameTy);
           types.push_back(ls_->Int32Ty);
 
@@ -2430,7 +2430,7 @@ use_send:
         }
       } else {
         Signature sig(ls_, ObjType);
-        sig << VMTy;
+        sig << StateTy;
         sig << CallFrameTy;
         sig << ptr_type("Arguments");
 
@@ -2481,7 +2481,7 @@ use_send:
           */
 
           Signature sig(ls_, ObjType);
-          sig << VMTy;
+          sig << StateTy;
           sig << "CallFrame";
           sig << ObjType;
           sig << ls_->Int32Ty;
@@ -2524,7 +2524,7 @@ use_send:
 
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
       types.push_back(ls_->Int32Ty);
@@ -2593,7 +2593,7 @@ use_send:
               */
 
           Signature sig(ls_, ObjType);
-          sig << VMTy;
+          sig << StateTy;
           sig << "CallFrame";
           sig << ls_->Int32Ty;
           sig << ls_->Int32Ty;
@@ -2637,7 +2637,7 @@ use_send:
       // Handle depth > 1
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ls_->Int32Ty);
       types.push_back(ls_->Int32Ty);
@@ -2757,7 +2757,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << "Object";
       sig << ls_->Int32Ty;
@@ -2788,7 +2788,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << "Object";
       sig << ls_->Int32Ty;
@@ -2817,7 +2817,7 @@ use_send:
     void visit_check_interrupts() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
 
       FunctionType* ft = FunctionType::get(ObjType, types, false);
@@ -2841,7 +2841,7 @@ use_send:
 
     void visit_check_serial(opcode index, opcode serial) {
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << "InlineCache";
       sig << ls_->Int32Ty;
@@ -2866,7 +2866,7 @@ use_send:
 
     void visit_check_serial_private(opcode index, opcode serial) {
       Signature sig(ls_, "Object");
-      sig << "VM";
+      sig << "State";
       sig << "CallFrame";
       sig << "InlineCache";
       sig << ls_->Int32Ty;
@@ -2935,7 +2935,7 @@ use_send:
         set_block(code);
 
         std::vector<Type*> types;
-        types.push_back(VMTy);
+        types.push_back(StateTy);
 
         FunctionType* ft = FunctionType::get(ls_->Int1Ty, types, false);
         Function* func = cast<Function>(
@@ -3003,7 +3003,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
 
@@ -3020,7 +3020,7 @@ use_send:
     void visit_ensure_return() {
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
 
@@ -3053,7 +3053,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjType;
 
@@ -3070,7 +3070,7 @@ use_send:
     void visit_push_current_exception() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
 
       FunctionType* ft = FunctionType::get(ObjType, types, false);
       Function* func = cast<Function>(
@@ -3086,7 +3086,7 @@ use_send:
 
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
 
       FunctionType* ft = FunctionType::get(ObjType, types, false);
       Function* func = cast<Function>(
@@ -3100,7 +3100,7 @@ use_send:
     void visit_push_exception_state() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
 
       FunctionType* ft = FunctionType::get(ObjType, types, false);
       Function* func = cast<Function>(
@@ -3114,7 +3114,7 @@ use_send:
     void visit_restore_exception_state() {
       std::vector<Type*> types;
 
-      types.push_back(VMTy);
+      types.push_back(StateTy);
       types.push_back(CallFrameTy);
       types.push_back(ObjType);
 
@@ -3130,7 +3130,7 @@ use_send:
     void visit_find_const(opcode which) {
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ls_->Int32Ty;
       sig << ObjType;
@@ -3152,7 +3152,7 @@ use_send:
     void visit_instance_of() {
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ObjType;
       sig << ObjType;
 
@@ -3171,7 +3171,7 @@ use_send:
     void visit_kind_of() {
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ObjType;
       sig << ObjType;
 
@@ -3241,7 +3241,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ls_->Int32Ty;
       sig << ObjArrayTy;
 
@@ -3263,7 +3263,7 @@ use_send:
 
         Signature sig(ls_, ObjType);
 
-        sig << VMTy;
+        sig << StateTy;
         sig << CallFrameTy;
         sig << ls_->Int32Ty;
         sig << ObjArrayTy;
@@ -3297,7 +3297,7 @@ use_send:
       } else {
         Signature sig(ls_, ObjType);
 
-        sig << VMTy;
+        sig << StateTy;
         sig << "Arguments";
         sig << ls_->Int32Ty;
 
@@ -3315,7 +3315,7 @@ use_send:
     void visit_passed_blockarg(opcode count) {
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << "Arguments";
       sig << ls_->Int32Ty;
 
@@ -3341,7 +3341,7 @@ use_send:
       // we're calling something that returns an Object
       Signature sig(ls_, ObjType);
       // given a system state and a 32bit int
-      sig << VMTy;
+      sig << StateTy;
       sig << ls_->Int32Ty;
 
       // the actual values of which are the calling arguments
@@ -3425,7 +3425,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ObjType;
       sig << ObjType;
 
@@ -3490,7 +3490,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << "CallFrame";
       sig << ObjType;
       sig << ObjType;
@@ -3513,7 +3513,7 @@ use_send:
     void visit_push_my_field(opcode which) {
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ObjType;
       sig << ls_->Int32Ty;
 
@@ -3535,7 +3535,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ObjType;
       sig << ls_->Int32Ty;
       sig << ObjType;
@@ -3566,7 +3566,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ObjArrayTy;
 
@@ -3585,7 +3585,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << ObjType;
       sig << ObjType;
 
@@ -3607,7 +3607,7 @@ use_send:
 
       Signature sig(ls_, ObjType);
 
-      sig << VMTy;
+      sig << StateTy;
       sig << CallFrameTy;
       sig << ls_->Int32Ty;
       sig << ObjArrayTy;

--- a/vm/llvm/types.cpp.gen
+++ b/vm/llvm/types.cpp.gen
@@ -214,16 +214,16 @@ StructTy_struct_rubinius__Executable_fields.push_back(StructTy_struct_rubinius__
 StructTy_struct_rubinius__Executable_fields.push_back(PointerTy_2);
 StructTy_struct_rubinius__Executable_fields.push_back(PointerTy_9);
 std::vector<Type*>FuncTy_20_args;
-StructType *StructTy_struct_rubinius__VM = mod->getTypeByName("struct.rubinius::VM");
-if (!StructTy_struct_rubinius__VM) {
-StructTy_struct_rubinius__VM = StructType::create(mod->getContext(), "struct.rubinius::VM");
+StructType *StructTy_struct_rubinius__State = mod->getTypeByName("struct.rubinius::State");
+if (!StructTy_struct_rubinius__State) {
+StructTy_struct_rubinius__State = StructType::create(mod->getContext(), "struct.rubinius::State");
 }
-std::vector<Type*>StructTy_struct_rubinius__VM_fields;
-if (StructTy_struct_rubinius__VM->isOpaque()) {
-StructTy_struct_rubinius__VM->setBody(StructTy_struct_rubinius__VM_fields, /*isPacked=*/false);
+std::vector<Type*>StructTy_struct_rubinius__State_fields;
+if (StructTy_struct_rubinius__State->isOpaque()) {
+StructTy_struct_rubinius__State->setBody(StructTy_struct_rubinius__State_fields, /*isPacked=*/false);
 }
 
-PointerType* PointerTy_21 = PointerType::get(StructTy_struct_rubinius__VM, 0);
+PointerType* PointerTy_21 = PointerType::get(StructTy_struct_rubinius__State, 0);
 
 FuncTy_20_args.push_back(PointerTy_21);
 StructType *StructTy_struct_rubinius__CallFrame = mod->getTypeByName("struct.rubinius::CallFrame");

--- a/vm/llvm/types.ll
+++ b/vm/llvm/types.ll
@@ -1,5 +1,5 @@
 
-%"struct.rubinius::VM" = type opaque
+%"struct.rubinius::State" = type opaque
 %"struct.rubinius::TypeInfo" = type opaque
 %"struct.rubinius::VMMethod" = type opaque
 %"struct.rubinius::Fixnum" = type opaque
@@ -46,8 +46,8 @@ declare void @output3(%"struct.rubinius::Dispatch"*)
             %"struct.rubinius::Symbol"*, ; name
   %"struct.rubinius::MethodCacheEntry"*, ; cache
           %"struct.rubinius::CallUnit"*, ; call_unit
-  %"struct.rubinius::Object"* (%"struct.rubinius::VM"*, %"struct.rubinius::InlineCache"*, %"struct.rubinius::CallFrame"*, %"struct.rubinius::Arguments"*)*, ; initial
-  %"struct.rubinius::Object"* (%"struct.rubinius::VM"*, %"struct.rubinius::InlineCache"*, %"struct.rubinius::CallFrame"*, %"struct.rubinius::Arguments"*)*, ; execute
+  %"struct.rubinius::Object"* (%"struct.rubinius::State"*, %"struct.rubinius::InlineCache"*, %"struct.rubinius::CallFrame"*, %"struct.rubinius::Arguments"*)*, ; initial
+  %"struct.rubinius::Object"* (%"struct.rubinius::State"*, %"struct.rubinius::InlineCache"*, %"struct.rubinius::CallFrame"*, %"struct.rubinius::Arguments"*)*, ; execute
                                       i32*, ; hits
                                        i32, ; seen_classes_overflow
   [3 x %"struct.rubinius::InlineCacheHit"], ; seen_classes
@@ -195,7 +195,7 @@ declare void @output17(%"struct.rubinius::CompiledMethod"*)
    %"struct.rubinius::Object", ; header
   %"struct.rubinius::Symbol"*, ; primitive
   %"struct.rubinius::Fixnum"*, ; serial
-  %"struct.rubinius::Object"* (%"struct.rubinius::VM"*, %"struct.rubinius::CallFrame"*, %"struct.rubinius::Executable"*, %"struct.rubinius::Module"*, %"struct.rubinius::Arguments"*)*, ; execute
+  %"struct.rubinius::Object"* (%"struct.rubinius::State"*, %"struct.rubinius::CallFrame"*, %"struct.rubinius::Executable"*, %"struct.rubinius::Module"*, %"struct.rubinius::Arguments"*)*, ; execute
                             i32, ; prim_index
   %"struct.rubinius::Inliners"*  ; inliners
 }


### PR DESCRIPTION
Since the following commit, many C++ functions are changed to take a pointer to
a State, not a pointer to a VM. But the LLVM code hasn't catch up the change.

  35a49f3 Introduce State class as STATE

This is very confusing. Just update it.

The reason Rubinius doesn't currently break in this situation is that the LLVM
IR type system is completely independent of the actual C++ type system.
