### PR TITLE
Make signature independent of config.rb.

### DIFF
--- a/rakelib/kernel.rake
+++ b/rakelib/kernel.rake
@@ -134,7 +134,6 @@ kernel_files = FileList[
 
 config_files = FileList[
   "Rakefile",
-  "config.rb",
   "rakelib/*.rb",
   "rakelib/*.rake"
 ]


### PR DESCRIPTION
This make the signature independent of platform.

I see no reason, why signature should be different just because I do build on different platform, where naturally the libdir path differs between builds for i386 or x86_64. The other configuration options are the same of course and the .rbc files looks the same.
