### PR TITLE
Extend the 1.9 Sprinter to handle negative numbers in hex, octal, binary

### DIFF
--- a/kernel/common/sprinter18.rb
+++ b/kernel/common/sprinter18.rb
@@ -8,6 +8,12 @@ module Rubinius
       def encode_result
       end
 
+      class Atom
+        def zero_pad?
+          @has_precision || (@has_width && @f_zero)
+        end
+      end
+
       class CharAtom < Atom
         def bytecode
           push_value
@@ -70,6 +76,17 @@ module Rubinius
       end
 
       class ExtIntegerAtom < Atom
+        def pad_negative_int(padding)
+          if zero_pad?
+            zero_pad(padding)
+
+          elsif !@has_precision && !@f_zero
+            @g.push_literal ".."
+            @g.string_dup
+            @g.string_append
+          end
+        end
+
         def prepend_prefix_bytecode
           prepend_prefix
         end

--- a/kernel/common/sprinter19.rb
+++ b/kernel/common/sprinter19.rb
@@ -86,6 +86,18 @@ module Rubinius
       end
 
       class ExtIntegerAtom < Atom
+        def pad_negative_int(padding)
+          zero_pad(padding) do
+            # decrease the width by 2 to account for the ".." below
+            @g.meta_push_2
+            @b.meta_op_minus
+          end
+
+          @g.push_literal ".."
+          @g.string_dup
+          @g.string_append
+        end
+
         def prepend_prefix_bytecode
           skip_prefix = @g.new_label
 

--- a/spec/tags/19/ruby/core/string/modulo_tags.txt
+++ b/spec/tags/19/ruby/core/string/modulo_tags.txt
@@ -1,5 +1,1 @@
-fails:String#% supports binary formats using %b for negative numbers
-fails:String#% supports octal formats using %o for negative numbers
 fails:String#% supports negative bignums with %u or %d
-fails:String#% supports hex formats using %x for negative numbers
-fails:String#% supports hex formats using %X for negative numbers

--- a/spec/tags/20/ruby/core/string/modulo_tags.txt
+++ b/spec/tags/20/ruby/core/string/modulo_tags.txt
@@ -1,5 +1,1 @@
-fails:String#% supports binary formats using %b for negative numbers
-fails:String#% supports octal formats using %o for negative numbers
 fails:String#% supports negative bignums with %u or %d
-fails:String#% supports hex formats using %x for negative numbers
-fails:String#% supports hex formats using %X for negative numbers


### PR DESCRIPTION
Correctly append `..` in front of negative integers when they are formatted into hex, octal or binary (`%x`, `%X`, `%o`, `%b`) under 1.9.

This entails splitting out a couple of methods concerned with padding negative integer values into the 1.8 and 1.9-specific files.

Also remove dead code and pointless predicate methods that simply delegate to ivars.

This pull request fixes 4 RubySpecs in 1.9 and 2.0 mode.
