### PR TITLE
Fixed the wrong comments.

### DIFF
--- a/vm/capi/19/include/ruby/ruby.h
+++ b/vm/capi/19/include/ruby/ruby.h
@@ -448,13 +448,13 @@ struct RFile {
 /** Convert a VALUE into a long int. */
 #define NUM2LONG(x)       (FIXNUM_P(x)?FIX2LONG(x):rb_num2long((VALUE)x))
 
-/** Convert a VALUE into a long int. */
+/** Convert a VALUE into an unsigned long int. */
 #define NUM2ULONG(x)      rb_num2ulong((VALUE)x)
 
 /** Convert a VALUE into an int. */
 #define NUM2INT(x)        ((int)NUM2LONG(x))
 
-/** Convert a VALUE into a long int. */
+/** Convert a VALUE into an unsigned int. */
 #define NUM2UINT(x)       ((unsigned int)NUM2ULONG(x))
 
 /** Convert a Fixnum into an int. */


### PR DESCRIPTION
The macro name of `NUM2ULONG(x)` implies that it returns an `unsigned long int`, and according to the signature of `rb_num2ulong`, it does return an `unsigned long int` instead of a `long int`. It might be a typo in the comments.

``` c
/** Convert a VALUE to an unsigned long int. */
unsigned long rb_num2ulong(VALUE obj);
```
