### PR TITLE
Add specs on Kernel#eval with unreached locals across the same binding.

### DIFF
--- a/spec/ruby/core/kernel/eval_spec.rb
+++ b/spec/ruby/core/kernel/eval_spec.rb
@@ -160,6 +160,13 @@ describe "Kernel#eval" do
       eval("y=3", level2)
       eval("y", level2).should == 3
     end
+
+    it "uses the same scope for local variables when given the same binding" do
+      outer_binding = binding
+
+      eval("if false; a = 1; end", outer_binding)
+      eval("a", outer_binding).should be_nil
+    end
   end
 
   ruby_version_is ""..."1.9" do

--- a/spec/tags/19/ruby/core/kernel/eval_tags.txt
+++ b/spec/tags/19/ruby/core/kernel/eval_tags.txt
@@ -1,3 +1,4 @@
 fails:Kernel#eval does not share locals across eval scopes
 fails:Kernel#eval unwinds through a Proc-style closure and returns from a lambda-style closure in the closure chain
 fails:Kernel#eval raises a LocalJumpError if there is no lambda-style closure in the chain
+fails:Kernel#eval uses the same scope for local variables when given the same binding

--- a/spec/tags/20/ruby/core/kernel/eval_tags.txt
+++ b/spec/tags/20/ruby/core/kernel/eval_tags.txt
@@ -1,3 +1,4 @@
 fails:Kernel#eval does not share locals across eval scopes
 fails:Kernel#eval unwinds through a Proc-style closure and returns from a lambda-style closure in the closure chain
 fails:Kernel#eval raises a LocalJumpError if there is no lambda-style closure in the chain
+fails:Kernel#eval uses the same scope for local variables when given the same binding


### PR DESCRIPTION
Failing tagged spec. See #1547.
