### PR TITLE
Noisy VM Mode

### DIFF
--- a/lib/rubinius/configuration.rb
+++ b/lib/rubinius/configuration.rb
@@ -26,6 +26,9 @@ Rubinius::ConfigurationVariables.define do |c|
     s.vm_variable "show", :bool,
       "Display information whenever the GC runs"
 
+    s.vm_variable "noisy", :bool,
+      "Beep whenever the GC runs (once for young, twice for mature). Requires gc.show"
+
     s.vm_variable "immix.debug", :bool,
       "Print out collection stats when the Immix collector finishes"
 
@@ -78,8 +81,8 @@ Rubinius::ConfigurationVariables.define do |c|
       i.vm_variable "blocks", true,
         "Have the JIT try and inline methods and their literal blocks"
     end
-    
-    s.vm_variable "log", :string, 
+
+    s.vm_variable "log", :string,
       "Send JIT debugging output to this file rather than stdout"
 
     s.vm_variable "debug", false,

--- a/vm/objectmemory.cpp
+++ b/vm/objectmemory.cpp
@@ -547,6 +547,10 @@ step1:
         std::cerr << "[GC " << std::fixed << std::setprecision(1) << stats.percentage_used << "% "
                   << stats.promoted_objects << "/" << stats.excess_objects << " "
                   << stats.lifetime << " " << diff << "ms]" << std::endl;
+
+        if(state->shared().config.gc_noisy) {
+          std::cerr << "\a" << std::flush;
+        }
       }
     }
 
@@ -574,6 +578,10 @@ step1:
         int diff = (fin_time - start_time) / 1000000;
         size_t kb = mature_bytes_allocated() / 1024;
         std::cerr << "[Full GC " << before_kb << "kB => " << kb << "kB " << diff << "ms]" << std::endl;
+
+        if(state->shared().config.gc_noisy) {
+          std::cerr << "\a\a" << std::flush;
+        }
       }
     }
 


### PR DESCRIPTION
Sometimes it's useful to be able to diagnose various things via the noise they make, rather than them just printing something. 

Someone showed me that haskell has a `-B` flag that makes your computer beep every time GC runs, and I thought it would be cool/fun/useful to implement for various other languages (including ruby), so I have

It is guarded by also having to enable `gc.show` so that you get that info as well. I (and others) felt this was the least offensive approach, but they could be made independent in future.

It beeps once for every young generation GC, and twice for every mature generation GC. The beeping is just done by sending ASCII BELL to standard error - so without a terminal/tty it probably won't work.
