### PR TITLE
Discard OpenBSD release number in config[:os]

### DIFF
--- a/configure
+++ b/configure
@@ -28,6 +28,7 @@ class Configure
     @host = `sh -c ./rakelib/config.guess`.chomp
     /([^-]+)-([^-]+)-(.*)/ =~ @host
     @cpu, @vendor, @os = $1, $2, $3
+    @os.sub! /openbsd[0-9\.]*$/, "openbsd" # Discard OpenBSD version number
     @little_endian = false
     @sizeof = {}
 


### PR DESCRIPTION
The rationale for this is as follows.

OpenBSD has a continuous evolution release model. The release numbers change twice a year like clockwork and reflect the release process phases rather than revolutionary changes of the platform (which are intentionally kept to a minimum). The system probably doesn't change radically enough to merit a release number in the os name here.  OpenBSD is OpenBSD.

http://www.openbsd.org/papers/asiabsdcon2009-release_engineering/mgp00017.html

Notice also that the release number does not follow the major/minor convention, for obvious reasons. Release 5.0 was simply the next release after 4.9.
