### PR TITLE
Use Rubinius.lock instead of Channel

### DIFF
--- a/kernel/bootstrap/thread19.rb
+++ b/kernel/bootstrap/thread19.rb
@@ -38,11 +38,10 @@ class Thread
   def __run__()
     begin
       begin
-        @lock.send nil
+        Rubinius.unlock(self)
         @result = @block.call(*@args)
       ensure
-        @lock.receive
-        unlock_locks
+        Rubinius.lock(self)
         @joins.each { |join| join.send self }
       end
     rescue Die
@@ -54,7 +53,8 @@ class Thread
       @exception = e # unless @dying
     ensure
       @alive = false
-      @lock.send nil
+      Rubinius.unlock(self)
+      unlock_locks
     end
 
     if @exception
@@ -73,8 +73,6 @@ class Thread
     @exception = nil
     @critical = false
     @dying = false
-    @lock = Rubinius::Channel.new
-    @lock.send nil if prime_lock
     @joins = []
     @killed = false
   end

--- a/vm/builtin/thread.hpp
+++ b/vm/builtin/thread.hpp
@@ -249,6 +249,7 @@ namespace rubinius {
     static Thread* create(STATE, VM* target, Object* self, Run runner,
                           bool main_thread = false);
 
+    int start_new_thread(STATE, const pthread_attr_t &attrs);
     static void* in_new_thread(void*);
 
   public:   /* TypeInfo */


### PR DESCRIPTION
Hi, As discussed earlier, I made thread use Rubinius.{lock, unlock, synchronize} instead of Channel.

Mostly, this was a straight forward transition.

I commented wherever I thought the code needed to be commented. If there are any other unclear code, please let me know. I'll add comments. :)

Also, because I'm not a Rubinius locking expert, I may be plain wrong.. :p

Any comments are very appreciated!
