### PR TITLE
lib/timeout.rb: In Ruby 1.9, Timeout::Error is a kind of RuntimeError

### DIFF
--- a/lib/timeout.rb
+++ b/lib/timeout.rb
@@ -35,7 +35,12 @@ module Timeout
   ##
   # Raised by Timeout#timeout when the block times out.
 
-  class Error<Interrupt
+  if RUBY_VERSION >= '1.9'
+    class Error<RuntimeError
+    end
+  else
+    class Error<Interrupt
+    end
   end
 
   # A mutex to protect @requests


### PR DESCRIPTION
Thanks!
