### PR TITLE
Fixes clang[++] build failure on Apple Clang 4.0.

### DIFF
--- a/lib/ext/melbourne/Rakefile
+++ b/lib/ext/melbourne/Rakefile
@@ -64,8 +64,8 @@ when ["build:build"]
     add_cflag "-g"
     add_cxxflag "-g"
     if ENV['DEV']
-      add_cflag "-O0 -ggdb3"
-      add_cxxflag "-O0 -ggdb3"
+      add_cflag "-O0"
+      add_cxxflag "-O0"
     else
       add_cflag "-O2"
       add_cxxflag "-O2"

--- a/lib/rbconfig.rb
+++ b/lib/rbconfig.rb
@@ -122,7 +122,7 @@ module RbConfig
   CONFIG["CFLAGS"]             = "-g -fPIC"
   CONFIG["LDFLAGS"]            = ""
   if ENV['DEV']
-    CONFIG["CFLAGS"] << " -O0 -ggdb3"
+    CONFIG["CFLAGS"] << " -O0 "
   else
     CONFIG["CFLAGS"] << " -O2"
   end

--- a/rakelib/blueprint.rb
+++ b/rakelib/blueprint.rb
@@ -25,7 +25,7 @@ Daedalus.blueprint do |i|
   gcc.cflags << Rubinius::BUILD_CONFIG[:user_cflags]
 
   if ENV['DEV']
-    gcc.cflags << "-O0 -ggdb3"
+    gcc.cflags << "-O0"
     gcc.mtime_only = true
   else
     gcc.cflags << "-O2"

--- a/rakelib/ext_helper.rb
+++ b/rakelib/ext_helper.rb
@@ -141,8 +141,8 @@ def add_rbx_capi
   add_cflag "-g"
   add_cxxflag "-g"
   if ENV['DEV']
-    add_cflag "-O0 -ggdb3"
-    add_cxxflag "-O0 -ggdb3"
+    add_cflag "-O0"
+    add_cxxflag "-O0"
   else
     add_cflag "-O2"
     add_cxxflag "-O2"

--- a/vm/test/one.sh
+++ b/vm/test/one.sh
@@ -10,4 +10,4 @@ fi
 
 vm/test/cxxtest/cxxtestgen.pl --error-printer --have-eh --abort-on-fail --include=string.h -o vm/test/one.cpp "$*"
 
-g++ $FLAGS -ggdb3 -g -Wall -Werror -Ivendor/libtommath -Ivm/test/cxxtest -I. -Ivm -o vm/test/one vm/test/one.cpp && ./vm/test/one
+g++ $FLAGS -g -Wall -Werror -Ivendor/libtommath -Ivm/test/cxxtest -I. -Ivm -o vm/test/one vm/test/one.cpp && ./vm/test/one


### PR DESCRIPTION
This fixes a build failure on Apple Mac OS X 10.8 "Mountain Lion" when building with Apple Clang 4.0 (from Xcode). (See https://gist.github.com/6d03ae640101d96d6193).

I'm not too knowledgable about hacking build scripts, so feel free to tell me to change something.

Thanks!
