### PR TITLE
Added specs for String#to_sym with non-ASCII string.

### DIFF
--- a/spec/ruby/core/string/shared/to_sym.rb
+++ b/spec/ruby/core/string/shared/to_sym.rb
@@ -44,5 +44,9 @@ describe :string_to_sym, :shared => true do
         ["-(unary)", :"-(unary)"]
       ].should be_computed_by(:to_sym)
     end
+
+    it "keeps the source encoding" do
+      "\xC3\xBC".force_encoding('UTF-8').to_sym.encoding.should == Encoding::UTF_8
+    end
   end
 end

--- a/spec/tags/19/ruby/core/string/intern_tags.txt
+++ b/spec/tags/19/ruby/core/string/intern_tags.txt
@@ -1,0 +1,1 @@
+fails:String#intern keeps the source encoding

--- a/spec/tags/19/ruby/core/string/to_sym_tags.txt
+++ b/spec/tags/19/ruby/core/string/to_sym_tags.txt
@@ -1,0 +1,1 @@
+fails:String#to_sym keeps the source encoding


### PR DESCRIPTION
When the source string is non-ASCII, the corresponding symbol should
retain the same encoding.

I think it's going to need a major patch at the VM level.
