### PR TITLE
Support Struct attribute names with a hyphen

### DIFF
--- a/spec/ruby/core/struct/element_reference_spec.rb
+++ b/spec/ruby/core/struct/element_reference_spec.rb
@@ -41,4 +41,12 @@ describe "Struct#[]" do
     car = StructClasses::Car.new('Ford', 'Ranger')
     lambda { car[Object.new] }.should raise_error(TypeError)
   end
+
+  it "returns attribute names that contain hyphens" do
+    klass = Struct.new(:'current-state')
+    tuple = klass.new(0)
+    tuple['current-state'].should == 0
+    tuple[:'current-state'].should == 0
+    tuple[0].should == 0
+  end
 end

--- a/spec/ruby/core/struct/struct_spec.rb
+++ b/spec/ruby/core/struct/struct_spec.rb
@@ -31,14 +31,6 @@ describe "Struct anonymous class instance methods" do
   end
 end
 
-describe "Struct attributes" do
-  it "name may contain hyphens" do
-    klass = Struct.new(:'current-state', :symbol, :'next-state', :action)
-    tuple = klass.new(0, 1, 0, :>>)
-    tuple['current-state'].should == 0
-  end
-end
-
 describe "Struct subclasses" do
   it "can be subclassed" do
     compact = Class.new StructClasses::Car


### PR DESCRIPTION
The Struct._specialize method (called when creating new
structs) generates code containing the attribute names.
If a name contains a hyphen this previously led to invalid
code (raising a runtime error because the hyphen was
interpreted as a minus). For example, the following Struct
creation:

```
klass = Struct.new(:'foo-bar')
```

Led to the following code:

```
def initialize(a0 = nil)
  @foo-bar = a0
  self
end
```

This commit changes all access to the instance variables
to use instance_variable_get and set respectively.
