### PR TITLE
Remove unused prime_lock arg from Thread#setup

### DIFF
--- a/kernel/bootstrap/thread.rb
+++ b/kernel/bootstrap/thread.rb
@@ -111,8 +111,7 @@ class Thread
       run obj
       dup
 
-      push_false
-      send :setup, 1, true
+      send :setup, 0, true
       pop
 
       run args

--- a/kernel/bootstrap/thread18.rb
+++ b/kernel/bootstrap/thread18.rb
@@ -13,8 +13,7 @@ class Thread
       run obj
       dup
 
-      push_false
-      send :setup, 1, true
+      send :setup, 0, true
       pop
 
       run args
@@ -99,7 +98,7 @@ class Thread
     end
   end
 
-  def setup(prime_lock)
+  def setup
     @group = nil
     @alive = true
     @result = false

--- a/kernel/bootstrap/thread19.rb
+++ b/kernel/bootstrap/thread19.rb
@@ -10,8 +10,7 @@ class Thread
       run obj
       dup
 
-      push_false
-      send :setup, 1, true
+      send :setup, 0, true
       pop
 
       run args
@@ -87,7 +86,7 @@ class Thread
     end
   end
 
-  def setup(prime_lock)
+  def setup
     @group = nil
     @alive = true
     @result = false

--- a/kernel/delta/thread.rb
+++ b/kernel/delta/thread.rb
@@ -1,7 +1,7 @@
 # -*- encoding: us-ascii -*-
 
 class Thread
-  Thread.current.setup(true)
+  Thread.current.setup
   Thread.initialize_main_thread(Thread.current)
   dg = ThreadGroup.new
   Default = dg


### PR DESCRIPTION
Remove unused argument called prime_lock from Thread#setup.

The following commit removed code, which was using prime_lock in Thread#setup.
But it forgot to change the method's signature to remove prime_lock itself.

  6097398 Use Rubinius.lock instead of Channel
