### PR TITLE
Added spec for DateTime.parse

### DIFF
--- a/spec/ruby/library/datetime/parse_spec.rb
+++ b/spec/ruby/library/datetime/parse_spec.rb
@@ -75,7 +75,7 @@ describe "DateTime.parse" do
     it "truncates seconds down to 59" do
       d = DateTime.parse("2012-11-08T15:43:61")
 
-      d.strftime('%c').should == DateTime.civil(2012, 11, 8, 15, 43, 59).strftime('%c')
+      d.should == DateTime.civil(2012, 11, 8, 15, 43, 59)
     end
 
   end


### PR DESCRIPTION
I'm adding this spec as I believe it may highlight a bug in all ruby implementations of DateTime.parse

Namely that seconds greater than 59 are parsed as 59 whereas hours, minutes, etc. with incorrect values raise an ArgumentError.

Also according to the iso8601 spec http://en.wikipedia.org/wiki/ISO_8601, 60 seconds is a valid value as it can be used to represent a leap second.
