### PR TITLE
Adds: Module#public_constant can only be passed constant names defined i...

### DIFF
--- a/kernel/common/module19.rb
+++ b/kernel/common/module19.rb
@@ -148,5 +148,7 @@ class Module
   end
 
   def public_constant(*names)
+    unknown_constants = names - @constant_table.keys
+    raise NameError, "Constant #{name}::#{unknown_constants.first} not defined" if unknown_constants.size > 0
   end
 end

--- a/spec/tags/19/ruby/core/module/public_constant_tags.txt
+++ b/spec/tags/19/ruby/core/module/public_constant_tags.txt
@@ -1,1 +1,0 @@
-fails:Module#public_constant can only be passed constant names defined in the target (self) module


### PR DESCRIPTION
...n the target (self) module.

This commit makes the corresponding spec in
spec/ruby/core/module/public_constant_spec.rb pass.
The error message is the very as issued by MRI Ruby (1.9.3 head).
