### PR TITLE
Add terminel width fallback.

### DIFF
--- a/kernel/delta/rubinius.rb
+++ b/kernel/delta/rubinius.rb
@@ -295,7 +295,7 @@ module Rubinius
         end
       end
     end
-    @terminal_width = 80 if @terminal_width.zero?
+    @terminal_width = 80 if @terminal_width.nil? || @terminal_width.zero?
     @terminal_width
   end
 


### PR DESCRIPTION
This provides fallback terminal width, in case there cannot be detected
any. This fixes several test suite issues when building RPM package for Fedora.
