### PR TITLE
Enhanced setsockopt parameter handling

### DIFF
--- a/lib/18/socket.rb
+++ b/lib/18/socket.rb
@@ -42,6 +42,12 @@ class BasicSocket < IO
 
     error = 0
 
+    sockname = Socket::Foreign.getsockname descriptor
+    family = Socket::Foreign.getnameinfo(sockname).first
+
+    level = level_arg(family, level)
+    optname = optname_arg(level, optname)
+
     case optval
     when Fixnum then
       FFI::MemoryPointer.new :socklen_t do |val|
@@ -154,6 +160,77 @@ class BasicSocket < IO
   def shutdown(how = 2)
     err = Socket::Foreign.shutdown @descriptor, how
     Errno.handle "shutdown" unless err == 0
+  end
+
+  private
+
+  def level_arg(family, level)
+    case level
+    when Symbol, String
+      if Socket::Constants.const_defined?(level)
+        Socket::Constants.const_get(level)
+      else
+        if is_ip_family?(family)
+          ip_level_to_int(level)
+        else
+          unknown_level_to_int(level)
+        end
+      end
+    else
+      level
+    end
+  end
+
+  def optname_arg(level, optname)
+    case optname
+    when Symbol, String
+      if Socket::Constants.const_defined?(optname)
+        Socket::Constants.const_get(optname)
+      else
+        case(level)
+        when Socket::Constants::SOL_SOCKET
+          constant("SO", optname)
+        when Socket::Constants::IPPROTO_IP
+          constant("IP", optname)
+        when Socket::Constants::IPPROTO_TCP
+          constant("TCP", optname)
+        when Socket::Constants::IPPROTO_UDP
+          constant("UDP", optname)
+        else
+          if Socket::Constants.const_defined?(Socket::Constants::IPPROTO_IPV6) &&
+            level == Socket::Constants::IPPROTO_IPV6
+            constant("IPV6", optname)
+          else
+            optname
+          end
+        end
+      end
+    else
+      optname
+    end
+  end
+
+  def is_ip_family?(family)
+    family == "AF_INET" || family == "AF_INET6"
+  end
+
+  def ip_level_to_int(level)
+    prefixes = ["IPPROTO", "SOL"]
+    prefixes.each do |prefix|
+      if Socket::Constants.const_defined?("#{prefix}_#{level}")
+        return Socket::Constants.const_get("#{prefix}_#{level}")
+      end
+    end
+  end
+
+  def unknown_level_to_int(level)
+    constant("SOL", level)
+  end
+
+  def constant(prefix, suffix)
+    if Socket::Constants.const_defined?("#{prefix}_#{suffix}")
+      Socket::Constants.const_get("#{prefix}_#{suffix}")
+    end
   end
 
 end

--- a/lib/19/socket.rb
+++ b/lib/19/socket.rb
@@ -51,6 +51,12 @@ class BasicSocket < IO
 
     error = 0
 
+    sockname = Socket::Foreign.getsockname descriptor
+    family = Socket::Foreign.getnameinfo(sockname).first
+
+    level = level_arg(family, level)
+    optname = optname_arg(level, optname)
+
     case optval
     when Fixnum then
       FFI::MemoryPointer.new :socklen_t do |val|
@@ -163,6 +169,77 @@ class BasicSocket < IO
   def shutdown(how = 2)
     err = Socket::Foreign.shutdown @descriptor, how
     Errno.handle "shutdown" unless err == 0
+  end
+
+  private
+
+  def level_arg(family, level)
+    case level
+    when Symbol, String
+      if Socket::Constants.const_defined?(level)
+        Socket::Constants.const_get(level)
+      else
+        if is_ip_family?(family)
+          ip_level_to_int(level)
+        else
+          unknown_level_to_int(level)
+        end
+      end
+    else
+      level
+    end
+  end
+
+  def optname_arg(level, optname)
+    case optname
+    when Symbol, String
+      if Socket::Constants.const_defined?(optname)
+        Socket::Constants.const_get(optname)
+      else
+        case(level)
+        when Socket::Constants::SOL_SOCKET
+          constant("SO", optname)
+        when Socket::Constants::IPPROTO_IP
+          constant("IP", optname)
+        when Socket::Constants::IPPROTO_TCP
+          constant("TCP", optname)
+        when Socket::Constants::IPPROTO_UDP
+          constant("UDP", optname)
+        else
+          if Socket::Constants.const_defined?(Socket::Constants::IPPROTO_IPV6) &&
+            level == Socket::Constants::IPPROTO_IPV6
+            constant("IPV6", optname)
+          else
+            optname
+          end
+        end
+      end
+    else
+      optname
+    end
+  end
+
+  def is_ip_family?(family)
+    family == "AF_INET" || family == "AF_INET6"
+  end
+
+  def ip_level_to_int(level)
+    prefixes = ["IPPROTO", "SOL"]
+    prefixes.each do |prefix|
+      if Socket::Constants.const_defined?("#{prefix}_#{level}")
+        return Socket::Constants.const_get("#{prefix}_#{level}")
+      end
+    end
+  end
+
+  def unknown_level_to_int(level)
+    constant("SOL", level)
+  end
+
+  def constant(prefix, suffix)
+    if Socket::Constants.const_defined?("#{prefix}_#{suffix}")
+      Socket::Constants.const_get("#{prefix}_#{suffix}")
+    end
   end
 
 end

--- a/spec/ruby/library/socket/basicsocket/setsockopt_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/setsockopt_spec.rb
@@ -11,149 +11,301 @@ describe "BasicSocket#setsockopt" do
     @sock.close unless @sock.closed?
   end
 
-  it "sets the socket linger to 0" do
-    linger = [0, 0].pack("ii")
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, linger).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
+  describe "using constants" do
+    it "sets the socket linger to 0" do
+      linger = [0, 0].pack("ii")
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, linger).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
 
-    if (n.size == 8) # linger struct on some platforms, not just a value
-      n.should == [0, 0].pack("ii")
-    else
+      if (n.size == 8) # linger struct on some platforms, not just a value
+        n.should == [0, 0].pack("ii")
+      else
+        n.should == [0].pack("i")
+      end
+    end
+
+    it "sets the socket linger to some positive value" do
+      linger = [64, 64].pack("ii")
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, linger).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
+      if (n.size == 8) # linger struct on some platforms, not just a value
+        a = n.unpack('ii')
+        a[0].should_not == 0
+        a[1].should == 64
+      else
+        n.should == [64].pack("i")
+      end
+    end
+
+    it "sets the socket option Socket::SO_OOBINLINE" do
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, true).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, false).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
       n.should == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 1).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 0).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 2).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      platform_is_not :os => :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "")
+        }.should raise_error(SystemCallError)
+      end
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "blah").should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      platform_is_not :os => :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "0")
+        }.should raise_error(SystemCallError)
+      end
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00\x00").should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
+
+      platform_is_not :os => :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "1")
+        }.should raise_error(SystemCallError)
+      end
+
+      platform_is_not :os => :windows do
+        lambda {
+          @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00")
+        }.should raise_error(SystemCallError)
+      end
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [0].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should == [0].pack("i")
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1000].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+      n.should_not == [0].pack("i")
+    end
+
+    it "sets the socket option Socket::SO_SNDBUF" do
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 4000).should == 0
+      sndbuf = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      # might not always be possible to set to exact size
+      sndbuf.unpack('i')[0].should >= 4000
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, true).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      n.unpack('i')[0].should >= 1
+
+      lambda {
+        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, nil).should == 0
+      }.should raise_error(TypeError)
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 1).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      n.unpack('i')[0].should >= 1
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 2).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      n.unpack('i')[0].should >= 2
+
+      lambda {
+        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "")
+      }.should raise_error(SystemCallError)
+
+      lambda {
+        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "bla")
+      }.should raise_error(SystemCallError)
+
+      lambda {
+        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "0")
+      }.should raise_error(SystemCallError)
+
+      lambda {
+        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "1")
+      }.should raise_error(SystemCallError)
+
+      lambda {
+        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "\x00\x00\x00")
+      }.should raise_error(SystemCallError)
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "\x00\x00\x01\x00").should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      n.unpack('i')[0].should >= "\x00\x00\x01\x00".unpack('i')[0]
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, [4000].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      n.unpack('i')[0].should >= 4000
+
+      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, [1000].pack('i')).should == 0
+      n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+      n.unpack('i')[0].should >= 1000
     end
   end
 
-  it "sets the socket linger to some positive value" do
-    linger = [64, 64].pack("ii")
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, linger).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
-    if (n.size == 8) # linger struct on some platforms, not just a value
-      a = n.unpack('ii')
-      a[0].should_not == 0
-      a[1].should == 64
-    else
-      n.should == [64].pack("i")
+  describe "using strings" do
+    context "without prefix" do
+      it "sets the socket linger to 0" do
+        linger = [0, 0].pack("ii")
+        @sock.setsockopt("SOCKET", "LINGER", linger).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
+
+        if (n.size == 8) # linger struct on some platforms, not just a value
+          n.should == [0, 0].pack("ii")
+        else
+          n.should == [0].pack("i")
+        end
+      end
+
+      it "sets the socket linger to some positive value" do
+        linger = [64, 64].pack("ii")
+        @sock.setsockopt("SOCKET", "LINGER", linger).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
+        if (n.size == 8) # linger struct on some platforms, not just a value
+          a = n.unpack('ii')
+          a[0].should_not == 0
+          a[1].should == 64
+        else
+          n.should == [64].pack("i")
+        end
+      end
+
+      it "sets the socket option Socket::SO_OOBINLINE" do
+        @sock.setsockopt("SOCKET", "OOBINLINE", true).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should_not == [0].pack("i")
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", false).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should == [0].pack("i")
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", 1).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should_not == [0].pack("i")
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", 0).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should == [0].pack("i")
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", 2).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should_not == [0].pack("i")
+
+        platform_is_not :os => :windows do
+          lambda {
+            @sock.setsockopt("SOCKET", "OOBINLINE", "")
+          }.should raise_error(SystemCallError)
+        end
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", "blah").should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should_not == [0].pack("i")
+
+        platform_is_not :os => :windows do
+          lambda {
+            @sock.setsockopt("SOCKET", "OOBINLINE", "0")
+          }.should raise_error(SystemCallError)
+        end
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", "\x00\x00\x00\x00").should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should == [0].pack("i")
+
+        platform_is_not :os => :windows do
+          lambda {
+            @sock.setsockopt("SOCKET", "OOBINLINE", "1")
+          }.should raise_error(SystemCallError)
+        end
+
+        platform_is_not :os => :windows do
+          lambda {
+            @sock.setsockopt("SOCKET", "OOBINLINE", "\x00\x00\x00")
+          }.should raise_error(SystemCallError)
+        end
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", [1].pack('i')).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should_not == [0].pack("i")
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", [0].pack('i')).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should == [0].pack("i")
+
+        @sock.setsockopt("SOCKET", "OOBINLINE", [1000].pack('i')).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+        n.should_not == [0].pack("i")
+      end
+
+      it "sets the socket option Socket::SO_SNDBUF" do
+        @sock.setsockopt("SOCKET", "SNDBUF", 4000).should == 0
+        sndbuf = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        # might not always be possible to set to exact size
+        sndbuf.unpack('i')[0].should >= 4000
+
+        @sock.setsockopt("SOCKET", "SNDBUF", true).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        n.unpack('i')[0].should >= 1
+
+        lambda {
+          @sock.setsockopt("SOCKET", "SNDBUF", nil).should == 0
+        }.should raise_error(TypeError)
+
+        @sock.setsockopt("SOCKET", "SNDBUF", 1).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        n.unpack('i')[0].should >= 1
+
+        @sock.setsockopt("SOCKET", "SNDBUF", 2).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        n.unpack('i')[0].should >= 2
+
+        lambda {
+          @sock.setsockopt("SOCKET", "SNDBUF", "")
+        }.should raise_error(SystemCallError)
+
+        lambda {
+          @sock.setsockopt("SOCKET", "SNDBUF", "bla")
+        }.should raise_error(SystemCallError)
+
+        lambda {
+          @sock.setsockopt("SOCKET", "SNDBUF", "0")
+        }.should raise_error(SystemCallError)
+
+        lambda {
+          @sock.setsockopt("SOCKET", "SNDBUF", "1")
+        }.should raise_error(SystemCallError)
+
+        lambda {
+          @sock.setsockopt("SOCKET", "SNDBUF", "\x00\x00\x00")
+        }.should raise_error(SystemCallError)
+
+        @sock.setsockopt("SOCKET", "SNDBUF", "\x00\x00\x01\x00").should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        n.unpack('i')[0].should >= "\x00\x00\x01\x00".unpack('i')[0]
+
+        @sock.setsockopt("SOCKET", "SNDBUF", [4000].pack('i')).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        n.unpack('i')[0].should >= 4000
+
+        @sock.setsockopt("SOCKET", "SNDBUF", [1000].pack('i')).should == 0
+        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+        n.unpack('i')[0].should >= 1000
+      end
     end
-  end
-
-  it "sets the socket option Socket::SO_OOBINLINE" do
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, true).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, false).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 1).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 0).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, 2).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    platform_is_not :os => :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "")
-      }.should raise_error(SystemCallError)
-    end
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "blah").should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    platform_is_not :os => :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "0")
-      }.should raise_error(SystemCallError)
-    end
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00\x00").should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
-
-    platform_is_not :os => :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "1")
-      }.should raise_error(SystemCallError)
-    end
-
-    platform_is_not :os => :windows do
-      lambda {
-        @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, "\x00\x00\x00")
-      }.should raise_error(SystemCallError)
-    end
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [0].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should == [0].pack("i")
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE, [1000].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-    n.should_not == [0].pack("i")
-  end
-
-  it "sets the socket option Socket::SO_SNDBUF" do
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 4000).should == 0
-    sndbuf = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    # might not always be possible to set to exact size
-    sndbuf.unpack('i')[0].should >= 4000
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, true).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    n.unpack('i')[0].should >= 1
-
-    lambda {
-      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, nil).should == 0
-    }.should raise_error(TypeError)
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 1).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    n.unpack('i')[0].should >= 1
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, 2).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    n.unpack('i')[0].should >= 2
-
-    lambda {
-      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "")
-    }.should raise_error(SystemCallError)
-
-    lambda {
-      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "bla")
-    }.should raise_error(SystemCallError)
-
-    lambda {
-      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "0")
-    }.should raise_error(SystemCallError)
-
-    lambda {
-      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "1")
-    }.should raise_error(SystemCallError)
-
-    lambda {
-      @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "\x00\x00\x00")
-    }.should raise_error(SystemCallError)
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, "\x00\x00\x01\x00").should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    n.unpack('i')[0].should >= "\x00\x00\x01\x00".unpack('i')[0]
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, [4000].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    n.unpack('i')[0].should >= 4000
-
-    @sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF, [1000].pack('i')).should == 0
-    n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-    n.unpack('i')[0].should >= 1000
   end
 end

--- a/spec/ruby/library/socket/tcpsocket/setsockopt_spec.rb
+++ b/spec/ruby/library/socket/tcpsocket/setsockopt_spec.rb
@@ -1,0 +1,48 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require File.expand_path('../../fixtures/classes', __FILE__)
+
+describe "TCPSocket#setsockopt" do
+  before :all do
+    SocketSpecs::SpecTCPServer.start
+  end
+
+  before(:each) do
+    hostname = SocketSpecs::SpecTCPServer.get.hostname
+    port = SocketSpecs::SpecTCPServer.get.port
+    @sock = TCPSocket.new(hostname, port)
+  end
+
+  after :each do
+    @sock.close unless @sock.closed?
+  end
+
+  describe "using constants" do
+    it "sets the TCP nodelay to 1" do
+      @sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1).should == 0
+    end
+  end
+
+  describe "using symbols" do
+    it "sets the TCP nodelay to 1" do
+      @sock.setsockopt(:IPPROTO_TCP, :TCP_NODELAY, 1).should == 0
+    end
+
+    context "without prefix" do
+      it "sets the TCP nodelay to 1" do
+        @sock.setsockopt(:TCP, :NODELAY, 1).should == 0
+      end
+    end
+  end
+
+  describe "using strings" do
+    it "sets the TCP nodelay to 1" do
+      @sock.setsockopt('IPPROTO_TCP', 'TCP_NODELAY', 1).should == 0
+    end
+
+    context "without prefix" do
+      it "sets the TCP nodelay to 1" do
+        @sock.setsockopt('TCP', 'NODELAY', 1).should == 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Correctly handle the case where a Symbol or String is used instead of a socket
constant for level or optname in calls to BasicSocket#setsockopt.

This behaviour is consistent with MRI, which permits both the level and optname
params to be a string or symbol of the name.

These strings are also allowed to omit the prefix from both the level and the
optname, for example:
`:IPPROTO_TCP`, `"IPROTO_TCP"`, `:TCP`, and `"TCP"` are all considered equivalent to
`Socket::Constants::IPPROTO_TCP`.

This commit adds support for levels and optnames based on those supported in
the MRI 1.9 socket code.

This resolves an issue preventing capybara-webkit specs from running as part of https://github.com/rubinius/rubinius/issues/2006
