### PR TITLE
Ruby 1.9 should not have defined RB_CVAR_SET_4_ARGS

### DIFF
--- a/vm/capi/19/include/ruby/intern.h
+++ b/vm/capi/19/include/ruby/intern.h
@@ -1,5 +1,3 @@
 /* Stub file provided for C extensions that expect it. All regular
  * defines and prototypes are in ruby.h
  */
-
-#define RB_CVAR_SET_4ARGS 1


### PR DESCRIPTION
Since 1.9.1 ruby don't use 4th argument from calls to rb_cvar_set

Fixes #1843
