### PR TITLE
Fix NameError in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -477,7 +477,7 @@ class Configure
     version = str.gsub(/[^\d]/, "")
     unless @supported_versions.include? version
       failure <<-EOM
-Unsupported language version requested: #{ver}. Options are #{@supported_versions.join(", ")}
+Unsupported language version requested: #{version}. Options are #{@supported_versions.join(", ")}
       EOM
     end
     version


### PR DESCRIPTION
d5ef35f10a9097b68d7c1053cf45478fb4023fea forgot to update the variable name in the failure message as well.
