### PR TITLE
Fixed a syntax confusion regarding blocks in specs.

### DIFF
--- a/spec/core/exception/arguments_spec.rb
+++ b/spec/core/exception/arguments_spec.rb
@@ -2,8 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "ArgumentError" do
   it "uses its internal message in #inspect" do
-    lambda { 1.+(2, 3) }.should raise_error(ArgumentError) do |e|
-      e.inspect.should == "#<ArgumentError: method '+': given 2, expected 1>"
-    end
+    error_inspection = lambda { |e| e.inspect.should == "#<ArgumentError: method '+': given 2, expected 1>" }
+    lambda { 1.+(2, 3) }.should raise_error(ArgumentError, &error_inspection)
   end
 end


### PR DESCRIPTION
The block wasn't passed to `raise_error`, due to missing parenthesis around it and the block.
Adding them would've looked a bit awkward, so I put the second expectation in a lambda and passed it as a block to `raise_error`.
Running just this example now correctly reports 2 expectations being run.
