### PR TITLE
Remove add_feature from ensure block

### DIFF
--- a/kernel/delta/codeloader.rb
+++ b/kernel/delta/codeloader.rb
@@ -40,10 +40,11 @@ module Rubinius
 
       CodeLoader.loaded_hook.trigger!(@path)
 
+      add_feature
+
       return true
     ensure
-      add_feature
-      req.remove!
+      req.remove! if req
 
       CodeLoader.check_version = saved_check
       CodeLoader.source_extension = saved_extension

--- a/spec/core/codeloader/require_compiled_spec.rb
+++ b/spec/core/codeloader/require_compiled_spec.rb
@@ -29,4 +29,10 @@ describe "Rubinius::CodeLoader#require_compiled" do
     @loader.require_compiled(@rbc).should be_true
     $LOADED_FEATURES.should == [@rb]
   end
+
+  it "raise an exception if loader can not load the file" do
+    lambda {
+      Rubinius::CodeLoader.require_compiled("not_an_existing_file")
+    }.should raise_error(LoadError)
+  end
 end


### PR DESCRIPTION
When require method raise LoadError @feature instance is not set.
We need to check also check that req local variable is set. Because
require method could raise exception.

**Before patch**

``` ruby

rubinius-2.0.0dev :001 > Rubinius::CodeLoader.require_compiled("lib")
NoMethodError: undefined method `suffix?' on nil:NilClass.
    from kernel/delta/kernel.rb:81:in `suffix? (method_missing)'
    from kernel/delta/codeloader.rb:76:in `add_feature'
    from kernel/delta/codeloader.rb:45:in `require_compiled'
    from kernel/delta/codeloader.rb:105:in `require_compiled'
    from (irb):1
    from kernel/common/block_environment.rb:75:in `call_on_instance'
    from kernel/common/eval.rb:72:in `eval'
    from kernel/common/kernel19.rb:42:in `loop'
    from kernel/common/throw_catch19.rb:8:in `catch'
    from kernel/common/throw_catch.rb:10:in `register'
    from kernel/common/throw_catch19.rb:7:in `catch'
    from kernel/common/throw_catch19.rb:8:in `catch'
    from kernel/common/throw_catch.rb:10:in `register'
    from kernel/common/throw_catch19.rb:7:in `catch'
    from kernel/common/codeloader.rb:207:in `require'
    from kernel/common/kernel.rb:631:in `gem_original_require (require)'
    from /home/lite/.rvm/rubies/rbx-head/lib/rubygems/custom_require.rb:36:in `require'
    from kernel/loader.rb:706:in `irb'
    from kernel/loader.rb:845:in `main'rubinius-2.0.0dev :002 > 
```

**After patch**

``` ruby
rbx-head :001 > Rubinius::CodeLoader.require_compiled("lib")
LoadError: no such file to load -- lib
    from kernel/common/codeloader.rb:390:in `load_error'
    from kernel/common/codeloader.rb:377:in `resolve_require_path'
    from kernel/common/codeloader.rb:104:in `require'
    from kernel/bootstrap/rubinius.rb:145:in `synchronize'
    from kernel/common/codeloader.rb:103:in `require'
    from kernel/delta/codeloader.rb:37:in `require_compiled'
    from kernel/delta/codeloader.rb:106:in `require_compiled'
    from (irb):1
    from kernel/common/block_environment.rb:75:in `call_on_instance'
    from kernel/common/eval.rb:72:in `eval'
    from kernel/common/kernel19.rb:42:in `loop'
    from kernel/common/throw_catch19.rb:8:in `catch'
    from kernel/common/throw_catch.rb:10:in `register'
    from kernel/common/throw_catch19.rb:7:in `catch'
    from kernel/common/throw_catch19.rb:8:in `catch'
    from kernel/common/throw_catch.rb:10:in `register'
    from kernel/common/throw_catch19.rb:7:in `catch'
    from kernel/common/codeloader.rb:212:in `require'
    from kernel/common/kernel.rb:631:in `gem_original_require (require)'
    from /home/lite/work/rubinius/lib/rubygems/custom_require.rb:36:in `require'
    from kernel/loader.rb:698:in `irb'
    from kernel/loader.rb:836:in `main'rbx-head :002 > 
```
