### PR TITLE
fix libffi not allocating trampoline correctly on mountain lion

### DIFF
--- a/vendor/libffi/configure
+++ b/vendor/libffi/configure
@@ -14402,7 +14402,7 @@ case "$target" in
 $as_echo "#define FFI_EXEC_TRAMPOLINE_TABLE 1" >>confdefs.h
 
      ;;
-     *-apple-darwin1[10]* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris*)
+     *-apple-darwin1* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris*)
 
 $as_echo "#define FFI_MMAP_EXEC_WRIT 1" >>confdefs.h
 

--- a/vendor/libffi/configure.ac
+++ b/vendor/libffi/configure.ac
@@ -351,7 +351,7 @@ case "$target" in
                  [Cannot use PROT_EXEC on this target, so, we revert to
                    alternative means])
      ;;
-     *-apple-darwin1[[10]]* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris*)
+     *-apple-darwin1* | *-*-freebsd* | *-*-kfreebsd* | *-*-openbsd* | *-pc-solaris*)
        AC_DEFINE(FFI_MMAP_EXEC_WRIT, 1,
                  [Cannot use malloc on this target, so, we revert to
                    alternative means])


### PR DESCRIPTION
mountain lion is darwin 12, which the regex wasn't picking up correctly
See https://bugzilla.mozilla.org/show_bug.cgi?id=682180

I've also open a pull release with libffi
