### PR TITLE
Fixed the contents of the message thrown when String#delete! is passed a...

### DIFF
--- a/kernel/common/string19.rb
+++ b/kernel/common/string19.rb
@@ -58,7 +58,7 @@ class String
       if string =~ /.+\-.+/
         ranges_found = string.scan(/\w{1}\-\w{1}/)
         ranges_found.map{ |range| range.gsub(/-/, '').split('') }.each do |range_array|
-          raise ArgumentError, "invalid range #{strings} in string transliteration" unless range_array == range_array.sort
+          raise ArgumentError, "invalid range \"#{range_array.join('-')}\" in string transliteration" unless range_array == range_array.sort
         end
       end
     end

--- a/spec/ruby/core/string/delete_spec.rb
+++ b/spec/ruby/core/string/delete_spec.rb
@@ -62,8 +62,9 @@ describe "String#delete" do
 
   ruby_version_is "1.9" do
     it "raises if the given ranges are invalid" do
-      lambda { "hello".delete("h-e") }.should raise_error(ArgumentError)
-      lambda { "hello".delete("^h-e") }.should raise_error(ArgumentError)
+      lambda { "hello".delete("h-e") }.should raise_error(ArgumentError, 'invalid range "h-e" in string transliteration')
+      lambda { "hello".delete("^h-e") }.should raise_error(ArgumentError, 'invalid range "h-e" in string transliteration')
+      lambda { "hello".delete("a-bjaph-e") }.should raise_error(ArgumentError, 'invalid range "h-e" in string transliteration')
     end
   end
 


### PR DESCRIPTION
...n invalid range in 1.9. It showed the whole input string up until now, but Ruby throws an exception containing only the invalid range:

```
1.9.3-p194 :010 > "".squeeze('a-b', 'trololok-a')
ArgumentError: invalid range "k-a" in string transliteration
    from (irb):10:in `squeeze'
    from (irb):10
    from /Users/tph/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'
```
