### PR TITLE
Fix for Matrix.hermitian?

### DIFF
--- a/lib/19/matrix.rb
+++ b/lib/19/matrix.rb
@@ -614,7 +614,7 @@ class Matrix
   #
   def hermitian?
     Matrix.Raise ErrDimensionMismatch unless square?
-    each_with_index(:strict_upper).all? do |e, row, col|
+    each_with_index(:upper).all? do |e, row, col|
       e == rows[col][row].conj
     end
   end

--- a/spec/tags/19/ruby/library/matrix/hermitian_tags.txt
+++ b/spec/tags/19/ruby/library/matrix/hermitian_tags.txt
@@ -1,1 +1,0 @@
-fails:Matrix.hermitian? returns false for a matrix with complex values on the diagonal


### PR DESCRIPTION
Fix for ruby 1.9 compatibility.
When there are complex values on the matrix diagonal then `hermitian?` must return false.
