### PR TITLE
IO#each_char in 1.9 handles utf-8

### DIFF
--- a/kernel/common/io.rb
+++ b/kernel/common/io.rb
@@ -599,38 +599,6 @@ class IO
     self
   end
 
-  def each_char
-    return to_enum(:each_char) unless block_given?
-
-    ensure_open_and_readable
-    if Rubinius.kcode == :UTF8
-      # TODO zoinks. This is the slowest way possible to do this.
-      # We'll have to rewrite it.
-      lookup = 7.downto(4)
-      while c = read(1) do
-        n = c[0]
-        leftmost_zero_bit = lookup.find { |i| n[i] == 0 }
-
-        case leftmost_zero_bit
-        when 7 # ASCII
-          yield c
-        when 6 # UTF 8 complementary characters
-          next # Encoding error, ignore
-        else
-          more = read(6 - leftmost_zero_bit)
-          break unless more
-          yield c + more
-        end
-      end
-    else
-      while s = read(1)
-        yield s
-      end
-    end
-
-    self
-  end
-
   ##
   # Set the pipe so it is at the end of the file
   def eof!

--- a/kernel/common/io18.rb
+++ b/kernel/common/io18.rb
@@ -153,6 +153,38 @@ class IO
 
   alias_method :each_line, :each
 
+  def each_char
+    return to_enum(:each_char) unless block_given?
+
+    ensure_open_and_readable
+    if Rubinius.kcode == :UTF8
+      # TODO zoinks. This is the slowest way possible to do this.
+      # We'll have to rewrite it.
+      lookup = 7.downto(4)
+      while c = read(1) do
+        n = c[0]
+        leftmost_zero_bit = lookup.find { |i| n[i] == 0 }
+
+        case leftmost_zero_bit
+        when 7 # ASCII
+          yield c
+        when 6 # UTF 8 complementary characters
+          next # Encoding error, ignore
+        else
+          more = read(6 - leftmost_zero_bit)
+          break unless more
+          yield c + more
+        end
+      end
+    else
+      while s = read(1)
+        yield s
+      end
+    end
+
+    self
+  end
+
   ##
   # Reads the next ``line’’ from the I/O stream;
   # lines are separated by sep_string. A separator

--- a/kernel/common/io19.rb
+++ b/kernel/common/io19.rb
@@ -449,6 +449,39 @@ class IO
     nil
   end
 
+  def each_char
+    return to_enum(:each_char) unless block_given?
+
+    ensure_open_and_readable
+    is_utf = self.external_encoding.names.include?(Encoding::UTF_8.name)
+    if is_utf
+      # TODO zoinks. This is the slowest way possible to do this.
+      # We'll have to rewrite it.
+      lookup = 7.downto(4)
+      while n = read(1) do
+        c = n.getbyte(0)
+        leftmost_zero_bit = lookup.find { |i| c[i] == 0 }
+
+        case leftmost_zero_bit
+        when 7 # ASCII
+          yield n
+        when 6 # UTF 8 complementary characters
+          next # Encoding error, ignore
+        else
+          more = read(6 - leftmost_zero_bit)
+          break unless more
+          yield n + more
+        end
+      end
+    else
+      while s = read(1)
+        yield s
+      end
+    end
+
+    self
+  end
+
   ##
   # Writes the given objects to ios as with IO#print.
   # Writes a record separator (typically a newline)

--- a/spec/tags/19/ruby/core/io/each_char_tags.txt
+++ b/spec/tags/19/ruby/core/io/each_char_tags.txt
@@ -1,2 +1,0 @@
-fails:IO#each_char yields each character
-fails:IO#each_char returns an Enumerator when passed no block


### PR DESCRIPTION
IO#each_char was incompatible with 1.9, the algorithm is copied from 1.8 and adjusted a bit to use 1.9 api
