### PR TITLE
Optimize Splitter in the matching delimiter regexp case

### DIFF
--- a/kernel/common/splitter.rb
+++ b/kernel/common/splitter.rb
@@ -76,7 +76,11 @@ module Rubinius
 
         unless collapsed && (match.full.at(0) == last_match_end)
           ret << match.pre_match_from(last_match_end)
-          ret.push(*match.captures.compact)
+
+          # length > 1 means there are captures
+          if match.length > 1
+            ret.concat(match.captures.compact)
+          end
         end
 
         if collapsed
@@ -98,8 +102,8 @@ module Rubinius
       end
 
       # Trim from end
-      if !ret.empty? and (limit.equal?(undefined) || limit == 0)
-        while s = ret.last and s.empty?
+      if limit.equal?(undefined) || limit == 0
+        while s = ret.at(-1) and s.empty?
           ret.pop
         end
       end


### PR DESCRIPTION
Inspired by @MSNexploder's profiling on #985, I did some digging around the `Splitter` class to see if I could optimise its execution time.

The main change is that we now avoid calling `MatchData#captures` in a tight loop unless there are in fact any captures.

I've also made a few micro-optimisations, like using `Array#concat` instead of `Array#push` with a splat, and favouring `Array#at(-1)` over `Array#last` when we know the array is not empty.

I used the benchmark in `benchmark/core/string/bench_split.rb` to guide my changes. In particular, the relevant benchmark is "matching delimiter regexp", which I ran against MRI.

Before:

```
Comparing benchmark/core/string/bench_split.rb:matching delimiter regexp:
   ruby:     138829 i/s
bin/rbx:      48619 i/s - 2.86x slower
```

After:

```
Comparing benchmark/core/string/bench_split.rb:matching delimiter regexp:
   ruby:     139696 i/s
bin/rbx:     138014 i/s - 1.01x slower
```
