### PR TITLE
Support unreleased LLVM 3.3 using svn trunk

### DIFF
--- a/vm/llvm/autotypes.cpp
+++ b/vm/llvm/autotypes.cpp
@@ -1,7 +1,9 @@
 #ifdef ENABLE_LLVM
 
 #include "vm/config.h"
-#if RBX_LLVM_API_VER >= 302
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/DataLayout.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/DataLayout.h>
 #else
 #include <llvm/Target/TargetData.h>
@@ -9,14 +11,31 @@
 // #include <llvm/LinkAllPasses.h>
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/Transforms/Scalar.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/CallingConv.h>
+#else
 #include <llvm/CallingConv.h>
+#endif
 #include <llvm/Support/CFG.h>
 #include <llvm/Analysis/Passes.h>
 
 #include <llvm/Target/TargetOptions.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/Module.h>
+#else
 #include <llvm/Module.h>
+#endif
 
 using namespace llvm;
+
+#if RBX_LLVM_API_VER >= 303
+// Starting from LLVM 3.3, AttrListPtr is renamed to AttributeSet, which
+// affects auto-generated types{32,64}.cpp.gen.
+// Alias AttrListPtr to AttributeSet as a temporary work-around at the moment.
+namespace llvm {
+  typedef AttributeSet AttrListPtr;
+};
+#endif
 
 namespace autogen_types {
 #ifdef IS_X8664

--- a/vm/llvm/disassembler.cpp
+++ b/vm/llvm/disassembler.cpp
@@ -3,7 +3,11 @@
 #include "vm/config.h"
 #include "llvm/disassembler.hpp"
 #include <llvm/Support/Host.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/Instructions.h>
+#else
 #include <llvm/Instructions.h>
+#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Target/TargetMachine.h>

--- a/vm/llvm/jit_builder.hpp
+++ b/vm/llvm/jit_builder.hpp
@@ -8,7 +8,9 @@
 #include "llvm/basic_block.hpp"
 #include "llvm/inline_block.hpp"
 #include "llvm/offset.hpp"
-#if RBX_LLVM_API_VER >= 302
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/IRBuilder.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/IRBuilder.h>
 #else
 #include <llvm/Support/IRBuilder.h>

--- a/vm/llvm/jit_compiler.cpp
+++ b/vm/llvm/jit_compiler.cpp
@@ -14,14 +14,20 @@
 
 #include "objectmemory.hpp"
 
-#if RBX_LLVM_API_VER >= 302
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/DataLayout.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/DataLayout.h>
 #else
 #include <llvm/Target/TargetData.h>
 #endif
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/Transforms/Scalar.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/CallingConv.h>
+#else
 #include <llvm/CallingConv.h>
+#endif
 #include <llvm/Support/CFG.h>
 #include <llvm/Analysis/Passes.h>
 

--- a/vm/llvm/jit_context.cpp
+++ b/vm/llvm/jit_context.cpp
@@ -9,7 +9,9 @@
 
 #include "machine_code.hpp"
 
-#if RBX_LLVM_API_VER >= 302
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/DataLayout.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/DataLayout.h>
 #else
 #include <llvm/Target/TargetData.h>

--- a/vm/llvm/jit_context.hpp
+++ b/vm/llvm/jit_context.hpp
@@ -2,7 +2,12 @@
 #define RBX_LLVM_JIT_CONTEXT
 
 #include <list>
+
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/LLVMContext.h>
+#else
 #include <llvm/LLVMContext.h>
+#endif
 
 #include "llvm/state.hpp"
 #include "llvm/jit_memory_manager.hpp"

--- a/vm/llvm/jit_memory_manager.cpp
+++ b/vm/llvm/jit_memory_manager.cpp
@@ -51,11 +51,17 @@ SOFTWARE.
 
 */
 
+#include "vm/config.h"
+
 #include <llvm/ExecutionEngine/JITMemoryManager.h>
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/Statistic.h>
 #include <llvm/ADT/Twine.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/GlobalValue.h>
+#else
 #include <llvm/GlobalValue.h>
+#endif
 #include <llvm/Support/Allocator.h>
 #include <llvm/Support/Compiler.h>
 #include <llvm/Support/Debug.h>

--- a/vm/llvm/jit_memory_manager.hpp
+++ b/vm/llvm/jit_memory_manager.hpp
@@ -495,10 +495,24 @@ namespace jit {
     }
 
     /// allocateDataSection - Allocate memory for a data section.
+#if RBX_LLVM_API_VER >= 303
+    uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
+                                 unsigned SectionID, bool IsReadOnly) {
+      // TODO: currently IsReadOnly is ignored.
+      return mgr_->allocateDataSection(Size, Alignment, SectionID);
+    }
+#else
     uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
                                  unsigned SectionID) {
       return mgr_->allocateDataSection(Size, Alignment, SectionID);
     }
+#endif
+
+#if RBX_LLVM_API_VER >= 303
+    virtual bool applyPermissions(std::string* ErrMsg = 0) {
+      return false;
+    };
+#endif
 
     void AllocateGOT() {
       GOTBase = new uint8_t[sizeof(void*) * 8192];

--- a/vm/llvm/jit_operations.hpp
+++ b/vm/llvm/jit_operations.hpp
@@ -23,15 +23,30 @@
 #include "llvm/method_info.hpp"
 #include "llvm/jit_runtime.hpp"
 
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/Value.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/Value.h>
+#endif
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Function.h>
+#else
 #include <llvm/BasicBlock.h>
 #include <llvm/Function.h>
-#if RBX_LLVM_API_VER >= 302
+#endif
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/IRBuilder.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/IRBuilder.h>
 #else
 #include <llvm/Support/IRBuilder.h>
 #endif
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/CallingConv.h>
+#else
 #include <llvm/CallingConv.h>
+#endif
 
 using namespace llvm;
 

--- a/vm/llvm/jit_visit.hpp
+++ b/vm/llvm/jit_visit.hpp
@@ -13,7 +13,11 @@
 
 #include "llvm/stack_args.hpp"
 
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/DerivedTypes.h>
+#else
 #include <llvm/DerivedTypes.h>
+#endif
 
 #include <list>
 

--- a/vm/llvm/passes.cpp
+++ b/vm/llvm/passes.cpp
@@ -1,7 +1,17 @@
 #ifdef ENABLE_LLVM
 
 #include "llvm/passes.hpp"
+#include "vm/config.h"
 
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Intrinsics.h>
+#else
 #include <llvm/Attributes.h>
 #include <llvm/BasicBlock.h>
 #include <llvm/Function.h>
@@ -9,6 +19,7 @@
 #include <llvm/Constants.h>
 #include <llvm/Module.h>
 #include <llvm/Intrinsics.h>
+#endif
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Support/CallSite.h>
 #include <llvm/ADT/APInt.h>

--- a/vm/llvm/state.cpp
+++ b/vm/llvm/state.cpp
@@ -28,7 +28,9 @@
 #include "instruments/timing.hpp"
 #include "dtrace/dtrace.h"
 
-#if RBX_LLVM_API_VER >= 302
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/DataLayout.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/DataLayout.h>
 #else
 #include <llvm/Target/TargetData.h>
@@ -36,7 +38,11 @@
 // #include <llvm/LinkAllPasses.h>
 #include <llvm/Analysis/Verifier.h>
 #include <llvm/Transforms/Scalar.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/CallingConv.h>
+#else
 #include <llvm/CallingConv.h>
+#endif
 #include <llvm/Support/CFG.h>
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Support/TargetSelect.h>

--- a/vm/llvm/state.hpp
+++ b/vm/llvm/state.hpp
@@ -6,11 +6,20 @@
 
 #include "vm/config.h"
 
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/Module.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#else
 #include <llvm/Module.h>
 #include <llvm/DerivedTypes.h>
 #include <llvm/Function.h>
 #include <llvm/Instructions.h>
-#if RBX_LLVM_API_VER >= 302
+#endif
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/IRBuilder.h>
+#elif RBX_LLVM_API_VER >= 302
 #include <llvm/IRBuilder.h>
 #else
 #include <llvm/Support/IRBuilder.h>
@@ -21,7 +30,11 @@
 #include <llvm/Pass.h>
 #include <llvm/PassManager.h>
 #include <llvm/Support/raw_ostream.h>
+#if RBX_LLVM_API_VER >= 303
+#include <llvm/IR/LLVMContext.h>
+#else
 #include <llvm/LLVMContext.h>
+#endif
 #include <llvm/ExecutionEngine/JITEventListener.h>
 
 #include "llvm/local_info.hpp"


### PR DESCRIPTION
LLVM 3.3 is still not released. So, note that LLVM's API may change further and
break buidling Rubinius with LLVM 3.3.
