### PR TITLE
explicitly cast utf8_limits to const int32_t

### DIFF
--- a/vm/builtin/unpack18.cpp
+++ b/vm/builtin/unpack18.cpp
@@ -275,13 +275,13 @@ namespace rubinius {
     }
 
     static const int32_t utf8_limits[] = {
-      0x0,        /* 1 */
-      0x80,       /* 2 */
-      0x800,      /* 3 */
-      0x10000,    /* 4 */
-      0x200000,   /* 5 */
-      0x4000000,  /* 6 */
-      0x80000000, /* 7 */
+      (const int32_t) 0x0,        /* 1 */
+      (const int32_t) 0x80,       /* 2 */
+      (const int32_t) 0x800,      /* 3 */
+      (const int32_t) 0x10000,    /* 4 */
+      (const int32_t) 0x200000,   /* 5 */
+      (const int32_t) 0x4000000,  /* 6 */
+      (const int32_t) 0x80000000, /* 7 */
     };
 
 #define MALFORMED_UTF8_ERROR_SIZE 60

--- a/vm/builtin/unpack19.cpp
+++ b/vm/builtin/unpack19.cpp
@@ -275,13 +275,13 @@ namespace rubinius {
     }
 
     static const int32_t utf8_limits[] = {
-      0x0,        /* 1 */
-      0x80,       /* 2 */
-      0x800,      /* 3 */
-      0x10000,    /* 4 */
-      0x200000,   /* 5 */
-      0x4000000,  /* 6 */
-      0x80000000, /* 7 */
+      (const int32_t) 0x0,        /* 1 */
+      (const int32_t) 0x80,       /* 2 */
+      (const int32_t) 0x800,      /* 3 */
+      (const int32_t) 0x10000,    /* 4 */
+      (const int32_t) 0x200000,   /* 5 */
+      (const int32_t) 0x4000000,  /* 6 */
+      (const int32_t) 0x80000000, /* 7 */
     };
 
 #define MALFORMED_UTF8_ERROR_SIZE 60


### PR DESCRIPTION
I tried to compile rubinius on my archlinux machine and got a warning/error regarding a implicit cast of (unsigned int) to (const int32_t) so I went ahead into the code and changed the necessary parts. If there is a less verbose option for this please let me know.
The changes should not change any behaviour of rubinius itself.

Here my setup and the exact error.

```
$> gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-unknown-linux-gnu/4.7.0/lto-wrapper
Target: x86_64-unknown-linux-gnu
Configured with: /build/src/gcc-4.7-20120324/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --enable-libstdcxx-time --enable-gnu-unique-object --enable-linker-build-id --with-ppl --enable-cloog-backend=isl --enable-lto --enable-gold --enable-ld=default --enable-plugin --with-plugin-ld=ld.gold --with-linker-hash-style=gnu --disable-multilib --disable-libssp --disable-build-with-cxx --disable-build-poststage1-with-cxx --enable-checking=release
Thread model: posix
gcc version 4.7.0 20120324 (prerelease) (GCC) 

$> git checkout master
$> ruby -v
ruby 1.9.3p125 (2012-02-16 revision 34643) [x86_64-linux]

$> rake clean
$> ./configure
$> ./configure --show
Checking gcc: found
Checking bison: found

Using the following configuration to build
------------------------------------------
module Rubinius
  BUILD_CONFIG = {
    :which_ruby     => :ruby,
    :build_ruby     => "/home/sch1zo/.rbenv/versions/1.9.3-p125/bin/ruby",
    :build_rake     => "rake",
    :build_perl     => "perl",
    :llvm           => :config,
    :llvm_configure => "/usr/bin/llvm-config",
    :cc             => "gcc",
    :cxx            => "g++",
    :user_cflags    => "",
    :user_cppflags  => "",
    :user_ldflags   => "",
    :include_dirs   => ["/usr/local/include"],
    :lib_dirs       => ["/usr/local/lib"],
    :defines        => ["HAS_EXECINFO", "HAVE_CLOCK_GETTIME", "HAVE_NL_LANGINFO", "HAVE_TM_GMTOFF", "HAVE_TM_ZONE", "HAVE_TIMEZONE", "HAVE_TZNAME", "HAVE_DAYLIGHT", "HAVE_ALLOCA_H", "HAVE_STRING_H", "HAVE_SYS_TIME_H", "HAVE_SYS_TIMES_H", "HAVE_SYS_TYPES_H", "HAVE_UNISTD_H", "HAVE_STDARG_H"],
    :curses         => "curses",
    :host           => "x86_64-unknown-linux-gnu",
    :cpu            => "x86_64",
    :vendor         => "unknown",
    :os             => "linux-gnu",
    :little_endian  => true,
    :sizeof_long    => 8,
    :x86_32         => false,
    :x86_64         => true,
    :fibers         => true,
    :bindir         => "/home/sch1zo/code/rubinius/bin",
    :libdir         => "/home/sch1zo/code/rubinius",
    :runtime        => "/home/sch1zo/code/rubinius/runtime",
    :kernel_path    => "/home/sch1zo/code/rubinius/kernel",
    :lib_path       => "/home/sch1zo/code/rubinius/lib",
    :include18dir   => "/home/sch1zo/code/rubinius/vm/capi/18/include",
    :include19dir   => "/home/sch1zo/code/rubinius/vm/capi/19/include",
    :include20dir   => "/home/sch1zo/code/rubinius/vm/capi/19/include",
    :mandir         => "/home/sch1zo/code/rubinius/man",
    :gemsdir        => "/home/sch1zo/code/rubinius/gems",
    :sitedir        => "/home/sch1zo/code/rubinius/lib/site",
    :vendordir      => "/home/sch1zo/code/rubinius/lib/vendor",
    :program_name   => "rbx",
    :version        => "2.0.0dev",
    :libversion     => "2.0",
    :release_date   => "yyyy-mm-dd",
    :config_version => 156,
    :windows        => false,
    :darwin         => false,
    :bsd            => false,
    :linux          => true,
    :version_list   => ["18", "19"],
    :default_version => "18",
    :vendor_zlib    => false,
    :readline       => :c_readline,
    :libyaml        => true
  }
end

Setting the following defines for the VM
----------------------------------------
#define RBX_HOST             "x86_64-unknown-linux-gnu"
#define RBX_CPU              "x86_64"
#define RBX_VENDOR           "unknown"
#define RBX_OS               "linux-gnu"
#define RBX_BIN_PATH         "/home/sch1zo/code/rubinius/bin"
#define RBX_GEMS_PATH        "/home/sch1zo/code/rubinius/gems"
#define RBX_RUNTIME          "/home/sch1zo/code/rubinius/runtime"
#define RBX_KERNEL_PATH      "/home/sch1zo/code/rubinius/kernel"
#define RBX_LIB_PATH         "/home/sch1zo/code/rubinius/lib"
#define RBX_HDR18_PATH       "/home/sch1zo/code/rubinius/vm/capi/18/include"
#define RBX_HDR19_PATH       "/home/sch1zo/code/rubinius/vm/capi/19/include"
#define RBX_HDR20_PATH       "/home/sch1zo/code/rubinius/vm/capi/19/include"
#define RBX_SITE_PATH        "/home/sch1zo/code/rubinius/lib/site"
#define RBX_VENDOR_PATH      "/home/sch1zo/code/rubinius/lib/vendor"
#define RBX_VERSION          "2.0.0dev"
#define RBX_LIB_VERSION      "2.0"
#define RBX_LDSHARED         "gcc -shared"
#define RBX_RELEASE_DATE     "yyyy-mm-dd"
#define RBX_SIZEOF_LONG      8
#define RBX_LLVM_API_VER     300
#define RBX_LIBC             "libc.so.6"
#define RBX_ZLIB_PATH        ""
#define RBX_DEFAULT_18       true
#define RBX_DEFAULT_19       false
#define RBX_DEFAULT_20       false
#define RBX_ENABLED_18       1
#define RBX_ENABLED_19       1
#define RBX_LITTLE_ENDIAN    1
#define RBX_HAVE_TR1_HASH    1
#define RBX_LINUX           1
#define RBX_FIBER_ENABLED    1

#define HAS_EXECINFO         1
#define HAVE_CLOCK_GETTIME   1
#define HAVE_NL_LANGINFO     1
#define HAVE_TM_GMTOFF       1
#define HAVE_TM_ZONE         1
#define HAVE_TIMEZONE        1
#define HAVE_TZNAME          1
#define HAVE_DAYLIGHT        1
#define HAVE_ALLOCA_H        1
#define HAVE_STRING_H        1
#define HAVE_SYS_TIME_H      1
#define HAVE_SYS_TIMES_H     1
#define HAVE_SYS_TYPES_H     1
#define HAVE_UNISTD_H        1
#define HAVE_STDARG_H        1


$> rake

...

vm/builtin/unpack18.cpp:285:5: error: narrowing conversion of ‘2147483648u’ from ‘unsigned int’ to ‘const int32_t {aka const int}’ inside { } is ill-formed in C++11 [-Werror=narro
wing]
vm/builtin/unpack19.cpp:285:5: error: narrowing conversion of ‘2147483648u’ from ‘unsigned int’ to ‘const int32_t {aka const int}’ inside { } is ill-formed in C++11 [-Werror=narro
wing]
cc1plus: all warnings being treated as errors
Error: gcc -fPIC -Ivm -Ivm/test/cxxtest -I.  -pipe -Wall -fno-omit-frame-pointer -Wno-unused-function -g -ggdb3 -Werror -DRBX_PROFILER -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D_LARGEF
ILE_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -DHAS_EXECINFO -DHAVE_CLOCK_GETTIME -DHAVE_NL_LANGINFO -DHAVE_TM_GMTOFF -DHAVE_TM_ZONE -DHAVE_TIMEZONE -DHAVE_TZNAME -DHAVE_DAYLIGHT -DHAVE_ALLOCA_H -DH
AVE_STRING_H -DHAVE_SYS_TIME_H -DHAVE_SYS_TIMES_H -DHAVE_SYS_TYPES_H -DHAVE_UNISTD_H -DHAVE_STDARG_H -I/usr/include -D_GNU_SOURCE -fomit-frame-pointer -fPIC -DENABLE_LLVM -Ivendor/oniguruma -
DHAVE_CONFIG_H -I. -I../../vm/capi/19/include -Ivendor/udis86 -Ivendor/libffi/include -Ivendor/libgdtoa -Ivendor/libtommath -I/usr/local/include  -c -o vm/builtin/artifacts/unpack18.cpp.o vm/
builtin/unpack18.cpp
cc1plus: all warnings being treated as errors
Error: gcc -fPIC -Ivm -Ivm/test/cxxtest -I.  -pipe -Wall -fno-omit-frame-pointer -Wno-unused-function -g -ggdb3 -Werror -DRBX_PROFILER -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D_LARGEF
ILE_SOURCE -D_FILE_OFFSET_BITS=64  -O2 -DHAS_EXECINFO -DHAVE_CLOCK_GETTIME -DHAVE_NL_LANGINFO -DHAVE_TM_GMTOFF -DHAVE_TM_ZONE -DHAVE_TIMEZONE -DHAVE_TZNAME -DHAVE_DAYLIGHT -DHAVE_ALLOCA_H -DH
AVE_STRING_H -DHAVE_SYS_TIME_H -DHAVE_SYS_TIMES_H -DHAVE_SYS_TYPES_H -DHAVE_UNISTD_H -DHAVE_STDARG_H -I/usr/include -D_GNU_SOURCE -fomit-frame-pointer -fPIC -DENABLE_LLVM -Ivendor/oniguruma -
DHAVE_CONFIG_H -I. -I../../vm/capi/19/include -Ivendor/udis86 -Ivendor/libffi/include -Ivendor/libgdtoa -Ivendor/libtommath -I/usr/local/include  -c -o vm/builtin/artifacts/unpack19.cpp.o vm/
builtin/unpack19.cpp
rake aborted!
Error compiling

Tasks: TOP => default => spec => spec18 => build => build:build => vm/vm
(See full trace by running task with --trace)
```
