### PR TITLE
OpenBSD chmod accepts all values of mode

### DIFF
--- a/spec/ruby/core/file/chmod_spec.rb
+++ b/spec/ruby/core/file/chmod_spec.rb
@@ -15,7 +15,7 @@ describe "File#chmod" do
     @file.chmod(0755).should == 0
   end
 
-  platform_is_not :freebsd, :netbsd, :openbsd do
+  platform_is_not :freebsd, :netbsd do
     it "always succeeds with any numeric values" do
       vals = [-2**30, -2**16, -2**8, -2, -1,
         -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8, 2**16, 2**30]
@@ -37,16 +37,6 @@ describe "File#chmod" do
     end
   end
 
-  # -256, -2 and -1 raise Errno::EINVAL on OpenBSD
-  platform_is :openbsd do
-    it "always succeeds with any numeric values" do
-      vals = [#-2**30, -2**16, -2**8, -2, -1,
-        -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8]#, 2**16, 2**30
-      vals.each { |v|
-        lambda { @file.chmod(v) }.should_not raise_error
-      }
-    end
-  end
   it "invokes to_int on non-integer argument" do
     mode = File.stat(@filename).mode
     (obj = mock('mode')).should_receive(:to_int).and_return(mode)
@@ -121,7 +111,7 @@ describe "File.chmod" do
     @count.should == 1
   end
 
-  platform_is_not :freebsd, :netbsd, :openbsd do
+  platform_is_not :freebsd, :netbsd do
     it "always succeeds with any numeric values" do
       vals = [-2**30, -2**16, -2**8, -2, -1,
         -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8, 2**16, 2**30]
@@ -139,22 +129,6 @@ describe "File.chmod" do
         -0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8, 2**16, 2**30]
       vals.each { |v|
         lambda { File.chmod(v, @file) }.should_not raise_error
-      }
-    end
-  end
-
-  platform_is :openbsd do
-    it "succeeds with valid values" do
-      vals = [-0.5, 0, 1, 2, 5.555575, 16, 32, 64, 2**8]
-      vals.each { |v|
-        lambda { File.chmod(v, @file) }.should_not raise_error
-      }
-    end
-
-    it "fails with invalid values" do
-      vals = [-2**30, -2**16, -2**8, -2, -1, 2**16, 2**30]
-      vals.each { |v|
-        lambda { File.chmod(v, @file) }.should raise_error(Errno::EINVAL)
       }
     end
   end


### PR DESCRIPTION
This revises the test set for chmod to reflect OpenBSD behaviour.

Per discussion with dbussink at https://github.com/rubinius/rubinius/pull/1907#issuecomment-8616004
