### PR TITLE
Fix rbx report to not overwrite .rubinius_last_error

### DIFF
--- a/lib/bin/report.rb
+++ b/lib/bin/report.rb
@@ -5,6 +5,12 @@ require 'net/https'
 
 GistSubmissionError = Class.new(StandardError)
 
+class Rubinius::Loader
+  def write_last_error(e)
+    # don't overwrite last error report
+  end
+end
+
 module Gist
   extend self
 


### PR DESCRIPTION
`rbx report` is overwritting `.rubinius_last_error` if the
submission fails.

Fixes #1510.
