### PR TITLE
DateTime.parse throws an argument error for invalid second values.

### DIFF
--- a/lib/20/date.rb
+++ b/lib/20/date.rb
@@ -944,7 +944,7 @@ class Date
     elem[:hour] ||= 0
     elem[:min]  ||= 0
     elem[:sec]  ||= 0
-    elem[:sec] = [elem[:sec], 59].min
+    elem[:sec] = elem[:sec] == 60 ? 59 : elem[:sec]
 
     elem
   end

--- a/spec/tags/20/ruby/library/datetime/parse_tags.txt
+++ b/spec/tags/20/ruby/library/datetime/parse_tags.txt
@@ -1,1 +1,0 @@
-fails:DateTime.parse YYYY-MM-DDTHH:MM:SS format throws an argument error for invalid second values


### PR DESCRIPTION
Failing spec for Ruby 2.0 now passes.
