### PR TITLE
Don't assume that llvm-config is a Perl script

### DIFF
--- a/configure
+++ b/configure
@@ -612,10 +612,10 @@ Unsupported language version requested: #{ver}. Options are #{@supported_version
   def setup_auto
     @log.print "  Checking for existing LLVM library tree: "
     if File.directory?("#{@llvm_default}/Release")
-      version = `#{@perl} #{@llvm_default}/Release/bin/llvm-config --version`.strip
+      version = `#{llvm_config_cmd "#{@llvm_default}/Release/bin/llvm-config"} --version`.strip
       if version == "3.0"
         # See if this has rtti turned off and reject it.
-        if `#{@perl} #{@llvm_default}/Release/bin/llvm-config --cxxflags`.index("-fno-rtti")
+        if `#{llvm_config_cmd "#{@llvm_default}/Release/bin/llvm-config"} --cxxflags`.index("-fno-rtti")
           @log.write "incorrectly configure (rtti is off)"
           remove_default
         else
@@ -667,10 +667,10 @@ Unsupported language version requested: #{ver}. Options are #{@supported_version
     end
 
     if config
-      version = `#{@perl} #{config} --version`.strip
+      version = `#{llvm_config_cmd config} --version`.strip
       parts = version.sub(/svn$/, "").split(".").map { |i| i.to_i }
       api_version = ("%d%02d" % parts[0..1]).to_i
-      if `#{@perl} #{config} --cxxflags`.index("-fno-rtti")
+      if `#{llvm_config_cmd config} --cxxflags`.index("-fno-rtti")
         @log.write "incorrectly configured llvm (rtti is off)"
       elsif api_version != 300
         @log.write "only LLVM 3.0 is supported"
@@ -1123,6 +1123,20 @@ int main() { return tgetnum(""); }
     @build_ruby
   end
 
+  # Checks whether the given config file is a Perl script by checking its first
+  # line for a Perl hashbang.
+  def llvm_config_cmd(config)
+    first_line = File.open(config).lines.first
+    if first_line =~ /^#! ?\/usr(\/local)?\/bin\/(env )?perl/
+      "#{@perl} #{config}"
+    else
+      config
+    end
+  rescue Errno::ENOENT, ArgumentError
+    # The file doesn't exist (ENOENT) or it's a binary file (ArgumentError).
+    config
+  end
+
   def get_system_name
     return unless @os =~ /linux/
     return unless File.exists? "/etc/issue"
@@ -1201,6 +1215,7 @@ module Rubinius
     :build_perl     => "#{@perl}",
     :llvm           => :#{@llvm},
     :llvm_configure => "#{@llvm_configure}",
+    :llvm_config_cmd => "#{llvm_config_cmd @llvm_configure if @llvm_configure}",
     :cc             => "#{@cc}",
     :cxx            => "#{@cxx}",
     :user_cflags    => "#{@user_cflags}",

--- a/rakelib/build.rb
+++ b/rakelib/build.rb
@@ -1,9 +1,9 @@
-def llvm_configure
+def llvm_config_cmd
   case Rubinius::BUILD_CONFIG[:llvm]
   when :svn, :prebuilt
-    "vendor/llvm/Release/bin/llvm-config"
+    "#{build_perl} vendor/llvm/Release/bin/llvm-config"
   when :config
-    Rubinius::BUILD_CONFIG[:llvm_configure]
+    Rubinius::BUILD_CONFIG[:llvm_config_cmd]
   else
     raise "Tried to use LLVM unconfigure!"
   end
@@ -25,7 +25,7 @@ def llvm_flags
     @llvm_flags = []
   end
 
-  @llvm_flags += `#{build_perl} #{llvm_configure} --cflags`.split(/\s+/)
+  @llvm_flags += `#{llvm_config_cmd} --cflags`.split(/\s+/)
   @llvm_flags.delete_if { |e| e.index("-O") == 0 }
   @llvm_flags
 end
@@ -33,7 +33,7 @@ end
 def llvm_link_flags
   return "" unless LLVM_ENABLE
 
-  flags = `#{build_perl} #{llvm_configure} --ldflags`.strip
+  flags = `#{llvm_config_cmd} --ldflags`.strip
   flags.sub!(%r[-L/([a-zA-Z])/], '-L\1:/') if Rubinius::BUILD_CONFIG[:windows]
 
   flags
@@ -42,7 +42,7 @@ end
 def llvm_lib_files
   return [] unless LLVM_ENABLE
 
-  files = `#{build_perl} #{llvm_configure} --libfiles`.split(/\s+/)
+  files = `#{llvm_config_cmd} --libfiles`.split(/\s+/)
   files.select do |f|
     f.sub!(%r[^/([a-zA-Z])/], '\1:/') if Rubinius::BUILD_CONFIG[:windows]
     File.file? f
@@ -50,7 +50,7 @@ def llvm_lib_files
 end
 
 def llvm_version
-  `#{build_perl} #{llvm_configure} --version`.strip
+  `#{llvm_config_cmd} --version`.strip
 end
 
 def host_triple


### PR DESCRIPTION
As of the upcoming LLVM 3.1 release llvm-config has been rewritten as a
[native executable](https://llvm.org/svn/llvm-project/llvm/branches/release_31/tools/llvm-config/?r=156062). Executing it with Perl causes the configure script
to fail with a message

```
Unrecognized character \x7F; marked by <-- HERE after
<-- HERE near column 1 at llvm-config line 1.
```

This commit makes the configure script detect whether llvm-config is a Perl
script using a simple regular expression. If it's a Perl script it's
invoked the old way, otherwise it's invoked directly. As a result it works
correctly with LLVM 3.0 and fails with a more friendly error message when
encountering newer versions of LLVM.
