### PR TITLE
Fix 1.9 array slice when the end of the range is >= array.size

### DIFF
--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -497,6 +497,8 @@ class Array
         range_end = Rubinius::Type.coerce_to range.end, Fixnum, :to_int
         if range_end < 0
           range_end = range_end + @total
+        elsif range_end >= @total
+          range_end = @total - 1
         end
 
         range_length = range_end - range_start

--- a/spec/ruby/core/array/slice_spec.rb
+++ b/spec/ruby/core/array/slice_spec.rb
@@ -73,6 +73,10 @@ describe "Array#slice!" do
     a.should == [1]
     a.slice!(0..0).should == [1]
     a.should == []
+
+    a = [1,2,3]
+    a.slice!(0..3).should == [1,2,3]
+    a.should == []
   end
 
   it "calls to_int on range arguments" do


### PR DESCRIPTION
Calling `Array.slice!` with a range as parameter didn't work properly
when the end of the range was major or equal to the length of the array.
In this corner case `Array.slice!` returned the expected values but
didn't remove them from the original array.
