### PR TITLE
Fix newly-introduced Thread#kill deadlock

### DIFF
--- a/kernel/bootstrap/thread19.rb
+++ b/kernel/bootstrap/thread19.rb
@@ -101,7 +101,9 @@ class Thread
   def kill
     @dying = true
     @sleep = false
-    kill_prim
+    Rubinius.synchronize(self) do
+      kill_prim
+    end
   end
 
   alias_method :exit, :kill


### PR DESCRIPTION
The following commit introduced another deadlock. Threads MUST be
Rubinius.synchronize-d, but they weren't in Thread#kill.

  ba7667b0ab28a6f9fb5b3a966d9ab32ea79318ed Correctly implement Thread#kill

Previously, Thread#kill internally used Thread#raise, which had gotten
completely deadlock-free. And there is no problem.

But, the commit made Thread#kill use a primitive for its function. That must be
inside Rubinius.synchronize as was before.
