### PR TITLE
Always export the RBX version number

### DIFF
--- a/vm/capi/18/include/ruby.h
+++ b/vm/capi/18/include/ruby.h
@@ -148,7 +148,7 @@ extern "C" {
 #endif
 
 #ifndef RBX_WINDOWS
-  extern int __X_rubinius_version __attribute__((weak));
+  extern int __X_rubinius_version __attribute__((weak, visibility ("default")));
   int __X_rubinius_version = 2;
 #endif
 

--- a/vm/capi/19/include/ruby/ruby.h
+++ b/vm/capi/19/include/ruby/ruby.h
@@ -190,7 +190,7 @@ typedef void (*RUBY_DATA_FUNC)(void*);
 /** Global class/object etc. types. */
 
 #ifndef RBX_WINDOWS
-  extern int __X_rubinius_version __attribute__((weak));
+  extern int __X_rubinius_version __attribute__((weak, visibility ("default")));
   int __X_rubinius_version = 2;
 #endif
 


### PR DESCRIPTION
Alright, this is not pretty, so excuse me in advance for the mess:

As you probably know, very bad things happen if you're working with 2 different C extensions that re-use small snippets of C code between them (e.g. a hash table implementation, an array implementation, a small library, and so on). As the two C extensions get loaded dynamically into the same memory space, their symbols table collide. If they are not using the same version of the shared code, one of the C extensions will break.

The only way to ensure this is to make sure that no other symbols besides the entry point are exported from the C extension, which is rather tricky to do in practice (it involves manually hiding every single function that is not set to `static` with visibility attributes).

Another way to accomplish this is the "shotgun" approach of hiding every single symbol in the C extension besides the `Init_` entry point by linking with `-Fvisibility=hidden` or with `-Bsymbol`. This works very well in practice for MRI, but Rubinius fails to load C extensions linked like this because it's looking for the `__X_rubinius_version` entry, which is now hidden at link time.

By enforcing a `default` visibility attribute on the Rubinius version, we make sure that it always gets exported and C extensions never fail to load, regardless of how they were linked.
