### PR TITLE
String#delete raises ArgumentError if the given ranges are invalid in 1....

### DIFF
--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -254,29 +254,6 @@ class String
     str.delete!(*strings) || str
   end
 
-  def delete!(*strings)
-    raise ArgumentError, "wrong number of arguments" if strings.empty?
-    self.modify!
-
-    table = count_table(*strings).__data__
-
-    i, j = 0, -1
-    while i < @num_bytes
-      c = @data[i]
-      unless table[c] == 1
-        @data[j+=1] = c
-      end
-      i += 1
-    end
-
-    if (j += 1) < @num_bytes
-      self.num_bytes = j
-      self
-    else
-      nil
-    end
-  end
-
   def clear
     Rubinius.check_frozen
     self.num_bytes = 0

--- a/kernel/common/string18.rb
+++ b/kernel/common/string18.rb
@@ -36,6 +36,31 @@ class String
     self
   end
 
+  def delete!(*strings)
+    raise ArgumentError, "wrong number of arguments" if strings.empty?
+
+    self.modify!
+
+    table = count_table(*strings).__data__
+
+    i, j = 0, -1
+    while i < @num_bytes
+      c = @data[i]
+      unless table[c] == 1
+        @data[j+=1] = c
+      end
+      i += 1
+    end
+
+    if (j += 1) < @num_bytes
+      self.num_bytes = j
+      self
+    else
+      nil
+    end
+  end
+
+
   def slice!(one, two=undefined)
     # This is un-DRY, but it's a simple manual argument splitting. Keeps
     # the code fast and clean since the sequence are pretty short.

--- a/kernel/common/string19.rb
+++ b/kernel/common/string19.rb
@@ -51,6 +51,39 @@ class String
     self
   end
 
+  def delete!(*strings)
+    raise ArgumentError, "wrong number of arguments" if strings.empty?
+
+    strings.each do |string|
+      if string =~ /.+\-.+/
+        ranges_found = string.scan(/\w{1}\-\w{1}/)
+        ranges_found.map{ |range| range.gsub(/-/, '').split('') }.each do |range_array|
+          raise ArgumentError, "invalid range #{strings} in string transliteration" unless range_array == range_array.sort
+        end
+      end
+    end
+
+    self.modify!
+
+    table = count_table(*strings).__data__
+
+    i, j = 0, -1
+    while i < @num_bytes
+      c = @data[i]
+      unless table[c] == 1
+        @data[j+=1] = c
+      end
+      i += 1
+    end
+
+    if (j += 1) < @num_bytes
+      self.num_bytes = j
+      self
+    else
+      nil
+    end
+  end
+
   def upto(stop, exclusive=false)
     return to_enum :upto, stop, exclusive unless block_given?
     stop = StringValue(stop)

--- a/spec/tags/19/ruby/core/string/delete_tags.txt
+++ b/spec/tags/19/ruby/core/string/delete_tags.txt
@@ -1,1 +1,0 @@
-fails:String#delete raises if the given ranges are invalid


### PR DESCRIPTION
...9

Moved String#delete! to relevant string implementations and added handling of invalid ranges for String#delete in ruby 1.9
