### PR TITLE
Don't initialize Arguments::name twice (VM part)

### DIFF
--- a/vm/instructions.def
+++ b/vm/instructions.def
@@ -955,7 +955,7 @@ instruction send_method(literal) [ receiver -- value ] => send
   Object* recv = stack_top();
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments args(cache->name, recv, cNil, 0, 0);
+  Arguments args(nil<Symbol>(), recv, cNil, 0, 0);
   Object* ret = cache->execute(state, call_frame, args);
 
   (void)stack_pop();
@@ -992,7 +992,7 @@ instruction send_stack(literal count) [ receiver +count -- value ] => send
   Object* recv = stack_back(count);
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments args(cache->name, recv, cNil, count,
+  Arguments args(nil<Symbol>(), recv, cNil, count,
                  stack_back_position(count));
 
   Object* ret = cache->execute(state, call_frame, args);
@@ -1033,7 +1033,7 @@ instruction send_stack_with_block(literal count) [ block receiver +count -- valu
   Object* recv = stack_back(count);
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments args(cache->name, recv, block, count,
+  Arguments args(nil<Symbol>(), recv, block, count,
                  stack_back_position(count));
 
   Object* ret = cache->execute(state, call_frame, args);
@@ -1076,7 +1076,7 @@ instruction send_stack_with_splat(literal count) [ block array receiver +count -
   Object* recv =  stack_back(count);
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments args(cache->name, recv, block, count,
+  Arguments args(nil<Symbol>(), recv, block, count,
                  stack_back_position(count));
 
   if(!ary->nil_p()) {
@@ -1118,7 +1118,7 @@ instruction send_super_stack_with_block(literal count) [ block +count -- value ]
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
   Object* const recv = call_frame->self();
 
-  Arguments new_args(cache->name, recv, block, count,
+  Arguments new_args(nil<Symbol>(), recv, block, count,
                      stack_back_position(count));
 
   Object* ret = cache->execute(state, call_frame, new_args);
@@ -1151,7 +1151,7 @@ instruction send_super_stack_with_splat(literal count) [ block array +count -- v
   Object* const recv = call_frame->self();
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments new_args(cache->name, recv, block, count,
+  Arguments new_args(nil<Symbol>(), recv, block, count,
                      stack_back_position(count));
 
   if(!ary->nil_p()) {
@@ -1163,11 +1163,6 @@ instruction send_super_stack_with_splat(literal count) [ block array +count -- v
   }
 
   SET_CALL_FLAGS(0);
-
-  Symbol* current_name = call_frame->original_name();
-  if(cache->name != current_name) {
-    cache->name = current_name;
-  }
 
   Object* ret = InlineCache::empty_cache_super(state, cache, call_frame, new_args);
 
@@ -1946,7 +1941,7 @@ instruction meta_send_op_lt(literal) [ value1 value2 -- boolean ]
   } else {
     flush_ip();
     InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
-    Arguments out_args(cache->name, t1, 1, stack_back_position(1));
+    Arguments out_args(nil<Symbol>(), t1, 1, stack_back_position(1));
     Object* ret = cache->execute(state, call_frame, out_args);
     stack_clear(2);
 
@@ -1973,7 +1968,7 @@ instruction meta_send_op_gt(literal) [ value1 value2 -- boolean ]
   } else {
     flush_ip();
     InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
-    Arguments out_args(cache->name, t1, 1, stack_back_position(1));
+    Arguments out_args(nil<Symbol>(), t1, 1, stack_back_position(1));
     Object* ret = cache->execute(state, call_frame, out_args);
     stack_clear(2);
 
@@ -2002,7 +1997,7 @@ instruction meta_send_op_tequal(literal) [ value1 value2 -- boolean ] => send
   } else {
     flush_ip();
     InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
-    Arguments out_args(cache->name, t1, 1, stack_back_position(1));
+    Arguments out_args(nil<Symbol>(), t1, 1, stack_back_position(1));
     Object* ret = cache->execute(state, call_frame, out_args);
     stack_clear(2);
 
@@ -2115,15 +2110,10 @@ instruction zsuper(literal) [ block -- value ]
 
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments new_args(cache->name, recv, block, arg_count, 0);
+  Arguments new_args(nil<Symbol>(), recv, block, arg_count, 0);
   new_args.use_tuple(tup, arg_count);
 
   Object* ret;
-
-  Symbol* current_name = call_frame->original_name();
-  if(cache->name != current_name) {
-    cache->name = current_name;
-  }
 
   ret = cache->execute(state, call_frame, new_args);
 
@@ -2302,7 +2292,7 @@ instruction call_custom(literal count) [ receiver +count -- value ] => send
   Object* recv = stack_back(count);
   InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-  Arguments args(cache->name, recv, cNil, count,
+  Arguments args(nil<Symbol>(), recv, cNil, count,
                  stack_back_position(count));
 
   Object* ret = cache->execute(state, call_frame, args);
@@ -2325,7 +2315,7 @@ instruction meta_to_s(literal) [ object -- string ] => send
     flush_ip();
     InlineCache* cache = reinterpret_cast<InlineCache*>(literal);
 
-    Arguments args(cache->name, stack_top(), cNil, 0, 0);
+    Arguments args(nil<Symbol>(), stack_top(), cNil, 0, 0);
     Object* ret = cache->execute(state, call_frame, args);
     if(ret && !kind_of<String>(ret)) {
       ret = stack_top()->to_s(state, false);


### PR DESCRIPTION
InlineCache::execute always initializes Arguments::name to appropriate name. So,
there is no need to initialize Arguments::name when Arguments objects are
constructed and immediately handed to it.

This commit is only for the VM. One for the JIT will follow.
