### PR TITLE
Altered the links on the markdown docs in rubinius/web/doc/en/

### DIFF
--- a/web/doc/en/bytecode-compiler.markdown
+++ b/web/doc/en/bytecode-compiler.markdown
@@ -25,12 +25,12 @@ stages, as well as their inputs and outputs, are illustrated below.
   <img src="/images/compilation_process.png" alt="Compilation process" />
 </div>
 
-1. [Parser Stage](/doc/en/bytecode-compiler/parser/)
-1. [AST](/doc/en/bytecode-compiler/ast/)
-1. [Generator Stage](/doc/en/bytecode-compiler/generator/)
-1. [Encoder Stage](/doc/en/bytecode-compiler/encoder/)
-1. [Packager Stage](/doc/en/bytecode-compiler/packager/)
-1. [Writer Stage](/doc/en/bytecode-compiler/writer/)
+1. [Parser Stage](bytecode-compiler/parser.markdown)
+1. [AST](bytecode-compiler/ast.markdown)
+1. [Generator Stage](bytecode-compiler/generator.markdown)
+1. [Encoder Stage](bytecode-compiler/encoder.markdown)
+1. [Packager Stage](bytecode-compiler/packager.markdown)
+1. [Writer Stage](bytecode-compiler/writer.markdown)
 1. Printers
-1. [Transformations](/doc/en/bytecode-compiler/transformations/)
-1. [Customizing the Pipeline](/doc/en/bytecode-compiler/customization/)
+1. [Transformations](bytecode-compiler/transformations.markdown)
+1. [Customizing the Pipeline](bytecode-compiler/customization.markdown)

--- a/web/doc/en/contributing.markdown
+++ b/web/doc/en/contributing.markdown
@@ -71,7 +71,7 @@ others learn about the implementation details.
 
 ## Cleanup Code
 
-Review the [Style Guide](/doc/en/contributing/style-guide/) for coding
+Review the [Style Guide](contributing/style-guide.markdown) for coding
 guidelines.
 
 

--- a/web/doc/en/getting-started.markdown
+++ b/web/doc/en/getting-started.markdown
@@ -13,7 +13,7 @@ about Ruby and about installing software on your system.
 If you have trouble following the directions here, visit the #rubinius IRC
 channel on irc.freenode.net for help.
 
-1. [Requirements](/doc/en/getting-started/requirements/)
-1. [Building](/doc/en/getting-started/building/)
-1. [Running Rubinius](/doc/en/getting-started/running-rubinius/)
-1. [Troubleshooting](/doc/en/getting-started/troubleshooting/)
+1. [Requirements](getting-started/requirements.markdown)
+1. [Building](getting-started/building.markdown)
+1. [Running Rubinius](getting-started/running-rubinius.markdown)
+1. [Troubleshooting](getting-started/troubleshooting.markdown)

--- a/web/doc/en/how-to.markdown
+++ b/web/doc/en/how-to.markdown
@@ -8,11 +8,11 @@ next_url: how-to/write-a-ticket
 review: true
 ---
 
-1. [Write a Ticket](/doc/en/how-to/write-a-ticket/)
-1. [Write a Ruby Spec](/doc/en/how-to/write-a-ruby-spec/)
-1. [Fix a Failing Spec](/doc/en/how-to/fix-a-failing-spec/)
-1. [Write Benchmarks](/doc/en/how-to/write-benchmarks/)
-1. [Write a Blog Post](/doc/en/how-to/write-a-blog-post/)
-1. [Write Documentation](/doc/en/how-to/write-documentation/)
-1. [Translate Documentation](/doc/en/how-to/translate-documentation/)
-1. [Commit to Github](/doc/en/how-to/commit-to-github/)
+1. [Write a Ticket](how-to/write-a-ticket.markdown)
+1. [Write a Ruby Spec](how-to/write-a-ruby-spec.markdown)
+1. [Fix a Failing Spec](how-to/fix-a-failing-spec.markdown)
+1. [Write Benchmarks](how-to/write-benchmarks.markdown)
+1. [Write a Blog Post](how-to/write-a-blog-post.markdown)
+1. [Write Documentation](how-to/write-documentation.markdown)
+1. [Translate Documentation](how-to/translate-documentation.markdown)
+1. [Commit to Github](how-to/commit-to-github.markdown)

--- a/web/doc/en/memory-system.markdown
+++ b/web/doc/en/memory-system.markdown
@@ -24,5 +24,5 @@ explain how we ensure that concurrent allocation of objects performs
 well and how you have to consider the implications of a moving garbage
 collector when working with the virtual machine code.
 
-1. [Object layout](/doc/en/memory-system/object-layout/)
-1. [Garbage collector](/doc/en/memory-system/garbage-collector/)
+1. [Object layout](memory-system/object-layout.markdown)
+1. [Garbage collector](memory-system/garbage-collector.markdown)

--- a/web/doc/en/ruby.markdown
+++ b/web/doc/en/ruby.markdown
@@ -47,12 +47,12 @@ Each of the following elements of Ruby are discussed from the perspective of
 understanding how Rubinius implements them and how the concept of _scope_ is
 involved in each one.
 
-1. [Scripts](/doc/en/ruby/scripts/)
-1. [Methods](/doc/en/ruby/methods/)
-1. [Constants](/doc/en/ruby/constants/)
-1. [Classes & Modules](/doc/en/ruby/classes-and-modules/)
-1. [Blocks & Procs](/doc/en/ruby/blocks-and-procs/)
-1. [Local Variables](/doc/en/ruby/local-variables/)
-1. [Instance Variables](/doc/en/ruby/instance-variables/)
-1. [Class Variables](/doc/en/ruby/class-variables/)
-1. [Global Variables](/doc/en/ruby/global-variables/)
+1. [Scripts](ruby/scripts.markdown)
+1. [Methods](ruby/methods.markdown)
+1. [Constants](ruby/constants.markdown)
+1. [Classes & Modules](ruby/classes-and-modules.markdown)
+1. [Blocks & Procs](ruby/blocks-and-procs.markdown)
+1. [Local Variables](ruby/local-variables.markdown)
+1. [Instance Variables](ruby/instance-variables.markdown)
+1. [Class Variables](ruby/class-variables.markdown)
+1. [Global Variables](ruby/global-variables.markdown)

--- a/web/doc/en/systems.markdown
+++ b/web/doc/en/systems.markdown
@@ -8,8 +8,8 @@ next_url: systems/primitives
 review: true
 ---
 
-1. [Primitives](/doc/en/systems/primitives/)
-1. [FFI](/doc/en/systems/ffi/)
-1. [Concurrency](/doc/en/systems/concurrency/)
-1. [IO](/doc/en/systems/io/)
-1. [C-API](/doc/en/systems/c-api/)
+1. [Primitives](systems/primitives.markdown)
+1. [FFI](systems/ffi.markdown)
+1. [Concurrency](systems/concurrency.markdown)
+1. [IO](systems/io.markdown)
+1. [C-API](systems/c-api.markdown)

--- a/web/doc/en/tools.markdown
+++ b/web/doc/en/tools.markdown
@@ -8,6 +8,6 @@ next_url: tools/debugger
 review: true
 ---
 
-1. [Debugger](/doc/en/tools/debugger/)
-1. [Profiler](/doc/en/tools/profiler/)
-1. [Memory Analysis](/doc/en/tools/memory-analysis/)
+1. [Debugger](tools/debugger.markdown)
+1. [Profiler](tools/profiler.markdown)
+1. [Memory Analysis](tools/memory-analysis.markdown)

--- a/web/doc/en/virtual-machine.markdown
+++ b/web/doc/en/virtual-machine.markdown
@@ -8,5 +8,5 @@ next_url: virtual-machine/instructions
 review: true
 ---
 
-1. [Instructions](/doc/en/virtual-machine/instructions/)
-1. [Custom Dispatch Logic](/doc/en/virtual-machine/custom-dispatch-logic/)
+1. [Instructions](virtual-machine/instructions.markdown)
+1. [Custom Dispatch Logic](virtual-machine/custom-dispatch-logic.markdown)

--- a/web/doc/en/what-is-rubinius.markdown
+++ b/web/doc/en/what-is-rubinius.markdown
@@ -27,7 +27,7 @@ Rubinius runs on Mac OS X and many Unix/Linux operating systems. Support for
 Microsoft Windows is coming soon.
 
 To install Rubinius, use the following steps. For more detailed information,
-see [Getting Started](/doc/en/getting-started/).
+see [Getting Started](getting-started.markdown).
 
 1. `git clone git://github.com/rubinius/rubinius.git`
 1. `cd rubinius`


### PR DESCRIPTION
The links ont he markdown documents in rubinius/web/doc/en kept throwing File not found errors when I would click on them. It was easy enough to figure out where they were going and click through manually bit I figured it would be nice to correct them
