### PR TITLE
Spec: Parse `a.b {|(*)|}`.

### DIFF
--- a/spec/ruby/language/block_spec.rb
+++ b/spec/ruby/language/block_spec.rb
@@ -283,6 +283,12 @@ describe "A block" do
     end
   end
 
+  describe "taking |(*)| arguments" do
+    it "does not raise an exception when no values are yielded" do
+      @y.z { |(*)| 1 }.should == 1
+    end
+  end
+
   describe "taking |*a| arguments" do
     it "assigns '[]' to the argument when no values are yielded" do
       @y.z { |*a| a }.should == []


### PR DESCRIPTION
Implementing this should fix #2073.

I'm not sure if the example name is a good one.  It's not clear to me
yet why someone would want to put parentheses around the `*`.  It should
just get Ruby to unpack the argument before it throws it away.

Also, what's interesting about getting it to pass isn't so much its
behavior (which should match the un-parenthesesed version) as the fact
that it parses.
