### PR TITLE
reset GEM_HOME & GEM_PATH to not install gems in currently used RVM ruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -207,6 +207,7 @@ end
 desc 'Install the pre-installed gems'
 task :gem_bootstrap do
   STDOUT.puts "Installing pre-installed gems..."
+  ENV['GEM_HOME'] = ENV['GEM_PATH'] = nil
 
   rbx = "#{BUILD_CONFIG[:bindir]}/#{BUILD_CONFIG[:program_name]}"
   gems = Dir["preinstalled-gems/*.gem"]


### PR DESCRIPTION
reset GEM_HOME & GEM_PATH to not install gems in currently used RVM ruby

this problem was introduced in #1712 with commit bed9da6ff9d914087cf50c6269cf8e22a985216f

also fixes things for @michaelklishin / @travis-ci
