### PR TITLE
Add FFI::Platform::IS_MAC constant

### DIFF
--- a/kernel/platform/ffi.rb
+++ b/kernel/platform/ffi.rb
@@ -223,6 +223,7 @@ end
 
 ##
 # Namespace for holding platform-specific C constants.
+##
 
 module FFI::Platform
   case
@@ -230,20 +231,29 @@ module FFI::Platform
     LIBSUFFIX = "dll"
     IS_WINDOWS = true
     IS_MAC = false
+    IS_LINUX = false
     OS = 'windows'
   when Rubinius.darwin?
     LIBSUFFIX = "dylib"
     IS_WINDOWS = false
     IS_MAC = true
+    IS_LINUX = false
     OS = 'darwin'
   else
     LIBSUFFIX = "so"
     IS_WINDOWS = false
     IS_MAC = false
+    IS_LINUX = true
     OS = 'linux'
   end
 
   ARCH = Rubinius::CPU
+
+  NAME = "#{ARCH}-#{OS}"
+  IS_GNU = defined?(FFI::Library::LIBC)
+  IS_FREEBSD = OS == "freebsd"
+  IS_OPENBSD = OS == "openbsd"
+  IS_BSD = IS_MAC || IS_FREEBSD || IS_OPENBSD
 
   # ruby-ffi compatible
   LONG_SIZE = Rubinius::SIZEOF_LONG * 8

--- a/spec/ruby/optional/ffi/platform_spec.rb
+++ b/spec/ruby/optional/ffi/platform_spec.rb
@@ -48,14 +48,34 @@ describe "FFI::Platform::IS_MAC" do
   end
 
   platform_is :windows do
-    it "returns true" do
+    it "returns false" do
       FFI::Platform::IS_MAC.should == false
     end
   end
 
   platform_is :darwin do
-    it "returns false" do
+    it "returns true" do
       FFI::Platform::IS_MAC.should == true
+    end
+  end
+end
+
+describe "FFI::Platform::IS_LINUX" do
+  platform_is :linux do
+    it "returns true" do
+      FFI::Platform::IS_LINUX.should == true
+    end
+  end
+
+  platform_is :windows do
+    it "returns false" do
+      FFI::Platform::IS_LINUX.should == false
+    end
+  end
+
+  platform_is :darwin do
+    it "returns false" do
+      FFI::Platform::IS_LINUX.should == false
     end
   end
 end


### PR DESCRIPTION
MRI FFI contains a number of constants missing from RBX. This
commit adds IS_MAC to the case statement defining Platform const.

TODO: add IS_GNU, IS_LINUX, IS_FREEBSD, IS_OPENBSD, IS_BSD

this should resolve https://github.com/rubinius/rubinius/issues/2095
