### PR TITLE
Fix String#match in 1.9 mode

### DIFF
--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -702,19 +702,6 @@ class String
     str.lstrip! || str
   end
 
-  # Converts <i>pattern</i> to a <code>Regexp</code> (if it isn't already one),
-  # then invokes its <code>match</code> method on <i>self</i>.
-  #
-  #   'hello'.match('(.)\1')      #=> #<MatchData:0x401b3d30>
-  #   'hello'.match('(.)\1')[0]   #=> "ll"
-  #   'hello'.match(/(.)\1/)[0]   #=> "ll"
-  #   'hello'.match('xx')         #=> nil
-  def match(pattern)
-    match_data = get_pattern(pattern).search_region(self, 0, @num_bytes, true)
-    Regexp.last_match = match_data
-    return match_data
-  end
-
   # Treats leading characters of <i>self</i> as a string of octal digits (with an
   # optional sign) and returns the corresponding number. Returns 0 if the
   # conversion fails.

--- a/kernel/common/string18.rb
+++ b/kernel/common/string18.rb
@@ -884,6 +884,19 @@ class String
     end
   end
 
+  # Converts <i>pattern</i> to a <code>Regexp</code> (if it isn't already one),
+  # then invokes its <code>match</code> method on <i>self</i>.
+  #
+  #   'hello'.match('(.)\1')      #=> #<MatchData:0x401b3d30>
+  #   'hello'.match('(.)\1')[0]   #=> "ll"
+  #   'hello'.match(/(.)\1/)[0]   #=> "ll"
+  #   'hello'.match('xx')         #=> nil
+  def match(pattern)
+    match_data = get_pattern(pattern).search_region(self, 0, @num_bytes, true)
+    Regexp.last_match = match_data
+    return match_data
+  end
+
   # call-seq:
   #   str[fixnum] = fixnum
   #   str[fixnum] = new_str

--- a/kernel/common/string19.rb
+++ b/kernel/common/string19.rb
@@ -996,6 +996,21 @@ class String
     return self
   end
 
+  # Converts <i>pattern</i> to a <code>Regexp</code> (if it isn't already one),
+  # then invokes its <code>match</code> method on <i>self</i>. If the second
+  # parameter is present, it specifies the position in the <i>self</i> to
+  # begin the search.
+  #
+  #   'hello'.match('(.)\1')      #=> #<MatchData:0x401b3d30>
+  #   'hello'.match('(.)\1')[0]   #=> "ll"
+  #   'hello'.match(/(.)\1/)[0]   #=> "ll"
+  #   'hello'.match('xx')         #=> nil
+  def match(pattern, pos=0)
+    match_data = get_pattern(pattern).search_region(self, pos, @num_bytes, true)
+    Regexp.last_match = match_data
+    return match_data
+  end
+
   # call-seq:
   #   str[fixnum] = fixnum
   #   str[fixnum] = new_str

--- a/spec/tags/19/ruby/core/string/match_tags.txt
+++ b/spec/tags/19/ruby/core/string/match_tags.txt
@@ -1,1 +1,0 @@
-fails:String#match matches the pattern against self starting at an optional index


### PR DESCRIPTION
Failing tag: "String#match matches the pattern against self starting at an optional index".
