### PR TITLE
pat clang 3.2svn on the head

### DIFF
--- a/vm/agent_components.cpp
+++ b/vm/agent_components.cpp
@@ -357,7 +357,7 @@ namespace agent {
 
   class ThreadCount : public DynamicVariable {
     SharedState& shared_;
-    State* state_;
+    State* state_ __attribute__((unused));
 
   public:
     ThreadCount(State* state, SharedState& ss, const char* name)

--- a/vm/agent_components.hpp
+++ b/vm/agent_components.hpp
@@ -13,7 +13,7 @@ namespace agent {
   class Tree;
 
   class Output {
-    bert::IOWriter& writer_;
+    bert::IOWriter& writer_ __attribute__((unused));
     bert::Encoder<bert::IOWriter> encoder_;
 
   public:

--- a/vm/llvm/jit_visit.hpp
+++ b/vm/llvm/jit_visit.hpp
@@ -80,8 +80,8 @@ namespace rubinius {
     opcode call_flags_;
 
     // Cached Function*s
-    llvm::Function* rbx_simple_send_;
-    llvm::Function* rbx_simple_send_private_;
+    llvm::Function* rbx_simple_send_ __attribute__((unused));
+    llvm::Function* rbx_simple_send_private_ __attribute__((unused));
 
     // bail out destinations
     llvm::BasicBlock* bail_out_;

--- a/vm/type_info.hpp
+++ b/vm/type_info.hpp
@@ -19,7 +19,7 @@ namespace rubinius {
 
   class GCTokenImpl {
   private:
-    int dummy;
+    int dummy __attribute__((unused));
   };
 
   typedef GCTokenImpl& GCToken;

--- a/vm/util/bert.hpp
+++ b/vm/util/bert.hpp
@@ -895,7 +895,7 @@ namespace bert {
 
     Value* new_dict() {
       Term* list = tzr_.next_term();
-      if(!list->type() == Term::List) {
+      if(!(list->type() == Term::List)) {
         delete list;
         return new_invalid();
       }


### PR DESCRIPTION
mark a few private variables as **attribute**((unused)) to compile with -Werror and the apparently new -Wunused-private-field

fix a logic error in bert where it was negating a boolean and comparing that to an enum rather than comparing against the enum and negating the result of the comparison
