### PR TITLE
Implement File::NULL

### DIFF
--- a/kernel/common/file19.rb
+++ b/kernel/common/file19.rb
@@ -145,10 +145,9 @@ class File::Stat
 end
 
 module File::Constants
-  NULL = case
-         when Rubinius.windows?
-           'NUL'
-         else
-           '/dev/null'
-         end
+  if Rubinius.windows?
+    NULL = 'NUL'
+  else
+    NULL = '/dev/null'
+  end
 end


### PR DESCRIPTION
This change addresses rubyspec/rubyspec#160 and is based on https://github.com/marcandre/backports/blob/master/lib/backports/1.9.3/file.rb. 

I wasn't sure if I should add the spec to this project, or rubyspec, or both? I submitted the PR to rubyspec, let me know if it needs to be submitted here.

Also, my first contributing to rbx, let me know where I got it wrong ;)
