### PR TITLE
inttypes.h needed in vendor/oniguruma/transcoder.h  for OpenBSD

### DIFF
--- a/vendor/oniguruma/transcoder.h
+++ b/vendor/oniguruma/transcoder.h
@@ -23,6 +23,10 @@ extern "C" {
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
+#ifdef __OpenBSD__
+#include <inttypes.h>
+#endif
+
 
 #define WORDINDEX_SHIFT_BITS 2
 #define WORDINDEX2INFO(widx)      ((widx) << WORDINDEX_SHIFT_BITS)


### PR DESCRIPTION
This is needed for a clean build on OpenBSD.
