### PR TITLE
Kernel#String raises TypeError if passed object doesn't respond_to?(:to_s)

### DIFF
--- a/kernel/common/kernel19.rb
+++ b/kernel/common/kernel19.rb
@@ -182,6 +182,10 @@ module Kernel
   def String(obj)
     return obj if obj.kind_of? String
 
+    unless obj.respond_to?(:to_s)
+      raise TypeError, "can't convert #{obj.class} into String"
+    end
+
     begin
       str = obj.to_s
     rescue NoMethodError

--- a/spec/tags/19/ruby/core/kernel/String_tags.txt
+++ b/spec/tags/19/ruby/core/kernel/String_tags.txt
@@ -1,2 +1,0 @@
-fails:Kernel.String raises a TypeError if respond_to? returns false for #to_s
-fails:Kernel#String raises a TypeError if respond_to? returns false for #to_s


### PR DESCRIPTION
Kernel#String raises TypeError if passed object doesn't respond_to?(:to_s)
