### PR TITLE
Add specs for Module#extend_object when given a frozen object

### DIFF
--- a/spec/ruby/core/module/extend_object_spec.rb
+++ b/spec/ruby/core/module/extend_object_spec.rb
@@ -25,4 +25,25 @@ describe "Module#extend_object" do
     obj.extend ModuleSpecs::ExtendObjectPrivate
     ScratchPad.recorded.should == :extended
   end
+
+  describe "when given a frozen object" do
+    before :each do
+      @receiver = Module.new
+      @object = Object.new.freeze
+    end
+
+    ruby_version_is ""..."1.9" do
+      it "raises a TypeError before extending the object" do
+        lambda { @receiver.send(:extend_object, @object) }.should raise_error(TypeError)
+        @object.should_not be_kind_of(@receiver)
+      end
+    end
+
+    ruby_version_is "1.9" do
+      it "raises a RuntimeError before extending the object" do
+        lambda { @receiver.send(:extend_object, @object) }.should raise_error(RuntimeError)
+        @object.should_not be_kind_of(@receiver)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a missing spec for #2399 fixes.
