### PR TITLE
Fix typo in instructions.def

### DIFF
--- a/vm/instructions.def
+++ b/vm/instructions.def
@@ -2235,7 +2235,7 @@ end
 #   ...
 #   arg2
 #   arg1
-#   reciever
+#   receiver
 # [Stack After]
 #   value
 #   ...

--- a/web/_includes/instructions.markdown
+++ b/web/_includes/instructions.markdown
@@ -2183,7 +2183,7 @@
 </td><td></td></tr>
 <tr><td>   arg1
 </td><td></td></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td></td></tr>
 </tbody>
 </table>

--- a/web/_site/doc/de/virtual-machine/instructions/index.html
+++ b/web/_site/doc/de/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/en/virtual-machine/instructions/index.html
+++ b/web/_site/doc/en/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/es/virtual-machine/instructions/index.html
+++ b/web/_site/doc/es/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/fr/virtual-machine/instructions/index.html
+++ b/web/_site/doc/fr/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/it/virtual-machine/instructions/index.html
+++ b/web/_site/doc/it/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/ja/virtual-machine/instructions/index.html
+++ b/web/_site/doc/ja/virtual-machine/instructions/index.html
@@ -2239,7 +2239,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/pl/virtual-machine/instructions/index.html
+++ b/web/_site/doc/pl/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/pt-br/virtual-machine/instructions/index.html
+++ b/web/_site/doc/pt-br/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>

--- a/web/_site/doc/ru/virtual-machine/instructions/index.html
+++ b/web/_site/doc/ru/virtual-machine/instructions/index.html
@@ -2230,7 +2230,7 @@ tuple data.</li>
 </td><td /></tr>
 <tr><td>   arg1
 </td><td /></tr>
-<tr><td>   reciever
+<tr><td>   receiver
 </td><td /></tr>
 </tbody>
 </table>


### PR DESCRIPTION
I noticed that the word "receiver" was misspelled in the documentation for the `call_custom` instruction. This pull requests fixes the typo in `vm/instructions.def` and all other documentation files that are generated from it.
