### PR TITLE
Support weakly-referencing to all kinds of objects

### DIFF
--- a/kernel/bootstrap/weakref.rb
+++ b/kernel/bootstrap/weakref.rb
@@ -21,12 +21,15 @@ class WeakRef
 
   def __getobj__
     obj = __object__()
-    ::Kernel.raise RefError, "Object has been collected as garbage" unless obj
+    unless weakref_alive?
+      ::Kernel.raise RefError, "Object has been collected as garbage"
+    end
     return obj
   end
 
   def weakref_alive?
-    !!__object__
+    Rubinius.primitive :weakref_alive_p
+    ::Kernel.raise PrimitiveFailure, "WeakRef#weakref_alive? failed"
   end
 
   def method_missing(method, *args, &block)

--- a/vm/builtin/weakref.cpp
+++ b/vm/builtin/weakref.cpp
@@ -28,7 +28,7 @@ namespace rubinius {
 
   void WeakRef::Info::mark(Object* obj, ObjectMark& mark) {
     WeakRef* ref = as<WeakRef>(obj);
-    if(ref->alive_p()) {
+    if(ref->reference_alive_p()) {
       mark.gc->add_weak_ref(obj);
     }
   }

--- a/vm/gc/gc.cpp
+++ b/vm/gc/gc.cpp
@@ -319,13 +319,13 @@ namespace rubinius {
       if(check_forwards) {
         if(obj->young_object_p()) {
           if(!obj->forwarded_p()) {
-            ref->set_object(object_memory_, cNil);
+            ref->update_object(object_memory_, cNil);
           } else {
-            ref->set_object(object_memory_, obj->forward());
+            ref->update_object(object_memory_, obj->forward());
           }
         }
       } else if(!obj->marked_p(object_memory_->mark())) {
-        ref->set_object(object_memory_, cNil);
+        ref->update_object(object_memory_, cNil);
       }
     }
 


### PR DESCRIPTION
Current WeakRef implementation doesn't support to reference to nil and false.

The reason for nil is that it can't know whether referenced object is nil or it
is garbage-collected and set to nil. The reason for false is that there is an
incorrect assumption that referenced objects can't be evaluated to false.

By adding a new field to C++ WeakRef class to record whether referenced object
is immediate or reference, WeakRef truly supports all kinds of objects.

Personally, I think the increase of WeakRef's size is well justified by the realized consistency in this case.

FYI, MRI's WeakRef doesn't support to referencing to immediates at all. So, as an alternative design decision, we can follow it.
