### PR TITLE
Improve NameError message for Module#public_constant.

### DIFF
--- a/kernel/common/module19.rb
+++ b/kernel/common/module19.rb
@@ -149,6 +149,8 @@ class Module
 
   def public_constant(*names)
     unknown_constants = names - @constant_table.keys
-    raise NameError, "Constant #{name}::#{unknown_constants.first} not defined" if unknown_constants.size > 0
+    if unknown_constants.size > 0
+      raise NameError, "#{unknown_constants.size > 1 ? 'Constants' : 'Constant'} #{unknown_constants.map{|e| "#{name}::#{e}"}.join(', ')} undefined"
+    end
   end
 end


### PR DESCRIPTION
This PR improves on the error message for Module#public_constants which was introduced in this PR: https://github.com/rubinius/rubinius/pull/1720

cc & thanks @dbussink
