### PR TITLE
Fix Rubinius.current_file

### DIFF
--- a/kernel/delta/rubinius.rb
+++ b/kernel/delta/rubinius.rb
@@ -273,6 +273,6 @@ module Rubinius
   #
   def self.current_file
     cs = Rubinius::ConstantScope.of_sender
-    return ss.absolute_active_path
+    return cs.absolute_active_path
   end
 end


### PR DESCRIPTION
It was using the wrong local variable name (left over from the StaticScope => ConstantScope name change, I assume)
