### PR TITLE
Support for MRI 2.0 as building platform

### DIFF
--- a/lib/ext/melbourne/parser_state19.hpp
+++ b/lib/ext/melbourne/parser_state19.hpp
@@ -239,7 +239,11 @@ typedef VALUE stack_type;
 #ifdef RUBINIUS
 #define ID2SYM(id)  (VALUE)((long)(id >> ID_SCOPE_SHIFT))
 #else
-#define SYMBOL_FLAG     0xe
+#ifdef RUBY_SYMBOL_FLAG
+#define SYMBOL_FLAG  RUBY_SYMBOL_FLAG
+#else
+#define SYMBOL_FLAG  0xe
+#endif
 #define ID2SYM(id)  ((VALUE)(((long)(id >> ID_SCOPE_SHIFT))<<8|SYMBOL_FLAG))
 #endif
 


### PR DESCRIPTION
MRI 2.0 introduced flonums to speed up float operations.

In this mode SYMBOL_FLAG represented differently – http://rxr.whitequark.org/mri/source/include/ruby/ruby.h?v=2.0.0-p0#416

In this patch I remove hardcoded value for SYMBOL_FLAG on mri and fallback to original value.
