### PR TITLE
Add spec for String#size with encoding change.

### DIFF
--- a/spec/ruby/core/string/shared/length.rb
+++ b/spec/ruby/core/string/shared/length.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 describe :string_length, :shared => true do
   it "returns the length of self" do
     "".send(@method).should == 0
@@ -6,5 +8,14 @@ describe :string_length, :shared => true do
     "two".send(@method).should == 3
     "three".send(@method).should == 5
     "four".send(@method).should == 4
+  end
+
+  with_feature :encoding do
+    it "returns the length of the new self after encoding is changed" do
+      str = 'こにちわ'
+      str.size
+
+      str.force_encoding('ASCII-8BIT').size.should == 12
+    end
   end
 end

--- a/spec/tags/19/ruby/core/string/length_tags.txt
+++ b/spec/tags/19/ruby/core/string/length_tags.txt
@@ -1,0 +1,1 @@
+fails:String#length returns the length of the new self after encoding is changed

--- a/spec/tags/19/ruby/core/string/size_tags.txt
+++ b/spec/tags/19/ruby/core/string/size_tags.txt
@@ -1,0 +1,1 @@
+fails:String#size returns the length of the new self after encoding is changed


### PR DESCRIPTION
The characters number of the string is cached inside `vm/builtin/string.cpp` in num_char. It should be invalidated when the encoding changes, for example because of `String#force_encoding`: with a different encoding, the correlation between characters and bytes may change completely.
