### PR TITLE
Fix Crash with ObjectSpace.define_finalizer(obj)

### DIFF
--- a/vm/gc/baker.cpp
+++ b/vm/gc/baker.cpp
@@ -353,7 +353,8 @@ namespace rubinius {
         fi.object = saw_object(fi.object);
       }
 
-      if(fi.ruby_finalizer && fi.ruby_finalizer->young_object_p()) {
+      Object *fin = fi.ruby_finalizer;
+      if(fin && fin != cTrue && fin->young_object_p()) {
         fi.ruby_finalizer = saw_object(fi.ruby_finalizer);
       }
 


### PR DESCRIPTION
This code produces a crash:

```
class Foo
  def __finalize__
  end
end
foo = Foo.new

ObjectSpace.define_finalizer(foo)
GC.run(true)
```

When run:

```
---------------------------------------------
CRASH: A fatal error has occurred.

Backtrace:
./bin/rbx[0x4a5370]
/lib/x86_64-linux-gnu/libc.so.6(+0x364a0)[0x7f5ab242e4a0]
./bin/rbx(_ZN8rubinius7BakerGC15walk_finalizersEv+0x69)[0x619bd9]
./bin/rbx(_ZN8rubinius7BakerGC7collectERNS_6GCDataEPNS_17YoungCollectStatsE+0x3a1)[0x61a031]
./bin/rbx(_ZN8rubinius12ObjectMemory13collect_youngERNS_6GCDataEPNS_17YoungCollectStatsE+0x66)[0x549de6]
./bin/rbx(_ZN8rubinius12ObjectMemory13collect_maybeEPNS_5StateERNS_11GCTokenImplEPNS_9CallFrameE+0x160)[0x54a170]
./bin/rbx(_ZN8rubinius2VM13collect_maybeERNS_11GCTokenImplEPNS_9CallFrameE+0x3f)[0x57f2ff]
./bin/rbx(_ZN8rubinius6System11vm_gc_startEPNS_5StateERNS_11GCTokenImplEPNS_6ObjectEPNS_9CallFrameE+0x31)[0x5e5091]
./bin/rbx(_ZN8rubinius10Primitives11vm_gc_startEPNS_5StateEPNS_9CallFrameEPNS_10ExecutableEPNS_6ModuleERNS_9ArgumentsE+0xcf)[0x50e20f]
...
```

When ObjectSpace.define_finalizer stores cTrue as a finalizer placeholder in
this case. And when GC runs, it doesn't consider there may be immediates and
dereference that cTrue. Thereby, a crash is waiting for you. :p
