### PR TITLE
Move thread under rubinius::utilities::thread

### DIFF
--- a/vm/agent.cpp
+++ b/vm/agent.cpp
@@ -654,7 +654,7 @@ auth_error:
   }
 
   QueryAgent::Thread::Thread(QueryAgent* agent)
-    : thread::Thread(0, false)
+    : utilities::thread::Thread(0, false)
     , agent_(agent)
     , exit_(false)
   {

--- a/vm/agent.hpp
+++ b/vm/agent.hpp
@@ -49,7 +49,7 @@ namespace rubinius {
 
     };
 
-    class Thread : public thread::Thread {
+    class Thread : public utilities::thread::Thread {
     private:
       QueryAgent* agent_;
       bool exit_;

--- a/vm/auxiliary_threads.cpp
+++ b/vm/auxiliary_threads.cpp
@@ -11,7 +11,7 @@ namespace rubinius {
   }
 
   void AuxiliaryThreads::shutdown(STATE) {
-    thread::Mutex::LockGuard guard(mutex_);
+    utilities::thread::Mutex::LockGuard guard(mutex_);
 
     if(shutdown_in_progress_) return;
     shutdown_in_progress_ = true;
@@ -26,7 +26,7 @@ namespace rubinius {
   }
 
   void AuxiliaryThreads::before_exec(STATE) {
-    thread::Mutex::LockGuard guard(mutex_);
+    utilities::thread::Mutex::LockGuard guard(mutex_);
 
     if(exec_in_progress_) return;
     exec_in_progress_ = true;
@@ -51,7 +51,7 @@ namespace rubinius {
   }
 
   void AuxiliaryThreads::before_fork(STATE) {
-    thread::Mutex::LockGuard guard(mutex_);
+    utilities::thread::Mutex::LockGuard guard(mutex_);
 
     if(fork_in_progress_) return;
     fork_in_progress_ = true;

--- a/vm/auxiliary_threads.hpp
+++ b/vm/auxiliary_threads.hpp
@@ -23,7 +23,7 @@ namespace rubinius {
     bool fork_in_progress_;
     bool exec_in_progress_;
     bool shutdown_in_progress_;
-    thread::Mutex mutex_;
+    utilities::thread::Mutex mutex_;
     std::set<AuxiliaryThread*> threads_;
 
   public:

--- a/vm/builtin/channel.cpp
+++ b/vm/builtin/channel.cpp
@@ -37,8 +37,8 @@ namespace rubinius {
     chan->semaphore_count_ = 0;
 
     // Using placement new to call the constructor of condition_
-    new(&chan->condition_) thread::Condition();
-    new(&chan->mutex_) thread::Mutex();
+    new(&chan->condition_) utilities::thread::Condition();
+    new(&chan->mutex_) utilities::thread::Mutex();
 
     chan->value(state, List::create(state));
 
@@ -51,8 +51,8 @@ namespace rubinius {
     chan->semaphore_count_ = 1;
 
     // Using placement new to call the constructor of condition_
-    new(&chan->condition_) thread::Condition();
-    new(&chan->mutex_) thread::Mutex();
+    new(&chan->condition_) utilities::thread::Condition();
+    new(&chan->mutex_) utilities::thread::Mutex();
 
     chan->value(state, List::create(state));
 
@@ -184,7 +184,7 @@ namespace rubinius {
         GCIndependent gc_guard(state, call_frame);
 
         if(use_timed_wait) {
-          if(self->condition_.wait_until(self->mutex_, &ts) == thread::cTimedOut) break;
+          if(self->condition_.wait_until(self->mutex_, &ts) == utilities::thread::cTimedOut) break;
         } else {
           self->condition_.wait(self->mutex_);
         }

--- a/vm/builtin/channel.hpp
+++ b/vm/builtin/channel.hpp
@@ -27,8 +27,8 @@ namespace rubinius {
   private:
     List* value_;  // slot
 
-    thread::Condition condition_;
-    thread::Mutex mutex_;
+    utilities::thread::Condition condition_;
+    utilities::thread::Mutex mutex_;
     int waiters_;
     int semaphore_count_;
 

--- a/vm/builtin/nativemethod.cpp
+++ b/vm/builtin/nativemethod.cpp
@@ -35,7 +35,7 @@
 
 namespace rubinius {
   /** Thread-local NativeMethodEnvironment instance. */
-  thread::ThreadData<NativeMethodEnvironment*> native_method_environment;
+  utilities::thread::ThreadData<NativeMethodEnvironment*> native_method_environment;
 
 /* Class methods */
 

--- a/vm/builtin/regexp.cpp
+++ b/vm/builtin/regexp.cpp
@@ -315,7 +315,7 @@ namespace rubinius {
       pattern->encoding(state, source_enc);
     }
 
-    thread::Mutex::LockGuard lg(state->shared().onig_lock());
+    utilities::thread::Mutex::LockGuard lg(state->shared().onig_lock());
 
     int err = onig_new(&this->onig_data, pat, end, opts & OPTION_MASK, enc, ONIG_SYNTAX_RUBY, &err_info);
 
@@ -523,7 +523,7 @@ namespace rubinius {
       Exception::argument_error(state, "Not properly initialized Regexp");
     }
 
-    // thread::Mutex::LockGuard lg(state->shared().onig_lock());
+    // utilities::thread::Mutex::LockGuard lg(state->shared().onig_lock());
 
     max = string->byte_size();
     native_int pos = start->to_native();

--- a/vm/builtin/regexp.hpp
+++ b/vm/builtin/regexp.hpp
@@ -29,7 +29,7 @@ namespace rubinius {
     regex_t* onig_data;
     bool fixed_encoding_;
     bool no_encoding_;
-    thread::SpinLock lock_;
+    utilities::thread::SpinLock lock_;
 
   public:
     /* accessors */

--- a/vm/builtin/thread.cpp
+++ b/vm/builtin/thread.cpp
@@ -191,7 +191,7 @@ namespace rubinius {
 
     std::ostringstream tn;
     tn << "rbx.ruby." << vm->thread_id();
-    thread::Thread::set_os_name(tn.str().c_str());
+    utilities::thread::Thread::set_os_name(tn.str().c_str());
 
     state->set_call_frame(0);
     vm->shared.gc_dependent(state);
@@ -331,7 +331,7 @@ namespace rubinius {
   }
 
   Tuple* Thread::context(STATE) {
-    thread::SpinLock::LockGuard lg(init_lock_);
+    utilities::thread::SpinLock::LockGuard lg(init_lock_);
 
     VM* vm = vm_;
     if(!vm) return nil<Tuple>();
@@ -344,7 +344,7 @@ namespace rubinius {
   }
 
   Array* Thread::mri_backtrace(STATE, GCToken gct, CallFrame* calling_environment) {
-    thread::SpinLock::LockGuard lg(init_lock_);
+    utilities::thread::SpinLock::LockGuard lg(init_lock_);
 
     VM* vm = vm_;
     if(!vm) return nil<Array>();

--- a/vm/builtin/thread.hpp
+++ b/vm/builtin/thread.hpp
@@ -44,7 +44,7 @@ namespace rubinius {
 
     LookupTable* locals_; // slot
 
-    thread::SpinLock init_lock_;
+    utilities::thread::SpinLock init_lock_;
 
     /// The VM state for this thread and this thread alone
     VM* vm_;

--- a/vm/capi/gc.cpp
+++ b/vm/capi/gc.cpp
@@ -9,7 +9,7 @@ using namespace rubinius;
 using namespace rubinius::capi;
 
 
-static thread::ThreadData<ObjectMark*> _current_mark;
+static utilities::thread::ThreadData<ObjectMark*> _current_mark;
 
 namespace rubinius {
   namespace capi {

--- a/vm/gc/code_manager.cpp
+++ b/vm/gc/code_manager.cpp
@@ -58,7 +58,7 @@ namespace rubinius {
   }
 
   void CodeManager::add_resource(CodeResource* cr) {
-    thread::Mutex::LockGuard guard(mutex_);
+    utilities::thread::Mutex::LockGuard guard(mutex_);
 
     total_allocated_ += cr->size();
     bytes_used_ += cr->size();

--- a/vm/gc/code_manager.hpp
+++ b/vm/gc/code_manager.hpp
@@ -41,7 +41,7 @@ namespace rubinius {
       ~Chunk();
     };
 
-    thread::Mutex mutex_;
+    utilities::thread::Mutex mutex_;
 
     SharedState* shared_;
 

--- a/vm/gc/managed.cpp
+++ b/vm/gc/managed.cpp
@@ -5,7 +5,7 @@
 #include "shared_state.hpp"
 
 namespace rubinius {
-  thread::ThreadData<ManagedThread*> _current_thread;
+  utilities::thread::ThreadData<ManagedThread*> _current_thread;
 
   ManagedThread::ManagedThread(uint32_t id, SharedState& ss, ManagedThread::Kind kind)
     : shared_(ss)

--- a/vm/gc/root.cpp
+++ b/vm/gc/root.cpp
@@ -10,12 +10,12 @@ namespace rubinius {
   }
 
   void Roots::add(Root* node) {
-    thread::Mutex::LockGuard guard(lock_);
+    utilities::thread::Mutex::LockGuard guard(lock_);
     this->LinkedList::add(node);
   }
 
   void Roots::remove(Root* node) {
-    thread::Mutex::LockGuard guard(lock_);
+    utilities::thread::Mutex::LockGuard guard(lock_);
     this->LinkedList::remove(node);
   }
 

--- a/vm/gc/root.hpp
+++ b/vm/gc/root.hpp
@@ -20,7 +20,7 @@ namespace rubinius {
    *  @todo Document methods. --rue
    */
   class Roots : public LinkedList {
-    thread::Mutex lock_;
+    utilities::thread::Mutex lock_;
 
   public:   /* Ctors */
     Roots()

--- a/vm/gc/write_barrier.cpp
+++ b/vm/gc/write_barrier.cpp
@@ -26,7 +26,7 @@ namespace gc {
    * @param target The mature object to be added to the remember set.
    */
   void WriteBarrier::remember_object(Object* target) {
-    thread::SpinLock::LockGuard lg(lock_);
+    utilities::thread::SpinLock::LockGuard lg(lock_);
 
     assert(target->mature_object_p());
 
@@ -54,7 +54,7 @@ namespace gc {
    * to be removed from the remember set.
    */
   void WriteBarrier::unremember_object(Object* target) {
-    thread::SpinLock::LockGuard lg(lock_);
+    utilities::thread::SpinLock::LockGuard lg(lock_);
 
     for(ObjectArray::iterator oi = remember_set_->begin();
         oi != remember_set_->end();
@@ -72,7 +72,7 @@ namespace gc {
    * @param mark The mark bit pattern used on the last trace of live objects.
    */
   int WriteBarrier::unremember_objects(unsigned int mark) {
-    thread::SpinLock::LockGuard lg(lock_);
+    utilities::thread::SpinLock::LockGuard lg(lock_);
     int cleared = 0;
     Object* tmp;
 
@@ -105,7 +105,7 @@ namespace gc {
    * prior to this method being called.
    */
   ObjectArray* WriteBarrier::swap_remember_set() {
-    thread::SpinLock::LockGuard lg(lock_);
+    utilities::thread::SpinLock::LockGuard lg(lock_);
 
     ObjectArray* cur = remember_set_;
     remember_set_ = new ObjectArray(0);

--- a/vm/gc/write_barrier.hpp
+++ b/vm/gc/write_barrier.hpp
@@ -38,7 +38,7 @@ namespace gc {
 
   class WriteBarrier {
     /// Lock for synchronising multi-threaded updates to the remember set
-    thread::SpinLock lock_;
+    utilities::thread::SpinLock lock_;
 
   protected:
 

--- a/vm/global_cache.cpp
+++ b/vm/global_cache.cpp
@@ -87,7 +87,7 @@ keep_looking:
   }
 
   MethodCacheEntry* GlobalCache::lookup_public(STATE, Module* mod, Class* cls, Symbol* name) {
-    thread::SpinLock::LockGuard guard(lock_);
+    utilities::thread::SpinLock::LockGuard guard(lock_);
 
     Symbol* entry_name = entry_names[CPU_CACHE_HASH(mod, name)];
     CacheEntry* entry = entries + CPU_CACHE_HASH(mod, name);
@@ -104,7 +104,7 @@ keep_looking:
   }
 
   MethodCacheEntry* GlobalCache::lookup_private(STATE, Module* mod, Class* cls, Symbol* name) {
-    thread::SpinLock::LockGuard guard(lock_);
+    utilities::thread::SpinLock::LockGuard guard(lock_);
 
     Symbol* entry_name = entry_names[CPU_CACHE_HASH(mod, name)];
     CacheEntry* entry = entries + CPU_CACHE_HASH(mod, name);
@@ -124,7 +124,7 @@ keep_looking:
   }
 
   bool GlobalCache::resolve_i(STATE, Symbol* name, Dispatch& msg, LookupData& lookup) {
-    thread::SpinLock::LockGuard guard(lock_);
+    utilities::thread::SpinLock::LockGuard guard(lock_);
 
     Module* klass = lookup.from;
     CacheEntry* entry = this->lookup(state, klass, name);

--- a/vm/global_cache.hpp
+++ b/vm/global_cache.hpp
@@ -34,7 +34,7 @@ namespace rubinius {
 
     Symbol *entry_names[CPU_CACHE_SIZE];
     CacheEntry entries[CPU_CACHE_SIZE];
-    thread::SpinLock lock_;
+    utilities::thread::SpinLock lock_;
 
   public:
 
@@ -50,7 +50,7 @@ namespace rubinius {
     MethodCacheEntry* lookup_private(STATE, Module* mod, Class* cls, Symbol* name);
 
     void clear(STATE, Symbol* name) {
-      thread::SpinLock::LockGuard guard(lock_);
+      utilities::thread::SpinLock::LockGuard guard(lock_);
       for(size_t i = 0; i < CPU_CACHE_SIZE; i++) {
         if(entry_names[i] == name) {
           entry_names[i] = NULL;
@@ -60,7 +60,7 @@ namespace rubinius {
     }
 
     void clear(STATE, Module* cls, Symbol* name) {
-      thread::SpinLock::LockGuard guard(lock_);
+      utilities::thread::SpinLock::LockGuard guard(lock_);
       size_t i = CPU_CACHE_HASH(cls, name);
       if(entry_names[i] == name && entries[i].klass == cls) {
         entry_names[i] = NULL;
@@ -74,7 +74,7 @@ namespace rubinius {
 
     void retain(STATE, Module* cls, Symbol* name, Module* mod, Executable* meth,
                 bool missing, Symbol* visibility) {
-      thread::SpinLock::LockGuard guard(lock_);
+      utilities::thread::SpinLock::LockGuard guard(lock_);
       retain_i(state, cls, name, mod, meth, missing, visibility);
     }
 

--- a/vm/inline_cache.hpp
+++ b/vm/inline_cache.hpp
@@ -69,7 +69,7 @@ namespace rubinius {
 
     int seen_classes_overflow_;
     InlineCacheHit seen_classes_[cTrackedICHits];
-    thread::SpinLock private_lock_;
+    utilities::thread::SpinLock private_lock_;
 
   public:
 

--- a/vm/llvm/background_compile_request.hpp
+++ b/vm/llvm/background_compile_request.hpp
@@ -17,7 +17,7 @@ namespace rubinius {
     Object* extra_;
 
     bool is_block_;
-    thread::Condition* waiter_;
+    utilities::thread::Condition* waiter_;
 
   public:
     BackgroundCompileRequest(STATE, CompiledMethod* cm, Object* extra, bool is_block=false)
@@ -51,11 +51,11 @@ namespace rubinius {
       return is_block_;
     }
 
-    void set_waiter(thread::Condition* cond) {
+    void set_waiter(utilities::thread::Condition* cond) {
       waiter_ = cond;
     }
 
-    thread::Condition* waiter() {
+    utilities::thread::Condition* waiter() {
       return waiter_;
     }
 

--- a/vm/llvm/state.hpp
+++ b/vm/llvm/state.hpp
@@ -79,7 +79,7 @@ namespace rubinius {
 
     bool type_optz_;
 
-    thread::SpinLock method_update_lock_;
+    utilities::thread::SpinLock method_update_lock_;
 
   public:
 

--- a/vm/lock.hpp
+++ b/vm/lock.hpp
@@ -49,21 +49,21 @@ namespace rubinius {
     }
   };
 
-  class Mutex : public Lock, public thread::Mutex {
+  class Mutex : public Lock, public utilities::thread::Mutex {
   public:
     bool mutex_p() {
       return true;
     }
 
     void lock(ManagedThread* th) {
-      thread::Mutex::lock();
+      utilities::thread::Mutex::lock();
       locking_thread_ = th;
       lock_file_ = "unknown";
       lock_line_ = 0;
     }
 
     void lock(ManagedThread* th, const char* file, int line) {
-      thread::Mutex::lock();
+      utilities::thread::Mutex::lock();
       locking_thread_ = th;
       lock_file_ = file;
       lock_line_ = line;
@@ -71,27 +71,27 @@ namespace rubinius {
 
     void unlock(ManagedThread* th) {
       locking_thread_ = 0;
-      thread::Mutex::unlock();
+      utilities::thread::Mutex::unlock();
       lock_file_ = "";
       lock_line_ = 0;
     }
   };
 
-  class SpinLock : public Lock, public thread::SpinLock {
+  class SpinLock : public Lock, public utilities::thread::SpinLock {
   public:
     bool mutex_p() {
       return false;
     }
 
     void lock(ManagedThread* th) {
-      thread::SpinLock::lock();
+      utilities::thread::SpinLock::lock();
       locking_thread_ = th;
       lock_file_ = "unknown";
       lock_line_ = 0;
     }
 
     void lock(ManagedThread* th, const char* file, int line) {
-      thread::SpinLock::lock();
+      utilities::thread::SpinLock::lock();
       locking_thread_ = th;
       lock_file_ = file;
       lock_line_ = line;
@@ -99,7 +99,7 @@ namespace rubinius {
 
     void unlock(ManagedThread* th) {
       locking_thread_ = 0;
-      thread::SpinLock::unlock();
+      utilities::thread::SpinLock::unlock();
       lock_file_ = "";
       lock_line_ = 0;
     }

--- a/vm/objectmemory.cpp
+++ b/vm/objectmemory.cpp
@@ -132,7 +132,7 @@ namespace rubinius {
   bool ObjectMemory::inflate_lock_count_overflow(STATE, ObjectHeader* obj,
                                                  int count)
   {
-    thread::SpinLock::LockGuard guard(inflation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(inflation_lock_);
 
     // Inflation always happens with the ObjectMemory lock held, so we don't
     // need to worry about another thread concurrently inflating it.
@@ -222,7 +222,7 @@ step1:
         GCIndependent gc_guard(state);
 
         if(timed) {
-          timeout = (contention_var_.wait_until(contention_lock_, &ts) == thread::cTimedOut);
+          timeout = (contention_var_.wait_until(contention_lock_, &ts) == utilities::thread::cTimedOut);
           if(timeout) break;
         } else {
           contention_var_.wait(contention_lock_);
@@ -285,7 +285,7 @@ step1:
   }
 
   bool ObjectMemory::inflate_and_lock(STATE, ObjectHeader* obj) {
-    thread::SpinLock::LockGuard guard(inflation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(inflation_lock_);
 
     InflatedHeader* ih = 0;
     int initial_count = 0;
@@ -355,7 +355,7 @@ step1:
   }
 
   bool ObjectMemory::inflate_for_contention(STATE, ObjectHeader* obj) {
-    thread::SpinLock::LockGuard guard(inflation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(inflation_lock_);
 
     for(;;) {
       HeaderWord orig = obj->header;
@@ -420,7 +420,7 @@ step1:
   // WARNING: This returns an object who's body may not have been initialized.
   // It is the callers duty to initialize it.
   Object* ObjectMemory::new_object_fast(STATE, Class* cls, size_t bytes, object_type type) {
-    thread::SpinLock::LockGuard guard(allocation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(allocation_lock_);
 
     if(Object* obj = young_->raw_allocate(bytes, &collect_young_now)) {
       gc_stats.young_object_allocated(bytes);
@@ -435,7 +435,7 @@ step1:
   }
 
   bool ObjectMemory::refill_slab(STATE, gc::Slab& slab) {
-    thread::SpinLock::LockGuard guard(allocation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(allocation_lock_);
 
     Address addr = young_->allocate_for_slab(slab_size_);
 
@@ -674,7 +674,7 @@ step1:
   InflatedHeader* ObjectMemory::inflate_header(STATE, ObjectHeader* obj) {
     if(obj->inflated_header_p()) return obj->inflated_header();
 
-    thread::SpinLock::LockGuard guard(inflation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(inflation_lock_);
 
     // Gotta check again because while waiting for the lock,
     // the object could have been inflated!
@@ -693,7 +693,7 @@ step1:
   }
 
   void ObjectMemory::inflate_for_id(STATE, ObjectHeader* obj, uint32_t id) {
-    thread::SpinLock::LockGuard guard(inflation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(inflation_lock_);
 
     HeaderWord orig = obj->header;
 
@@ -831,7 +831,7 @@ step1:
   }
 
   Object* ObjectMemory::new_object_typed(STATE, Class* cls, size_t bytes, object_type type) {
-    thread::SpinLock::LockGuard guard(allocation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(allocation_lock_);
 
     Object* obj;
 
@@ -846,7 +846,7 @@ step1:
   }
 
   Object* ObjectMemory::new_object_typed_mature(STATE, Class* cls, size_t bytes, object_type type) {
-    thread::SpinLock::LockGuard guard(allocation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(allocation_lock_);
 
     Object* obj;
 
@@ -870,7 +870,7 @@ step1:
   }
 
   Object* ObjectMemory::new_object_typed_enduring(STATE, Class* cls, size_t bytes, object_type type) {
-    thread::SpinLock::LockGuard guard(allocation_lock_);
+    utilities::thread::SpinLock::LockGuard guard(allocation_lock_);
 
     Object* obj = mark_sweep_->allocate(bytes, &collect_mature_now);
     gc_stats.mature_object_allocated(bytes);
@@ -989,7 +989,7 @@ step1:
 
   void ObjectMemory::in_finalizer_thread(STATE) {
     CallFrame* call_frame = 0;
-    thread::Thread::set_os_name("rbx.finalizer");
+    utilities::thread::Thread::set_os_name("rbx.finalizer");
 
     // Forever
     for(;;) {

--- a/vm/objectmemory.hpp
+++ b/vm/objectmemory.hpp
@@ -132,8 +132,8 @@ namespace rubinius {
 
   class ObjectMemory : public gc::WriteBarrier, public Lockable {
 
-    thread::SpinLock allocation_lock_;
-    thread::SpinLock inflation_lock_;
+    utilities::thread::SpinLock allocation_lock_;
+    utilities::thread::SpinLock inflation_lock_;
 
     /// BakerGC used for the young generation
     BakerGC* young_;
@@ -177,13 +177,13 @@ namespace rubinius {
 
     /// A condition variable used to control access to
     /// to_finalize_
-    thread::Condition finalizer_var_;
+    utilities::thread::Condition finalizer_var_;
 
     /// Mutex used to manage lock contention
-    thread::Mutex contention_lock_;
+    utilities::thread::Mutex contention_lock_;
 
     /// Condition variable used to manage lock contention
-    thread::Condition contention_var_;
+    utilities::thread::Condition contention_var_;
 
     TypedRoot<Thread*> finalizer_thread_;
 

--- a/vm/oop.cpp
+++ b/vm/oop.cpp
@@ -58,7 +58,7 @@ namespace rubinius {
 
   bool InflatedHeader::update(STATE, HeaderWord header) {
     // Gain exclusive access to the insides of the InflatedHeader.
-    thread::Mutex::LockGuard lg(mutex_);
+    utilities::thread::Mutex::LockGuard lg(mutex_);
 
     flags_ = header.f;
 
@@ -766,7 +766,7 @@ step2:
       while(owner_id_ != 0) {
 
         if(ts) {
-          timeout = (condition_.wait_until(mutex_, ts) == thread::cTimedOut);
+          timeout = (condition_.wait_until(mutex_, ts) == utilities::thread::cTimedOut);
           if(timeout) break;
         } else {
           condition_.wait(mutex_);
@@ -931,7 +931,7 @@ step2:
   }
 
   void InflatedHeader::wakeup() {
-    thread::Mutex::LockGuard lg(mutex_);
+    utilities::thread::Mutex::LockGuard lg(mutex_);
     condition_.signal();
 
     if(cDebugThreading) {

--- a/vm/oop.hpp
+++ b/vm/oop.hpp
@@ -16,11 +16,12 @@
 #include "util/thread.hpp"
 #include "bug.hpp"
 
+namespace rubinius {
+namespace utilities {
 namespace thread {
   class Mutex;
 }
-
-namespace rubinius {
+}
 
 /* We use a variable length OOP tag system:
  * The tag represents 1 to 3 bits which uniquely
@@ -236,8 +237,8 @@ Object* const cUndef = reinterpret_cast<Object*>(0x22L);
     capi::Handle* handle_;
     uint32_t object_id_;
 
-    thread::Mutex mutex_;
-    thread::Condition condition_;
+    utilities::thread::Mutex mutex_;
+    utilities::thread::Condition condition_;
     uint32_t owner_id_;
     int rec_lock_count_;
 

--- a/vm/park.cpp
+++ b/vm/park.cpp
@@ -4,7 +4,7 @@
 
 namespace rubinius {
   void Park::park(STATE, CallFrame* call_frame) {
-    thread::Mutex::LockGuard lg(mutex_);
+    utilities::thread::Mutex::LockGuard lg(mutex_);
 
     wake_ = false;
     sleeping_ = true;
@@ -21,7 +21,7 @@ namespace rubinius {
   }
 
   bool Park::park_timed(STATE, CallFrame* call_frame, struct timespec* ts) {
-    thread::Mutex::LockGuard lg(mutex_);
+    utilities::thread::Mutex::LockGuard lg(mutex_);
 
     wake_ = false;
     sleeping_ = true;
@@ -32,7 +32,7 @@ namespace rubinius {
     while(!wake_) {
       GCIndependent gc_guard(state, call_frame);
 
-      if(cond_.wait_until(mutex_, ts) == thread::cTimedOut) {
+      if(cond_.wait_until(mutex_, ts) == utilities::thread::cTimedOut) {
         timeout = true;
         break;
       }

--- a/vm/park.hpp
+++ b/vm/park.hpp
@@ -7,8 +7,8 @@ namespace rubinius {
   struct CallFrame;
 
   class Park {
-    thread::Condition cond_;
-    thread::Mutex mutex_;
+    utilities::thread::Condition cond_;
+    utilities::thread::Mutex mutex_;
     bool sleeping_;
     bool wake_;
 
@@ -19,7 +19,7 @@ namespace rubinius {
     {}
 
     void unpark() {
-      thread::Mutex::LockGuard lg(mutex_);
+      utilities::thread::Mutex::LockGuard lg(mutex_);
       if(!sleeping_) return;
 
       wake_ = true;
@@ -27,7 +27,7 @@ namespace rubinius {
     }
 
     bool parked_p() {
-      thread::Mutex::LockGuard lg(mutex_);
+      utilities::thread::Mutex::LockGuard lg(mutex_);
       return sleeping_;
     }
 

--- a/vm/shared_state.hpp
+++ b/vm/shared_state.hpp
@@ -83,11 +83,11 @@ namespace rubinius {
     Environment* env_;
     tooling::ToolBroker* tool_broker_;
 
-    thread::Mutex onig_lock_;
+    utilities::thread::Mutex onig_lock_;
 
     // This lock is to implement Thread.critical. It is not critical as
     // the name would make it sound.
-    thread::Mutex ruby_critical_lock_;
+    utilities::thread::Mutex ruby_critical_lock_;
     pthread_t ruby_critical_thread_;
     bool ruby_critical_set_;
 
@@ -226,7 +226,7 @@ namespace rubinius {
       return env_;
     }
 
-    thread::Mutex& onig_lock() {
+    utilities::thread::Mutex& onig_lock() {
       return onig_lock_;
     }
 

--- a/vm/signal.cpp
+++ b/vm/signal.cpp
@@ -141,7 +141,7 @@ namespace rubinius {
 #endif
 
     GCTokenImpl gct;
-    thread::Thread::set_os_name("rbx.signal-dispatch");
+    utilities::thread::Thread::set_os_name("rbx.signal-dispatch");
 
     for(;;) {
       fd_set fds;

--- a/vm/signal.hpp
+++ b/vm/signal.hpp
@@ -23,7 +23,7 @@ namespace rubinius {
 
     int pending_signals_[NSIG];
     int queued_signals_;
-    thread::SpinLock lock_;
+    utilities::thread::SpinLock lock_;
     int read_fd_;
     int write_fd_;
     bool exit_;

--- a/vm/symboltable.cpp
+++ b/vm/symboltable.cpp
@@ -117,7 +117,7 @@ namespace rubinius {
     // Symbols can be looked up by multiple threads at the same time.
     // This is fast operation, so we protect this with a spinlock.
     {
-      thread::SpinLock::LockGuard guard(lock_);
+      utilities::thread::SpinLock::LockGuard guard(lock_);
       SymbolMap::iterator entry = symbols.find(hash);
       if(entry == symbols.end()) {
         sym = add(std::string(str, length));

--- a/vm/symboltable.hpp
+++ b/vm/symboltable.hpp
@@ -56,7 +56,7 @@ namespace rubinius {
     SymbolMap symbols;
     SymbolStrings strings;
     SymbolKinds kinds;
-    thread::SpinLock lock_;
+    utilities::thread::SpinLock lock_;
     size_t bytes_used_;
 
     Symbol* lookup(const char* str, size_t length, uint32_t seed);

--- a/vm/util/allocator.hpp
+++ b/vm/util/allocator.hpp
@@ -11,7 +11,7 @@ namespace rubinius {
     uintptr_t free_list_;
     size_t allocations_;
     size_t in_use_;
-    thread::SpinLock lock_;
+    utilities::thread::SpinLock lock_;
 
     static const size_t cChunkSize = 1024;
     static const size_t cChunkLimit = 128;
@@ -51,7 +51,7 @@ namespace rubinius {
     }
 
     T* allocate(bool* needs_gc) {
-      thread::SpinLock::LockGuard lg(lock_);
+      utilities::thread::SpinLock::LockGuard lg(lock_);
       if(free_list_ == (uintptr_t)-1) allocate_chunk(needs_gc);
       T* t = from_index(free_list_);
       free_list_ = t->next();
@@ -63,7 +63,7 @@ namespace rubinius {
     }
 
     uintptr_t allocate_index(bool* needs_gc) {
-      thread::SpinLock::LockGuard lg(lock_);
+      utilities::thread::SpinLock::LockGuard lg(lock_);
       if(free_list_ == (uintptr_t)-1) allocate_chunk(needs_gc);
 
       uintptr_t current_index = free_list_;

--- a/vm/util/thread.hpp
+++ b/vm/util/thread.hpp
@@ -27,6 +27,9 @@ extern "C" int pthread_setname_np(const char*);
 #define HAVE_PTHREAD_SETNAME
 #endif
 
+namespace rubinius {
+namespace utilities {
+
 namespace thread {
 
   static inline void fail(const char* str) {
@@ -489,11 +492,15 @@ namespace thread {
     }
   };
 }
+}
+}
 
 #ifdef HAVE_OSX_SPINLOCK
 
 #include <libkern/OSAtomic.h>
 
+namespace rubinius {
+namespace utilities {
 namespace thread {
 
   class SpinLock {
@@ -537,9 +544,13 @@ namespace thread {
     }
   };
 };
+}
+}
 
 #else
 
+namespace rubinius {
+namespace utilities {
 namespace thread {
   class SpinLock {
   public: // Types
@@ -583,6 +594,8 @@ namespace thread {
       return ss.str();
     }
   };
+}
+}
 }
 
 #endif

--- a/vm/vm.cpp
+++ b/vm/vm.cpp
@@ -112,7 +112,7 @@ namespace rubinius {
 
   void VM::initialize_as_root() {
 
-    thread::Thread::set_os_name("rbx.ruby.main");
+    utilities::thread::Thread::set_os_name("rbx.ruby.main");
 
     om = new ObjectMemory(this, shared.config);
     shared.om = om;

--- a/vm/vm.hpp
+++ b/vm/vm.hpp
@@ -473,11 +473,11 @@ namespace rubinius {
   };
 
   template <class T>
-  class GCIndependentLockGuard : public thread::LockGuardTemplate<T> {
+  class GCIndependentLockGuard : public utilities::thread::LockGuardTemplate<T> {
     State* state_;
   public:
     GCIndependentLockGuard(STATE, GCToken gct, T& in_lock)
-      : thread::LockGuardTemplate<T>(in_lock, false)
+      : utilities::thread::LockGuardTemplate<T>(in_lock, false)
       , state_(state)
     {
       state_->shared().gc_independent(state_);
@@ -490,7 +490,7 @@ namespace rubinius {
     }
   };
 
-   typedef GCIndependentLockGuard<thread::Mutex> GCLockGuard;
+   typedef GCIndependentLockGuard<utilities::thread::Mutex> GCLockGuard;
 };
 
 #endif


### PR DESCRIPTION
As agreed on, this commit moves `thread` under `rubinius::utilities::thread`. Every references to `thread` are changed to refer to `utilities::thread` not to `rubinius::utilities::thread`, because they are referencing from `rubinius::`.

Buildable and no spec failure.

Alternatively, we could use `using namespace rubinius::utilities;`. If it is better, I'll updatre this pull request accordingly. :)
