### PR TITLE
Simplify mkmf.rb.

### DIFF
--- a/lib/18/mkmf.rb
+++ b/lib/18/mkmf.rb
@@ -132,11 +132,7 @@ end
 
 # ---------------------- Changed for Rubinius --------------------------------
 if dir = ENV['RBX_CAPI_DIR']
-  if Rubinius.ruby18?
-    $topdir = "#{dir}/vm/capi/18/include"
-  else
-    $topdir = "#{dir}/vm/capi/19/include"
-  end
+  $topdir = "#{dir}/vm/capi/18/include"
 else
   $topdir = RbConfig::CONFIG["rubyhdrdir"]
 end

--- a/lib/19/mkmf.rb
+++ b/lib/19/mkmf.rb
@@ -156,11 +156,7 @@ end
 
 # ---------------------- Changed for Rubinius --------------------------------
 if dir = ENV['RBX_CAPI_DIR']
-  if Rubinius.ruby18?
-    $topdir = "#{dir}/vm/capi/18/include"
-  else
-    $topdir = "#{dir}/vm/capi/19/include"
-  end
+  $topdir = "#{dir}/vm/capi/19/include"
 else
   $topdir = RbConfig::CONFIG["rubyhdrdir"]
 end


### PR DESCRIPTION
There is no need to check for CAPI version in mkmf.rb, since Rubinius already
loaded mkmf.rb from version dependent location.
