### PR TITLE
Fix IO#each_char in 1.9

### DIFF
--- a/kernel/common/io.rb
+++ b/kernel/common/io.rb
@@ -555,38 +555,6 @@ class IO
     self
   end
 
-  def each_char
-    return to_enum(:each_char) unless block_given?
-
-    ensure_open_and_readable
-    if Rubinius.kcode == :UTF8
-      # TODO zoinks. This is the slowest way possible to do this.
-      # We'll have to rewrite it.
-      lookup = 7.downto(4)
-      while c = read(1) do
-        n = c[0]
-        leftmost_zero_bit = lookup.find { |i| n[i] == 0 }
-
-        case leftmost_zero_bit
-        when 7 # ASCII
-          yield c
-        when 6 # UTF 8 complementary characters
-          next # Encoding error, ignore
-        else
-          more = read(6 - leftmost_zero_bit)
-          break unless more
-          yield c + more
-        end
-      end
-    else
-      while s = read(1)
-        yield s
-      end
-    end
-
-    self
-  end
-
   ##
   # Set the pipe so it is at the end of the file
   def eof!

--- a/kernel/common/io18.rb
+++ b/kernel/common/io18.rb
@@ -153,6 +153,38 @@ class IO
 
   alias_method :each_line, :each
 
+  def each_char
+    return to_enum(:each_char) unless block_given?
+
+    ensure_open_and_readable
+    if Rubinius.kcode == :UTF8
+      # TODO zoinks. This is the slowest way possible to do this.
+      # We'll have to rewrite it.
+      lookup = 7.downto(4)
+      while c = read(1) do
+        n = c[0]
+        leftmost_zero_bit = lookup.find { |i| n[i] == 0 }
+
+        case leftmost_zero_bit
+        when 7 # ASCII
+          yield c
+        when 6 # UTF 8 complementary characters
+          next # Encoding error, ignore
+        else
+          more = read(6 - leftmost_zero_bit)
+          break unless more
+          yield c + more
+        end
+      end
+    else
+      while s = read(1)
+        yield s
+      end
+    end
+
+    self
+  end
+
   ##
   # Reads the next ``line’’ from the I/O stream;
   # lines are separated by sep_string. A separator

--- a/kernel/common/io19.rb
+++ b/kernel/common/io19.rb
@@ -492,6 +492,38 @@ class IO
 
   alias_method :each_line, :each
 
+  def each_char
+    return to_enum(:each_char) unless block_given?
+
+    ensure_open_and_readable
+    if Rubinius.kcode == :UTF8
+      # TODO zoinks. This is the slowest way possible to do this.
+      # We'll have to rewrite it.
+      lookup = 7.downto(4)
+      while c = read(1) do
+        n = c[0].ord
+        leftmost_zero_bit = lookup.find { |i| n[i] == 0 }
+
+        case leftmost_zero_bit
+        when 7 # ASCII
+          yield c
+        when 6 # UTF 8 complementary characters
+          next # Encoding error, ignore
+        else
+          more = read(6 - leftmost_zero_bit)
+          break unless more
+          yield c + more
+        end
+      end
+    else
+      while s = read(1)
+        yield s
+      end
+    end
+
+    self
+  end
+
   def gets(sep_or_limit=$/, limit=nil)
     each sep_or_limit, limit do |line|
       $_ = line if line

--- a/spec/tags/19/ruby/core/io/chars_tags.txt
+++ b/spec/tags/19/ruby/core/io/chars_tags.txt
@@ -1,3 +1,0 @@
-fails:IO#chars returns an enumerator of the next chars from the stream
-fails:IO#chars yields each character
-fails:IO#chars raises an IOError when the stream for the enumerator is closed

--- a/spec/tags/19/ruby/core/io/each_char_tags.txt
+++ b/spec/tags/19/ruby/core/io/each_char_tags.txt
@@ -1,2 +1,0 @@
-fails:IO#each_char yields each character
-fails:IO#each_char returns an Enumerator when passed no block


### PR DESCRIPTION
`String#[]` returns a `String` in 1.9 so need to call `String#ord` on it to get it's `Fixnum`
equivalent before cheking the bits
