### PR TITLE
Failing spec for String#tr.

### DIFF
--- a/spec/ruby/core/string/tr_spec.rb
+++ b/spec/ruby/core/string/tr_spec.rb
@@ -7,6 +7,10 @@ describe "String#tr" do
     "hello".tr('aeiou', '*').should == "h*ll*"
     "hello".tr('el', 'ip').should == "hippo"
     "Lisp".tr("Lisp", "Ruby").should == "Ruby"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".tr(
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+      "2223334445556667777888999922233344455566677778889999"
+    ).should == "2223334445556667777888999922233344455566677778889999"
   end
 
   it "accepts c1-c2 notation to denote ranges of characters" do


### PR DESCRIPTION
`"hello".tr("helo", "1212").should == "12112"` but incorrectly results in `"122222"`. The pull request contains a more comprehensive example.

Please also see https://github.com/rubinius/rubinius/issues/1871 for a more in-depth description of the problem.
