### PR TITLE
Use correct scope by setting CompiledCode::scope

### DIFF
--- a/vm/llvm/jit_util.cpp
+++ b/vm/llvm/jit_util.cpp
@@ -237,9 +237,7 @@ extern "C" {
     CompiledCode* code = as<CompiledCode>(_lit);
 
     // TODO: We don't need to be doing this everytime.
-    if(code->scope()->nil_p()) {
-      code->scope(state, call_frame->constant_scope());
-    }
+    code->scope(state, call_frame->constant_scope());
 
     MachineCode* mcode = call_frame->compiled_code->machine_code();
     GCTokenImpl gct;


### PR DESCRIPTION
In some cases, wrong ConstantScope can be used when JIT is enabled.

For example, ConstantScope should be different with each invocation of
class_exec in the following code:

```
definition_block = proc do
  proc do
    def baz
    end
  end.call
end
Foo.class_exec(&definition_block)
Bar.class_exec(&definition_block)
```

But, it becomes always same after this code is JIT-ted.

The cause is the following commit's modification for perfmance. It changed to
only initialize CompiledCode::scope if it's nil:

```
e3e230646aa1330c19727b3fde6bf38248733a6c Improve block creation speed

// TODO: We don't need to be doing this everytime.
-    cm->scope(state, call_frame->static_scope());
+    if(cm->scope()->nil_p()) {
+      cm->scope(state, call_frame->static_scope());
+    }
```

But this is wrong, as shown above, there are cases where unconditional
overwriting of ConstantScope is needed.

Also, this diverges from the code of the create_block VM instruction defined
at vm/instructions.def. This also indicates something wrong.

So, always initialize CompiledCode::scope here too.
