### PR TITLE
Format zero without "0x" prefix when using "%#x" and "%#X" on 1.9

### DIFF
--- a/kernel/common/sprinter.rb
+++ b/kernel/common/sprinter.rb
@@ -390,11 +390,9 @@ module Rubinius
         end
 
         def prepend_prefix
-          if @prefix
-            @g.push_literal @prefix
-            @g.string_dup
-            @g.string_append
-          end
+          @g.push_literal @prefix
+          @g.string_dup
+          @g.string_append
         end
 
         def set_value(ref)
@@ -881,7 +879,9 @@ module Rubinius
 
           zero_pad
 
-          prepend_prefix
+          if @prefix
+            prepend_prefix_bytecode
+          end
 
           if @f_plus || @f_space
             append_sign = @g.new_label

--- a/kernel/common/sprinter18.rb
+++ b/kernel/common/sprinter18.rb
@@ -69,6 +69,12 @@ module Rubinius
         end
       end
 
+      class ExtIntegerAtom < Atom
+        def prepend_prefix_bytecode
+          prepend_prefix
+        end
+      end
+
       RE = /
         ([^%]+|%(?:[\n\0]|\z)) # 1
         |

--- a/kernel/common/sprinter19.rb
+++ b/kernel/common/sprinter19.rb
@@ -10,6 +10,11 @@ module Rubinius
         @g.send :force_encoding, 1
       end
 
+      def is_zero
+        @g.meta_push_0
+        @g.meta_send_op_equal @g.find_literal(:==)
+      end
+
       class CharAtom < Atom
         def bytecode
           push_value
@@ -77,6 +82,24 @@ module Rubinius
               end
             end
           end
+        end
+      end
+
+      class ExtIntegerAtom < Atom
+        def prepend_prefix_bytecode
+          skip_prefix = @g.new_label
+
+          # For 'x' and 'X', don't prepend the "0x" prefix
+          # if the value is zero
+          if @format_code == 'x' || @format_code == 'X'
+            push_value
+            @b.is_zero
+            @g.git skip_prefix
+          end
+
+          prepend_prefix
+
+          skip_prefix.set!
         end
       end
 

--- a/spec/tags/19/ruby/core/string/modulo_tags.txt
+++ b/spec/tags/19/ruby/core/string/modulo_tags.txt
@@ -3,5 +3,3 @@ fails:String#% supports octal formats using %o for negative numbers
 fails:String#% supports negative bignums with %u or %d
 fails:String#% supports hex formats using %x for negative numbers
 fails:String#% supports hex formats using %X for negative numbers
-fails:String#% formats zero without prefix using %#x
-fails:String#% formats zero without prefix using %#X

--- a/spec/tags/20/ruby/core/string/modulo_tags.txt
+++ b/spec/tags/20/ruby/core/string/modulo_tags.txt
@@ -3,5 +3,3 @@ fails:String#% supports octal formats using %o for negative numbers
 fails:String#% supports negative bignums with %u or %d
 fails:String#% supports hex formats using %x for negative numbers
 fails:String#% supports hex formats using %X for negative numbers
-fails:String#% formats zero without prefix using %#x
-fails:String#% formats zero without prefix using %#X


### PR DESCRIPTION
Ruby 1.9 doesn't prepend the `0x` prefix to the number 0 when using the `"%#x"` and `"%#X"` formats. 

This pull request extracts some of the behaviour of `Sprinter::ExtIntegerAtom` to add a check for whether the given integer is zero on 1.9.
