### PR TITLE
Fix typo in io19.rb

### DIFF
--- a/kernel/common/io19.rb
+++ b/kernel/common/io19.rb
@@ -583,7 +583,7 @@ class IO
           wanted = limit
         else
           str << @buffer.shift
-          wanted -= evailable
+          wanted -= available
         end
       end
     end


### PR DESCRIPTION
This commit fixes a typo which was causing rdoc to fail

$ RBXOPT=-X19 bin/rbx -S gem install rdoc
Fetching: rdoc-4.0.0.gem (100%)
Depending on your version of ruby, you may need to install ruby rdoc/ri data:

<= 1.8.6 : unsupported
 = 1.8.7 : gem install rdoc-data; rdoc-data --install
 = 1.9.1 : gem install rdoc-data; rdoc-data --install

> = 1.9.2 : nothing to do! Yay!
> Successfully installed rdoc-4.0.0
> 1 gem installed
> Installing ri documentation for rdoc-4.0.0...
> Before reporting this, could you check that the file you're documenting
> has proper syntax:

  /home/adrian/dev/adzankich/rubinius/bin/rbx -c Rakefile

RDoc is not a full Ruby parser and will fail when fed invalid ruby programs.

The internal error was:

```
    (NameError) undefined local variable or method `evailable' on an instance of IO::EachReader.
```

ERROR:  While generating documentation for rdoc-4.0.0
... MESSAGE:   undefined local variable or method `evailable' on an instance of IO::EachReader.
... RDOC args: --ri --op /home/adrian/dev/adzankich/rubinius/gems/1.9/doc/rdoc-4.0.0/ri --main README.rdoc lib CVE-2013-0256.rdoc DEVELOPERS.rdoc History.rdoc LEGAL.rdoc LICENSE.rdoc Manifest.txt README.rdoc RI.rdoc TODO.rdoc bin/rdoc Rakefile --title rdoc-4.0.0 Documentation --quiet
