### PR TITLE
Keep runtimedir and kernel dir at the same level as libdir.

### DIFF
--- a/configure
+++ b/configure
@@ -180,8 +180,8 @@ class Configure
     @prefixdir    = @sourcedir unless @prefixdir
     @bindir       = @prefixdir + "/bin" unless @bindir
     @libdir       = @prefixdir + "/lib" unless @libdir
-    @runtimedir   = @prefixdir + "/runtime" unless @runtimedir
-    @kerneldir    = @prefixdir + "/kernel" unless @kerneldir
+    @runtimedir   = File.expand_path "../runtime", @libdir
+    @kerneldir    = File.expand_path "../kernel", @libdir
     @sitedir      = @prefixdir + "/site" unless @sitedir
     @vendordir    = @prefixdir + "/vendor" unless @vendordir
     @mandir       = @prefixdir + "/man" unless @mandir


### PR DESCRIPTION
It seems that there are some assumptions about some libraries placement. In my case, when I use the `--libdir` configure option, build breaks with error

```
LDSHARED build/melbourne20.so
rake aborted!
cannot load such file -- /builddir/build/BUILD/rubinius-rubinius-aac4fb6/staging/usr/lib64/kernel/common/compiled_code
Tasks: TOP => build => build:build => kernel:build => compiler:load
(See full trace by running task with --trace)
```

The error is due to these two lines [1]. Since there is this assumption (and I am not sure it can be removed), the configure script should be fixed accordingly. Additional argument is that neither `kernledir` nor `runtimedir` are configurable, so the `unless` section is useless.

[1] https://github.com/rubinius/rubinius/blob/master/lib/mri_bridge.rb#L68-L69
