### PR TITLE
Fix build on FreeBSD.

### DIFF
--- a/vm/agent.cpp
+++ b/vm/agent.cpp
@@ -40,7 +40,9 @@
 #endif
 
 #ifdef __FreeBSD__
+#define thread	freebsd_thread
 #include <sys/sysctl.h>
+#undef thread
 #endif
 
 namespace rubinius {


### PR DESCRIPTION
FreeBSD's sys/sysctl.h exposes the 'struct thread' definition
which conflicts with the rubinius one.  Fix build by redefining
it for the duration of the include file processing.
