### PR TITLE
Running spec/ruby/core for 1.8 fails

### DIFF
--- a/spec/ruby/core/basicobject/fixtures/common.rb
+++ b/spec/ruby/core/basicobject/fixtures/common.rb
@@ -1,9 +1,13 @@
-module BasicObjectSpecs
-  class BOSubclass < BasicObject
-    def self.kernel_defined?
-      defined?(Kernel)
-    end
+ruby_version_is "1.9" do
 
-    include ::Kernel
+  module BasicObjectSpecs
+    class BOSubclass < BasicObject
+      def self.kernel_defined?
+        defined?(Kernel)
+      end
+
+      include ::Kernel
+    end
   end
+
 end

--- a/spec/ruby/core/basicobject/not_spec.rb
+++ b/spec/ruby/core/basicobject/not_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 ruby_version_is "1.9" do
   describe "BasicObject#!" do
     it "is a public instance method" do
-      BasicObject.should have_public_instance_method(:!)
+      BasicObject.should have_public_instance_method(:"!")
     end
 
     it "returns false" do


### PR DESCRIPTION
I'm new to Rubinius and not sure if I reproduced it ok, but when I tried to run `./bin/mspec ci -T -X18 spec/ruby/core/` (which I believe is a subset of specs which should work for rubinius 1.8.X) I got two errors:
1. Syntax on `:!` : MRI allows it and in RBX you have to `:"!"` -- this looks like a bug?
2. BasicObject fixtures which should not load in 1.8 (no BO there)
