### PR TITLE
Prevent exception when --preserve-prefix is used without --prefix.

### DIFF
--- a/configure
+++ b/configure
@@ -211,8 +211,10 @@ class Configure
 
     dirs.each { |d| d.replace d[size..-1] }
 
-    @stagingdir = "#{@sourcedir}/staging" unless @prefixdir == @sourcedir
-    @stagingdir = File.join @stagingdir, @prefixdir if @preserve_prefix
+    unless @prefixdir == @sourcedir
+      @stagingdir = "#{@sourcedir}/staging"
+      @stagingdir = File.join @stagingdir, @prefixdir if @preserve_prefix
+    end
   end
 
   def options


### PR DESCRIPTION
Fixes the following exception:

```
$ ./configure --default-version 19 --preserve-prefix
Checking gcc: found
Checking g++: found
Checking bison: found
./configure:227:in `join': can't convert nil into String (TypeError)
    from ./configure:227:in `set_filesystem_paths'
    from ./configure:1709:in `run'
    from ./configure:1865:in `<main>'
```
