### PR TITLE
Add type definitions for :buffer_in and :buffer_out

### DIFF
--- a/kernel/platform/ffi.rb
+++ b/kernel/platform/ffi.rb
@@ -129,6 +129,8 @@ module FFI
 
   # Converts a pointer to opaque data
   add_typedef TYPE_PTR,     :pointer
+  add_typedef TYPE_PTR,     :buffer_in
+  add_typedef TYPE_PTR,     :buffer_out
 
   # For when a function has no return value
   add_typedef TYPE_VOID,    :void


### PR DESCRIPTION
Not sure if specs should be added here. `:buffer_in` and `:buffer_out` are just another names of the same type (pointer), i.e. go into the same class of equivalence.

Rubinius actually has specs which use `:buffer_in` and `:buffer_out`, but those specs also rely on `FFI::Buffer`, which is not implemented yet.
