### PR TITLE
Implement correct priority of "-" in format strings under 1.9

### DIFF
--- a/kernel/common/sprinter.rb
+++ b/kernel/common/sprinter.rb
@@ -727,17 +727,15 @@ module Rubinius
 
       class IntegerAtom < Atom
         def bytecode
-          # A fast, common case.
-          wid = @width_static
-          if @f_zero and wid and !@f_space and !@f_plus
+          if fast_common_case?
             @g.push :self
 
             push_value
 
-            if wid == 2
+            if @width_static == 2
               @g.send :zero_two_expand_integer, 1
             else
-              @g.push_int wid
+              @g.push_int @width_static
               @g.send :zero_expand_integer, 2
             end
 
@@ -793,27 +791,7 @@ module Rubinius
 
               push_width_value
 
-              if @f_zero
-                if @f_space or @f_plus
-                  @g.send :zero_expand_leader, 2
-                else
-                  @g.send :zero_expand_integer, 2
-                end
-              else
-                if @f_space or @f_plus
-                  if @f_ljust
-                    @g.send :space_expand_leader_left, 2
-                  else
-                    @g.send :space_expand_leader, 2
-                  end
-                else
-                  if @f_ljust
-                    @g.send :space_expand_integer_left, 2
-                  else
-                    @g.send :space_expand_integer, 2
-                  end
-                end
-              end
+              expand_with_width
 
               @b.append_str
             else

--- a/kernel/common/sprinter18.rb
+++ b/kernel/common/sprinter18.rb
@@ -39,6 +39,36 @@ module Rubinius
 
       AtomMap[?c] = CharAtom
 
+      class IntegerAtom < Atom
+        def fast_common_case?
+          @f_zero and @width_static and !@f_space and !@f_plus
+        end
+
+        def expand_with_width
+          if @f_zero
+            if @f_space or @f_plus
+              @g.send :zero_expand_leader, 2
+            else
+              @g.send :zero_expand_integer, 2
+            end
+          else
+            if @f_space or @f_plus
+              if @f_ljust
+                @g.send :space_expand_leader_left, 2
+              else
+                @g.send :space_expand_leader, 2
+              end
+            else
+              if @f_ljust
+                @g.send :space_expand_integer_left, 2
+              else
+                @g.send :space_expand_integer, 2
+              end
+            end
+          end
+        end
+      end
+
       RE = /
         ([^%]+|%(?:[\n\0]|\z)) # 1
         |

--- a/kernel/common/sprinter19.rb
+++ b/kernel/common/sprinter19.rb
@@ -50,6 +50,36 @@ module Rubinius
 
       AtomMap[?c] = CharAtom
 
+      class IntegerAtom < Atom
+        def fast_common_case?
+          @f_zero and @width_static and !@f_space and !@f_plus and !@f_ljust
+        end
+
+        def expand_with_width
+          if @f_ljust
+            if @f_space or @f_plus
+              @g.send :space_expand_leader_left, 2
+            else
+              @g.send :space_expand_integer_left, 2
+            end
+          else
+            if @f_zero
+              if @f_space or @f_plus
+                @g.send :zero_expand_leader, 2
+              else
+                @g.send :zero_expand_integer, 2
+              end
+            else
+              if @f_space or @f_plus
+                @g.send :space_expand_leader, 2
+              else
+                @g.send :space_expand_integer, 2
+              end
+            end
+          end
+        end
+      end
+
       RE = /
         ([^%]+|%(?:[\n\0]|\z)) # 1
         |

--- a/spec/tags/19/ruby/core/string/modulo_tags.txt
+++ b/spec/tags/19/ruby/core/string/modulo_tags.txt
@@ -5,5 +5,3 @@ fails:String#% supports hex formats using %x for negative numbers
 fails:String#% supports hex formats using %X for negative numbers
 fails:String#% formats zero without prefix using %#x
 fails:String#% formats zero without prefix using %#X
-fails:String#% supports negative integers using %d, giving priority to `-`
-fails:String#% supports negative integers using %i, giving priority to `-`

--- a/spec/tags/20/ruby/core/string/modulo_tags.txt
+++ b/spec/tags/20/ruby/core/string/modulo_tags.txt
@@ -5,5 +5,3 @@ fails:String#% supports hex formats using %x for negative numbers
 fails:String#% supports hex formats using %X for negative numbers
 fails:String#% formats zero without prefix using %#x
 fails:String#% formats zero without prefix using %#X
-fails:String#% supports negative integers using %d, giving priority to `-`
-fails:String#% supports negative integers using %i, giving priority to `-`


### PR DESCRIPTION
Ruby 1.9 and 2.0 give higher priority to the `-` (left justify) operator than to the `0` (pad with zeros) operator when used in format string in conjunction with numeric values.

See http://ujihisa.blogspot.com/2009/12/string-differs-between-ruby-18-and-19.html for details.

This pull request fixes the two failing RubySpecs by extracting two methods out of the `Sprinter::IntegerAtom` class, with slightly different implementations for 1.8 and 1.9.
