### PR TITLE
Set hits to 0 for inline block's JITMethodInfo

### DIFF
--- a/vm/llvm/inline.cpp
+++ b/vm/llvm/inline.cpp
@@ -619,6 +619,7 @@ remember:
     prime_info(info);
 
     info.is_block = true;
+    info.hits = 0;
 
     info.set_creator_info(creator_info_);
     info.set_block_info(block_info_);


### PR DESCRIPTION
This fixes the following valgrind error:

```
==13303== Thread 4:
==13303== Conditional jump or move depends on uninitialised value(s)
==13303==    at 0x7826ED: rubinius::Inliner::inline_for_class(rubinius::Class*, int) (inline.cpp:159)
==13303==    by 0x782312: rubinius::Inliner::consider_mono() (inline.cpp:35)
==13303==    by 0x7A9EFE: rubinius::JITVisit::visit_send_stack(unsigned long, unsigned long) (jit_visit.hpp:1481)
==13303==    by 0x7A1CD6: rubinius::VisitInstructions<rubinius::JITVisit>::dispatch(int) (jit_visit.hpp:1565)
==13303==    by 0x7A1426: rubinius::jit::Walker::call(rubinius::OpcodeIterator&) (jit_builder.cpp:554)
==13303==    by 0x7A11B4: void rubinius::jit::ControlFlowWalker::run<rubinius::jit::Walker>(rubinius::jit::Walker&) (control_flow.hpp:49)
==13303==    by 0x79FB30: rubinius::jit::Builder::generate_body() (jit_builder.cpp:591)
==13303==    by 0x788576: rubinius::Inliner::emit_inline_block(rubinius::JITInlineBlock*, llvm::Value*) (inline.cpp:648)
==13303==    by 0x78809A: rubinius::Inliner::inline_block(rubinius::JITInlineBlock*, llvm::Value*) (inline.cpp:284)
==13303==    by 0x7AD231: rubinius::JITVisit::visit_yield_stack(unsigned long) (jit_visit.hpp:2709)
==13303==    by 0x7A1E55: rubinius::VisitInstructions<rubinius::JITVisit>::dispatch(int) (instruction_visitors.hpp:62)
==13303==    by 0x7A1426: rubinius::jit::Walker::call(rubinius::OpcodeIterator&) (jit_builder.cpp:554)
==13303==
```

This valgrind error is introduced by this commit:

a787d839d88e8542d573f966b82f4376a0858ed4
    Don't inline calls for not often called methods
