### PR TITLE
Add Sprinter#print_built_method

### DIFF
--- a/kernel/common/sprinter.rb
+++ b/kernel/common/sprinter.rb
@@ -49,6 +49,13 @@ module Rubinius
       end
     end
 
+    def debug_print
+      printer = Compiler::MethodPrinter.new
+      printer.input(method(:call).executable)
+      printer.bytecode = true
+      printer.run
+    end
+
     def zero_two_expand_integer(int)
       int = Integer(int) unless int.kind_of? Fixnum
 


### PR DESCRIPTION
This is a helper method for debugging purpose.

I found it to be useful when investigating how Sprinter works.
