### PR TITLE
Fix libffi build issue with Clang

### DIFF
--- a/vendor/libffi/configure
+++ b/vendor/libffi/configure
@@ -14252,10 +14252,10 @@ if ${libffi_cv_as_x86_pcrel+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-	libffi_cv_as_x86_pcrel=yes
+	libffi_cv_as_x86_pcrel=no
 	echo '.text; foo: nop; .data; .long foo-.; .text' > conftest.s
-	if $CC $CFLAGS -c conftest.s 2>&1 | $EGREP -i 'illegal|warning' > /dev/null; then
-	    libffi_cv_as_x86_pcrel=no
+	if $CC $CFLAGS -c conftest.s > /dev/null; then
+	    libffi_cv_as_x86_pcrel=yes
 	fi
 
 fi

--- a/vendor/libffi/configure.ac
+++ b/vendor/libffi/configure.ac
@@ -297,10 +297,10 @@ fi
 if test x$TARGET = xX86 || test x$TARGET = xX86_WIN32 || test x$TARGET = xX86_64; then
     AC_CACHE_CHECK([assembler supports pc related relocs],
 	libffi_cv_as_x86_pcrel, [
-	libffi_cv_as_x86_pcrel=yes
+	libffi_cv_as_x86_pcrel=no
 	echo '.text; foo: nop; .data; .long foo-.; .text' > conftest.s
-	if $CC $CFLAGS -c conftest.s 2>&1 | $EGREP -i 'illegal|warning' > /dev/null; then
-	    libffi_cv_as_x86_pcrel=no
+	if $CC $CFLAGS -c conftest.s > /dev/null; then
+	    libffi_cv_as_x86_pcrel=yes
 	fi
 	])
     if test "x$libffi_cv_as_x86_pcrel" = xyes; then


### PR DESCRIPTION
This cherry-picks a commit by hand to fix a libffi build failure with clang.
In particular, I applied the following patch from the official libffi
repository:
  https://github.com/atgreen/libffi/blob/master/patches/x86_pcrel_test

References:
  http://bugs.python.org/issue12812
  https://bugzilla.mozilla.org/show_bug.cgi?id=631928
  http://sourceware.org/ml/libffi-discuss/2011/msg00024.html

Because I'm changing any part of the build system, I'm being careful :)

Could anybody test building with this patch?

I tested on Ubuntu 12.04 (GCC 4.6 and Clnag 3.0)
