### PR TITLE
Fix last failing spec for Kernel#sprintf on 1.9

### DIFF
--- a/kernel/common/sprinter.rb
+++ b/kernel/common/sprinter.rb
@@ -568,17 +568,18 @@ module Rubinius
         def zero_pad(pad="0")
           if @has_precision
             push_precision
-
-            # let the caller adjust the width if needed
-            yield if block_given?
-
-            @g.push_literal pad
-            @g.send :rjust, 2
           elsif @has_width && @f_zero
             push_width true
-            @g.push_literal pad
-            @g.send :rjust, 2
+          else
+            # exit early if no width has been pushed
+            return
           end
+
+          # let the caller adjust the width if needed
+          yield if block_given?
+
+          @g.push_literal pad
+          @g.send :rjust, 2
         end
 
         attr_reader :width_static

--- a/spec/tags/19/ruby/core/kernel/sprintf_tags.txt
+++ b/spec/tags/19/ruby/core/kernel/sprintf_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#sprintf with negative values with format %x precedes the number with '..'

--- a/spec/tags/20/ruby/core/kernel/sprintf_tags.txt
+++ b/spec/tags/20/ruby/core/kernel/sprintf_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#sprintf with negative values with format %x precedes the number with '..'


### PR DESCRIPTION
This pull request extends the changes to the `zero_pad` method introduced in 157860a, whereby a block can be passed in to modify the width that the string will be padded to.

This should fix all 1.9 compatibility issues in the Sprinter, although the specs in question still need to be reviewed for completion.
