### PR TITLE
Fix typo in CallFrame::print_backtrace.

### DIFF
--- a/vm/call_frame.cpp
+++ b/vm/call_frame.cpp
@@ -83,7 +83,7 @@ namespace rubinius {
 
       if(NativeMethodFrame* nmf = cf->native_method_frame()) {
         NativeMethod* nm = try_as<NativeMethod>(nmf->get_object(nmf->method()));
-        if(nm || !nm->name()->symbol_p()) {
+        if(nm && !nm->name()->symbol_p()) {
           stream << "capi:" << nm->name()->debug_str(state) << " at ";
           stream << nm->file()->c_str(state);
         } else {


### PR DESCRIPTION
A friend of mine is playing with a new static analysis tool that he wrote, and he found a bug in Rubinius. If `nm` is null, the condition after the `||` will be evaluated, resulting in a null pointer dereference.

We thought there are two possible typos: `nm && !nm->name()->symbol_p()` and `!nm || !nm->name()->symbol_p()`. However, the second variant still results in a null pointer dereference, so I'm pretty sure it's the first one.

Also, all the tests pass on Fedora 17 and OSX 10.8.

Last, I have a commit bit, but I'd like someone to take a second look at this. Thanks!
