### PR TITLE
Remove Array#indexes, Array#indices on X19

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -683,25 +683,6 @@ class Array
     nil
   end
 
-  def indexes(*args)
-    warn 'Array#indexes is deprecated, use Array#values_at instead'
-
-    out = []
-
-    args.each do |a|
-      if a.kind_of? Range
-        out << self[a]
-      else
-        idx = Rubinius::Type.coerce_to(a, Fixnum, :to_int)
-        out << at(idx)
-      end
-    end
-
-    out
-  end
-
-  alias_method :indices, :indexes
-
   def last(n=undefined)
     if size < 1
       return nil if n.equal? undefined

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -260,6 +260,25 @@ class Array
     nil
   end
 
+  def indexes(*args)
+    warn 'Array#indexes is deprecated, use Array#values_at instead'
+
+    out = []
+
+    args.each do |a|
+      if a.kind_of? Range
+        out << self[a]
+      else
+        idx = Rubinius::Type.coerce_to(a, Fixnum, :to_int)
+        out << at(idx)
+      end
+    end
+
+    out
+  end
+
+  alias_method :indices, :indexes
+
   def insert(idx, *items)
     return self if items.length == 0
 


### PR DESCRIPTION
These methods are deprecated on X18.
And removed from Ruby 1.9~.

Specs are already described.
- [Array#indices](https://github.com/rubinius/rubinius/blob/673bd98b29e5f0618eef2f9d9bd7fab0d20ae82d/spec/ruby/core/array/indices_spec.rb#L5)
- [Array#indexes](https://github.com/rubinius/rubinius/blob/673bd98b29e5f0618eef2f9d9bd7fab0d20ae82d/spec/ruby/core/array/indexes_spec.rb#L5)
