### PR TITLE
gcc 4.7.0 error : 0x80000000 does not fit into int32_t

### DIFF
--- a/vm/builtin/unpack18.cpp
+++ b/vm/builtin/unpack18.cpp
@@ -274,7 +274,7 @@ namespace rubinius {
       return str;
     }
 
-    static const int32_t utf8_limits[] = {
+    static const uint32_t utf8_limits[] = {
       0x0,        /* 1 */
       0x80,       /* 2 */
       0x800,      /* 3 */
@@ -294,7 +294,7 @@ namespace rubinius {
 
       for(; count > 0 && bytes < bytes_end; count--) {
         native_int remainder = bytes_end - bytes;
-        int32_t c = *bytes++ & 0xff, value = c;
+        uint32_t c = *bytes++ & 0xff, value = c;
         int n = 0;
         length = 1;
 

--- a/vm/builtin/unpack19.cpp
+++ b/vm/builtin/unpack19.cpp
@@ -274,7 +274,7 @@ namespace rubinius {
       return str;
     }
 
-    static const int32_t utf8_limits[] = {
+    static const uint32_t utf8_limits[] = {
       0x0,        /* 1 */
       0x80,       /* 2 */
       0x800,      /* 3 */
@@ -294,7 +294,7 @@ namespace rubinius {
 
       for(; count > 0 && bytes < bytes_end; count--) {
         native_int remainder = bytes_end - bytes;
-        int32_t c = *bytes++ & 0xff, value = c;
+        uint32_t c = *bytes++ & 0xff, value = c;
         int n = 0;
         length = 1;
 


### PR DESCRIPTION
gcc (GCC) 4.7.0 20120407 (prerelease)

vm/builtin/unpack19.cpp:285:5: error: narrowing conversion of ‘2147483648u’ from ‘unsigned int’ to ‘const int32_t {aka const int}’ inside { } is ill-formed in C++11 [-Werror=narrowing]
