### PR TITLE
Modify visibility of Struct#_attrs, "public" to "private"

### DIFF
--- a/kernel/common/struct.rb
+++ b/kernel/common/struct.rb
@@ -68,6 +68,7 @@ class Struct
   def _attrs # :nodoc:
     return self.class::STRUCT_ATTRS
   end
+  private :_attrs
 
   def instance_variables
     # Hide the ivars used to store the struct fields


### PR DESCRIPTION
I guess, Struct#_attrs is a private method.
Because directly accessing inner data structures.

[some discussions](https://github.com/kachick/rubinius/pull/3)
