### PR TITLE
Keep RubyGems untouched

### DIFF
--- a/lib/rubygems/defaults/rbx.rb
+++ b/lib/rubygems/defaults/rbx.rb
@@ -18,7 +18,7 @@ module Gem
   end
 
   def self.default_path
-    dirs = [default_dir]
+    dirs = [default_dir, default_preinstalled_dir]
     # This is the same test rubygems/defaults.rb uses
     dirs.unshift(Gem.user_dir) if File.exists?(Gem.user_home)
     dirs

--- a/lib/rubygems/path_support.rb
+++ b/lib/rubygems/path_support.rb
@@ -65,10 +65,6 @@ class Gem::PathSupport
       gem_path << APPLE_GEM_HOME if defined?(APPLE_GEM_HOME)
     end
 
-    if Gem.respond_to?(:default_preinstalled_dir)
-      gem_path << Gem.default_preinstalled_dir
-    end
-
     @path = gem_path.uniq
   end
 end


### PR DESCRIPTION
No reasons to modify RubyGems code if the same functionality can be achieved by modifying default settings of RubyGems for Rubinius (reverts 479b268).
