### PR TITLE
Fix issues affecting dates before 1902, after 2037

### DIFF
--- a/lib/19/date.rb
+++ b/lib/19/date.rb
@@ -1786,8 +1786,7 @@ class Time
   def to_time() getlocal end
 
   def to_date
-    jd = Date.__send__(:civil_to_jd, year, mon, mday, Date::ITALY)
-    Date.new!(Date.__send__(:jd_to_ajd, jd, 0, 0), 0, Date::ITALY)
+    Date.jd(Date.__send__(:civil_to_jd, year, mon, mday, Date::GREGORIAN))
   end
 
   def to_datetime


### PR DESCRIPTION
Fixed off-by-one in calls to Sakamoto day-of-week function. This bug caused miscalculations for some dates before 1902 and after 2037. Fixing this bug caused another spec to fail, revealing a secondary issue in timestamp64 where a leap day was being skipped in the calculation of epoch seconds for a date in 1801. Fixed that, too.

Revised Ruby 1.9 Time#to_date to use logic like MRI > 1.8, which assumes a proleptic Gregorian calendar when converting the value. Current implementation is based on MRI 1.8's private Time#to_date, which has different behavior.

With these changes, newly added failing rubyspecs in core/time ("pre-Gregorian reform dates" via Time#gm, Time#utc) pass for -X18 and -X19. Newly added failing rubyspecs in library/time/to_date ("pre-Gregorian" and "Julian-Gregorian gap", -X19 only) also pass.
