### PR TITLE
Add debug.rb for compatibility with MRI/JRuby.

### DIFF
--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -1,0 +1,3 @@
+require 'rubinius/debugger'
+
+Rubinius::Debugger.start


### PR DESCRIPTION
Requiring `debug.rb` should always drop you into an interactive debugger.
