### PR TITLE
Require date when time is required

### DIFF
--- a/lib/19/time.rb
+++ b/lib/19/time.rb
@@ -36,7 +36,7 @@
 #   but it is not portable.
 #
 
-require 'date/format'
+require 'date'
 
 #
 # Implements the extensions to the Time class that are described in the

--- a/lib/20/date.rb
+++ b/lib/20/date.rb
@@ -193,7 +193,7 @@
 #
 #     puts secs_to_new_year()
 
-require 'date/format'
+require 'date'
 
 # Class representing a date.
 #


### PR DESCRIPTION
In MRI 1.9 and 2.0 there is `require 'date'` inside time.rb. 
https://github.com/ruby/ruby/blob/ruby_1_9_3/lib/time.rb#L43
https://github.com/ruby/ruby/blob/trunk/lib/time.rb#L1

So following works:

``` ruby
  require 'time'
  Date.today
```
