### PR TITLE
Remove old tags for Rational and Complex specs

### DIFF
--- a/spec/tags/19/ruby/core/rational/Rational_tags.txt
+++ b/spec/tags/19/ruby/core/rational/Rational_tags.txt
@@ -1,3 +1,0 @@
-fails:Rational() raises a TypeError if the arguments are not Integers
-fails:Rational() passed two arguments sets the numerator to the first argument
-fails:Rational() passed two arguments sets the denominator to the second argument

--- a/spec/tags/20/ruby/core/complex/Complex_tags.txt
+++ b/spec/tags/20/ruby/core/complex/Complex_tags.txt
@@ -1,4 +1,0 @@
-fails:Complex when passed [Complex, Complex] returns a new Complex number based on the two given numbers
-fails:Complex when passed [Complex] returns the passed Complex number
-fails:Complex when passed [Integer, Integer] returns a new Complex number
-fails:Complex when passed [Integer] returns a new Complex number with 0 as the imaginary component

--- a/spec/tags/20/ruby/core/rational/Rational_tags.txt
+++ b/spec/tags/20/ruby/core/rational/Rational_tags.txt
@@ -1,4 +1,0 @@
-fails:Rational() raises a TypeError if the arguments are not Integers
-fails:Rational() passed two arguments returns a Rational instance
-fails:Rational() passed two arguments sets the numerator to the first argument
-fails:Rational() passed two arguments sets the denominator to the second argument


### PR DESCRIPTION
The following commit moved some Rational and Complex specs. But didn't
update spec tags. Just remove them bacause it's now passing:
  1779c73 Rational()/Complex() should be Kernel specs
