### PR TITLE
Completely fix deadlocks of Thread#raise

### DIFF
--- a/kernel/bootstrap/rubinius.rb
+++ b/kernel/bootstrap/rubinius.rb
@@ -119,6 +119,11 @@ module Rubinius
     raise PrimitiveFailure, "Rubinius.lock primitive failed"
   end
 
+  def self.uninterrupted_lock(obj)
+    Rubinius.primitive :vm_object_uninterrupted_lock
+    raise PrimitiveFailure, "Rubinius.uninterrupted_lock primitive failed"
+  end
+
   def self.lock_timed(obj, duration)
     Rubinius.primitive :vm_object_lock_timed
     raise PrimitiveFailure, "Rubinius.lock primitive failed"
@@ -191,6 +196,11 @@ module Rubinius
   def self.thread_state
     Rubinius.primitive :vm_thread_state
     raise PrimitiveFailure, "Rubinius.thread_state primitive failed"
+  end
+
+  def self.check_interrupts
+    Rubinius.primitive :vm_check_interrupts
+    raise PrimitiveFailure, "Rubinius.check_interrupts primitive failed"
   end
 
   # Used to invoke a CompiledCode instance as a script body.  Sets up the MAIN

--- a/kernel/bootstrap/thread.rb
+++ b/kernel/bootstrap/thread.rb
@@ -264,12 +264,14 @@ class Thread
         STDERR.puts "Exception: #{exc.message} (#{exc.class})"
       end
 
-      Kernel.raise exc if self == Thread.current
+      if self == Thread.current
+        Kernel.raise exc
+      else
+        raise_prim exc
+      end
     ensure
       Rubinius.unlock(self)
     end
-
-    raise_prim exc
   end
   private :raise_prim
 

--- a/kernel/bootstrap/thread19.rb
+++ b/kernel/bootstrap/thread19.rb
@@ -41,8 +41,29 @@ class Thread
         Rubinius.unlock(self)
         @result = @block.call(*@args)
       ensure
-        Rubinius.lock(self)
-        @joins.each { |join| join.send self }
+        begin
+          # We must lock self in a careful way.
+          #
+          # At this point, it's possible that an other thread does Thread#raise
+          # and then our execution is interrupted AT ANY GIVEN TIME. We
+          # absolutely must make sure to lock self as soon as possible to lock
+          # out interrupts from other threads.
+          #
+          # Rubinius.uninterrupted_lock(self) just does that.
+          #
+          # Notice that this can't be moved to other methods and there should be
+          # no preceding code before it in the enclosing ensure clause.
+          # These are to prevent any interrupted lock failures.
+          Rubinius.uninterrupted_lock(self)
+
+          # Now, we locked self. No other thread can interrupt this thread
+          # anymore.
+          # If there is any not-triggered interrupt, check and process it. In
+          # either case, we jump to the following ensure clause.
+          Rubinius.check_interrupts
+        ensure
+          @joins.each { |join| join.send self }
+        end
       end
     rescue Die
       @killed = true

--- a/vm/builtin/system.hpp
+++ b/vm/builtin/system.hpp
@@ -190,6 +190,9 @@ namespace rubinius {
     // Rubinius.primitive :vm_sleep
     static Object*  vm_sleep(STATE, GCToken gct, Object* duration, CallFrame* calling_environment);
 
+    // Rubinius.primitive :vm_check_interrupts
+    static Object*  vm_check_interrupts(STATE, CallFrame* calling_environment);
+
     // Rubinius.primitive :vm_times
     static Array*   vm_times(STATE);
 
@@ -322,6 +325,9 @@ namespace rubinius {
 
     // Rubinius.primitive :vm_object_lock
     static Object* vm_object_lock(STATE, GCToken gct, Object* obj, CallFrame* calling_environment);
+
+    // Rubinius.primitive :vm_object_uninterrupted_lock
+    static Object* vm_object_uninterrupted_lock(STATE, GCToken gct, Object* obj, CallFrame* calling_environment);
 
     // Rubinius.primitive :vm_object_lock_timed
     static Object* vm_object_lock_timed(STATE, GCToken gct, Object* obj, Integer* time, CallFrame* calling_environment);

--- a/vm/objectmemory.cpp
+++ b/vm/objectmemory.cpp
@@ -154,7 +154,7 @@ namespace rubinius {
   }
 
   LockStatus ObjectMemory::contend_for_lock(STATE, GCToken gct, ObjectHeader* obj,
-                                            bool* error, size_t us)
+                                            bool* error, size_t us, bool interrupt)
   {
     bool timed = false;
     bool timeout = false;
@@ -233,7 +233,7 @@ step1:
         }
 
         // Someone is interrupting us trying to lock.
-        if(state->vm()->check_local_interrupts) {
+        if(interrupt && state->vm()->check_local_interrupts) {
           state->vm()->check_local_interrupts = false;
 
           if(!state->vm()->interrupted_exception()->nil_p()) {
@@ -273,9 +273,9 @@ step1:
     InflatedHeader* ih = obj->inflated_header();
 
     if(timed) {
-      return ih->lock_mutex_timed(state, gct, &ts);
+      return ih->lock_mutex_timed(state, gct, &ts, interrupt);
     } else {
-      return ih->lock_mutex(state, gct);
+      return ih->lock_mutex(state, gct, 0, interrupt);
     }
   }
 

--- a/vm/objectmemory.hpp
+++ b/vm/objectmemory.hpp
@@ -320,7 +320,7 @@ namespace rubinius {
     void assign_object_id(STATE, Object* obj);
     Integer* assign_object_id_ivar(STATE, Object* obj);
     bool inflate_lock_count_overflow(STATE, ObjectHeader* obj, int count);
-    LockStatus contend_for_lock(STATE, GCToken gct, ObjectHeader* obj, bool* error, size_t us=0);
+    LockStatus contend_for_lock(STATE, GCToken gct, ObjectHeader* obj, bool* error, size_t us, bool interrupt);
     void release_contention(STATE, GCToken gct);
     bool inflate_and_lock(STATE, ObjectHeader* obj);
     bool inflate_for_contention(STATE, ObjectHeader* obj);

--- a/vm/oop.hpp
+++ b/vm/oop.hpp
@@ -304,8 +304,8 @@ Object* const cUndef = reinterpret_cast<Object*>(0x22L);
 
     bool update(STATE, HeaderWord header);
     void initialize_mutex(int thread_id, int count);
-    LockStatus lock_mutex(STATE, GCToken gct, size_t us=0);
-    LockStatus lock_mutex_timed(STATE, GCToken gct, const struct timespec* ts);
+    LockStatus lock_mutex(STATE, GCToken gct, size_t us, bool interrupt);
+    LockStatus lock_mutex_timed(STATE, GCToken gct, const struct timespec* ts, bool interrupt);
     LockStatus try_lock_mutex(STATE, GCToken gct);
     bool locked_mutex_p(STATE, GCToken gct);
     LockStatus unlock_mutex(STATE, GCToken gct);
@@ -638,7 +638,7 @@ Object* const cUndef = reinterpret_cast<Object*>(0x22L);
 
     void set_object_id(STATE, ObjectMemory* om, uint32_t id);
 
-    LockStatus lock(STATE, GCToken gct, size_t us=0);
+    LockStatus lock(STATE, GCToken gct, size_t us=0, bool interrupt=true);
     LockStatus try_lock(STATE, GCToken gct);
     bool locked_p(STATE, GCToken gct);
     LockStatus unlock(STATE, GCToken gct);


### PR DESCRIPTION
For details see the commit message.

I have a question. As far as I understand, waiting_channel_ seems to be doing a bad thing. So I just removed it. And there is no spec failures. However, is it really OK to remove it? Should I resolve to other approaches?? Also I can't tell very well why there exists waiting_channel for what kind of use cases, first of all. I'd like to be enlightened :)
