### PR TITLE
Fix download link for source tarball

### DIFF
--- a/web/doc/de/getting-started/building.markdown
+++ b/web/doc/de/getting-started/building.markdown
@@ -29,7 +29,7 @@ kompiliert.
 
 Der Rubinius Quellcode ist als Tarball und als Projekt auf Github
 verfügbar. Der Tarball kann [hier heruntergeladen
-werden](http://rubini.us/download/latest).
+werden](https://github.com/rubinius/rubinius/tarball/master).
 
 Um Git zu nutzen:
 

--- a/web/doc/en/getting-started/building.markdown
+++ b/web/doc/en/getting-started/building.markdown
@@ -21,7 +21,8 @@ LLVM installed and Rubinius fails to link with it for any reason, pass
 ### Getting the Source
 
 The Rubinius source code is available as a tarball and as a project on Github.
-You can [download the tarball here](http://rubini.us/download/latest).
+You can [download the tarball
+here](https://github.com/rubinius/rubinius/tarball/master).
 
 To use Git:
 

--- a/web/doc/es/getting-started/building.markdown
+++ b/web/doc/es/getting-started/building.markdown
@@ -21,7 +21,8 @@ las instrucciones que encontrará a continuación.
 ### Obtención del Código Fuente
 
 El código fuente de Rubinius esta disponible como un archivo comprimido y como un
-proyecto en Github.  Puede [descargar el archivo comprimido aquí](http://rubini.us/download/latest).
+proyecto en Github.  Puede [descargar el archivo comprimido
+aquí](https://github.com/rubinius/rubinius/tarball/master).
 
 Para usar Git:
 

--- a/web/doc/fr/getting-started/building.markdown
+++ b/web/doc/fr/getting-started/building.markdown
@@ -24,7 +24,8 @@ instructions suivantes.
 ### Récupérer les sources
 
 Le code source de Rubinius est disponible sous la forme d'une archive et d'un projet sur Github.
-Vous pouvez [télécharger l'archive ici](http://rubini.us/download/latest).
+Vous pouvez [télécharger l'archive
+ici](https://github.com/rubinius/rubinius/tarball/master).
 
 Pour utiliser Git :
 

--- a/web/doc/it/getting-started/building.markdown
+++ b/web/doc/it/getting-started/building.markdown
@@ -23,7 +23,8 @@ rilevarlo per qualche motivo, passate l'opzione `--skip-system` allo script
 ### Ottenere i sorgenti
 
 I sorgenti di Rubinius sono disponibili come tarball e come progetto su
-Github. Potete [scaricare il tarball qui](http://rubini.us/download/latest).
+Github. Potete [scaricare il tarball
+qui](https://github.com/rubinius/rubinius/tarball/master).
 
 Per usare Git:
 

--- a/web/doc/ja/getting-started/building.markdown
+++ b/web/doc/ja/getting-started/building.markdown
@@ -22,7 +22,7 @@ LLVMのバージョンの。お使いのシステムにLLVMのインストール
 ### Getting the Source
 
 RubiniusのソースコードはtarballとしてのGitHubにプロジェクトとして利用可能です。
-あなたは[ここのtarballをダウンロード](http://rubini.us/download/latest)することができます。
+あなたは[ここのtarballをダウンロード](https://github.com/rubinius/rubinius/tarball/master)することができます。
 
 To use Git:
 

--- a/web/doc/pl/getting-started/building.markdown
+++ b/web/doc/pl/getting-started/building.markdown
@@ -26,7 +26,8 @@ systemowa LLVM podczas kompilacji, Rubinius użyje swojej wersji LLVM.
 ### Pobieranie kodu źródłowego
 
 Kod źródłowy Rubiniusa dostępny jest jako archiwum tar oraz jako
-projekt na Github'ie. Archiwum tar możesz [pobrać tutaj](http://rubini.us/download/latest).
+projekt na Github'ie. Archiwum tar możesz [pobrać
+tutaj](https://github.com/rubinius/rubinius/tarball/master).
 
 Pobieranie źródeł przy pomocy Git'a:
 

--- a/web/doc/pt-br/getting-started/building.markdown
+++ b/web/doc/pt-br/getting-started/building.markdown
@@ -21,7 +21,8 @@ argumento do script `configure` nas instruções abaixo.
 ### Obtendo o código fonte
 
 O código fonte do Rubinius está disponível como tarball e como projeto no Github.
-Você pode [fazer o download do tarball aqui](http://rubini.us/download/latest).
+Você pode [fazer o download do tarball
+aqui](https://github.com/rubinius/rubinius/tarball/master).
 
 Se preferir, utilize o Git:
 

--- a/web/doc/ru/getting-started/building.markdown
+++ b/web/doc/ru/getting-started/building.markdown
@@ -23,7 +23,8 @@ information). Скрипт "`configure`" автоматически провер
 ### Получение исходного кода
 
 Исходный код Rubinius доступен как tar-архив и как проект на Github.
-Tar-архив можно скачать [здесь](http://rubini.us/download/latest).
+Tar-архив можно скачать
+[здесь](https://github.com/rubinius/rubinius/tarball/master).
 
 Чтобы использовать Git:
 


### PR DESCRIPTION
The link on the Getting Started -> Building page of the docs is broken. Changed it to the github tarball download.

![](https://img.skitch.com/20120428-qks9c4wq628br9nratgskyjmf8.jpg)

![](https://img.skitch.com/20120428-fmtspuths861w7i1jh6x21bjmb.jpg)
