### PR TITLE
Use timelocal instead of mktime in timelocal64 in OpenBSD

### DIFF
--- a/vm/util/time64.c
+++ b/vm/util/time64.c
@@ -338,7 +338,11 @@ time64_t mktime64(struct tm64* tm64) {
 }
 
 time64_t timelocal64(struct tm64* tm64) {
+#ifdef __OpenBSD__
+  return timestamp64(timelocal, tm64);
+#else
   return timestamp64(mktime, tm64);
+#endif
 }
 
 time64_t timegm64(struct tm64* tm64) {


### PR DESCRIPTION
OpenBSD is pernickerty about struct_tm in mktime. Setting tm_isdst to -1 prior to calling mktime (which is what timelocal does) makes mktime less pedantic.
