### PR TITLE
Remove 1.8-incompatible changes to #setsockopt

### DIFF
--- a/spec/ruby/library/socket/basicsocket/setsockopt_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/setsockopt_spec.rb
@@ -159,152 +159,154 @@ describe "BasicSocket#setsockopt" do
     end
   end
 
-  describe "using strings" do
-    context "without prefix" do
-      it "sets the socket linger to 0" do
-        linger = [0, 0].pack("ii")
-        @sock.setsockopt("SOCKET", "LINGER", linger).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
+  ruby_version_is "1.9" do
+    describe "using strings" do
+      context "without prefix" do
+        it "sets the socket linger to 0" do
+          linger = [0, 0].pack("ii")
+          @sock.setsockopt("SOCKET", "LINGER", linger).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
 
-        if (n.size == 8) # linger struct on some platforms, not just a value
-          n.should == [0, 0].pack("ii")
-        else
+          if (n.size == 8) # linger struct on some platforms, not just a value
+            n.should == [0, 0].pack("ii")
+          else
+            n.should == [0].pack("i")
+          end
+        end
+
+        it "sets the socket linger to some positive value" do
+          linger = [64, 64].pack("ii")
+          @sock.setsockopt("SOCKET", "LINGER", linger).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
+          if (n.size == 8) # linger struct on some platforms, not just a value
+            a = n.unpack('ii')
+            a[0].should_not == 0
+            a[1].should == 64
+          else
+            n.should == [64].pack("i")
+          end
+        end
+
+        it "sets the socket option Socket::SO_OOBINLINE" do
+          @sock.setsockopt("SOCKET", "OOBINLINE", true).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should_not == [0].pack("i")
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", false).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
           n.should == [0].pack("i")
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", 1).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should_not == [0].pack("i")
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", 0).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should == [0].pack("i")
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", 2).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should_not == [0].pack("i")
+
+          platform_is_not :os => :windows do
+            lambda {
+              @sock.setsockopt("SOCKET", "OOBINLINE", "")
+            }.should raise_error(SystemCallError)
+          end
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", "blah").should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should_not == [0].pack("i")
+
+          platform_is_not :os => :windows do
+            lambda {
+              @sock.setsockopt("SOCKET", "OOBINLINE", "0")
+            }.should raise_error(SystemCallError)
+          end
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", "\x00\x00\x00\x00").should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should == [0].pack("i")
+
+          platform_is_not :os => :windows do
+            lambda {
+              @sock.setsockopt("SOCKET", "OOBINLINE", "1")
+            }.should raise_error(SystemCallError)
+          end
+
+          platform_is_not :os => :windows do
+            lambda {
+              @sock.setsockopt("SOCKET", "OOBINLINE", "\x00\x00\x00")
+            }.should raise_error(SystemCallError)
+          end
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", [1].pack('i')).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should_not == [0].pack("i")
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", [0].pack('i')).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should == [0].pack("i")
+
+          @sock.setsockopt("SOCKET", "OOBINLINE", [1000].pack('i')).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
+          n.should_not == [0].pack("i")
         end
-      end
 
-      it "sets the socket linger to some positive value" do
-        linger = [64, 64].pack("ii")
-        @sock.setsockopt("SOCKET", "LINGER", linger).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER).to_s
-        if (n.size == 8) # linger struct on some platforms, not just a value
-          a = n.unpack('ii')
-          a[0].should_not == 0
-          a[1].should == 64
-        else
-          n.should == [64].pack("i")
-        end
-      end
+        it "sets the socket option Socket::SO_SNDBUF" do
+          @sock.setsockopt("SOCKET", "SNDBUF", 4000).should == 0
+          sndbuf = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          # might not always be possible to set to exact size
+          sndbuf.unpack('i')[0].should >= 4000
 
-      it "sets the socket option Socket::SO_OOBINLINE" do
-        @sock.setsockopt("SOCKET", "OOBINLINE", true).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should_not == [0].pack("i")
+          @sock.setsockopt("SOCKET", "SNDBUF", true).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          n.unpack('i')[0].should >= 1
 
-        @sock.setsockopt("SOCKET", "OOBINLINE", false).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should == [0].pack("i")
-
-        @sock.setsockopt("SOCKET", "OOBINLINE", 1).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should_not == [0].pack("i")
-
-        @sock.setsockopt("SOCKET", "OOBINLINE", 0).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should == [0].pack("i")
-
-        @sock.setsockopt("SOCKET", "OOBINLINE", 2).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should_not == [0].pack("i")
-
-        platform_is_not :os => :windows do
           lambda {
-            @sock.setsockopt("SOCKET", "OOBINLINE", "")
-          }.should raise_error(SystemCallError)
-        end
+            @sock.setsockopt("SOCKET", "SNDBUF", nil).should == 0
+          }.should raise_error(TypeError)
 
-        @sock.setsockopt("SOCKET", "OOBINLINE", "blah").should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should_not == [0].pack("i")
+          @sock.setsockopt("SOCKET", "SNDBUF", 1).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          n.unpack('i')[0].should >= 1
 
-        platform_is_not :os => :windows do
+          @sock.setsockopt("SOCKET", "SNDBUF", 2).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          n.unpack('i')[0].should >= 2
+
           lambda {
-            @sock.setsockopt("SOCKET", "OOBINLINE", "0")
+            @sock.setsockopt("SOCKET", "SNDBUF", "")
           }.should raise_error(SystemCallError)
-        end
 
-        @sock.setsockopt("SOCKET", "OOBINLINE", "\x00\x00\x00\x00").should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should == [0].pack("i")
-
-        platform_is_not :os => :windows do
           lambda {
-            @sock.setsockopt("SOCKET", "OOBINLINE", "1")
+            @sock.setsockopt("SOCKET", "SNDBUF", "bla")
           }.should raise_error(SystemCallError)
-        end
 
-        platform_is_not :os => :windows do
           lambda {
-            @sock.setsockopt("SOCKET", "OOBINLINE", "\x00\x00\x00")
+            @sock.setsockopt("SOCKET", "SNDBUF", "0")
           }.should raise_error(SystemCallError)
+
+          lambda {
+            @sock.setsockopt("SOCKET", "SNDBUF", "1")
+          }.should raise_error(SystemCallError)
+
+          lambda {
+            @sock.setsockopt("SOCKET", "SNDBUF", "\x00\x00\x00")
+          }.should raise_error(SystemCallError)
+
+          @sock.setsockopt("SOCKET", "SNDBUF", "\x00\x00\x01\x00").should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          n.unpack('i')[0].should >= "\x00\x00\x01\x00".unpack('i')[0]
+
+          @sock.setsockopt("SOCKET", "SNDBUF", [4000].pack('i')).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          n.unpack('i')[0].should >= 4000
+
+          @sock.setsockopt("SOCKET", "SNDBUF", [1000].pack('i')).should == 0
+          n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
+          n.unpack('i')[0].should >= 1000
         end
-
-        @sock.setsockopt("SOCKET", "OOBINLINE", [1].pack('i')).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should_not == [0].pack("i")
-
-        @sock.setsockopt("SOCKET", "OOBINLINE", [0].pack('i')).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should == [0].pack("i")
-
-        @sock.setsockopt("SOCKET", "OOBINLINE", [1000].pack('i')).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_OOBINLINE).to_s
-        n.should_not == [0].pack("i")
-      end
-
-      it "sets the socket option Socket::SO_SNDBUF" do
-        @sock.setsockopt("SOCKET", "SNDBUF", 4000).should == 0
-        sndbuf = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        # might not always be possible to set to exact size
-        sndbuf.unpack('i')[0].should >= 4000
-
-        @sock.setsockopt("SOCKET", "SNDBUF", true).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        n.unpack('i')[0].should >= 1
-
-        lambda {
-          @sock.setsockopt("SOCKET", "SNDBUF", nil).should == 0
-        }.should raise_error(TypeError)
-
-        @sock.setsockopt("SOCKET", "SNDBUF", 1).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        n.unpack('i')[0].should >= 1
-
-        @sock.setsockopt("SOCKET", "SNDBUF", 2).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        n.unpack('i')[0].should >= 2
-
-        lambda {
-          @sock.setsockopt("SOCKET", "SNDBUF", "")
-        }.should raise_error(SystemCallError)
-
-        lambda {
-          @sock.setsockopt("SOCKET", "SNDBUF", "bla")
-        }.should raise_error(SystemCallError)
-
-        lambda {
-          @sock.setsockopt("SOCKET", "SNDBUF", "0")
-        }.should raise_error(SystemCallError)
-
-        lambda {
-          @sock.setsockopt("SOCKET", "SNDBUF", "1")
-        }.should raise_error(SystemCallError)
-
-        lambda {
-          @sock.setsockopt("SOCKET", "SNDBUF", "\x00\x00\x00")
-        }.should raise_error(SystemCallError)
-
-        @sock.setsockopt("SOCKET", "SNDBUF", "\x00\x00\x01\x00").should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        n.unpack('i')[0].should >= "\x00\x00\x01\x00".unpack('i')[0]
-
-        @sock.setsockopt("SOCKET", "SNDBUF", [4000].pack('i')).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        n.unpack('i')[0].should >= 4000
-
-        @sock.setsockopt("SOCKET", "SNDBUF", [1000].pack('i')).should == 0
-        n = @sock.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDBUF).to_s
-        n.unpack('i')[0].should >= 1000
       end
     end
   end

--- a/spec/ruby/library/socket/tcpsocket/setsockopt_spec.rb
+++ b/spec/ruby/library/socket/tcpsocket/setsockopt_spec.rb
@@ -22,26 +22,28 @@ describe "TCPSocket#setsockopt" do
     end
   end
 
-  describe "using symbols" do
-    it "sets the TCP nodelay to 1" do
-      @sock.setsockopt(:IPPROTO_TCP, :TCP_NODELAY, 1).should == 0
-    end
-
-    context "without prefix" do
+  ruby_version_is "1.9" do
+    describe "using symbols" do
       it "sets the TCP nodelay to 1" do
-        @sock.setsockopt(:TCP, :NODELAY, 1).should == 0
+        @sock.setsockopt(:IPPROTO_TCP, :TCP_NODELAY, 1).should == 0
+      end
+
+      context "without prefix" do
+        it "sets the TCP nodelay to 1" do
+          @sock.setsockopt(:TCP, :NODELAY, 1).should == 0
+        end
       end
     end
-  end
 
-  describe "using strings" do
-    it "sets the TCP nodelay to 1" do
-      @sock.setsockopt('IPPROTO_TCP', 'TCP_NODELAY', 1).should == 0
-    end
-
-    context "without prefix" do
+    describe "using strings" do
       it "sets the TCP nodelay to 1" do
-        @sock.setsockopt('TCP', 'NODELAY', 1).should == 0
+        @sock.setsockopt('IPPROTO_TCP', 'TCP_NODELAY', 1).should == 0
+      end
+
+      context "without prefix" do
+        it "sets the TCP nodelay to 1" do
+          @sock.setsockopt('TCP', 'NODELAY', 1).should == 0
+        end
       end
     end
   end


### PR DESCRIPTION
This commit corrects changes mistakenly added to lib/18/socket.rb.
It also adds ruby version guards to ensure the specs only run against 1.9
implementations.
