### PR TITLE
Slightly reformatted the style of backtraces.

### DIFF
--- a/kernel/common/exception.rb
+++ b/kernel/common/exception.rb
@@ -53,6 +53,7 @@ class Exception
     message_lines = message.to_s.split("\n")
 
     io.puts header
+    io.puts
     io.puts "    #{message_lines.shift} (#{self.class})"
 
     message_lines.each do |line|
@@ -61,12 +62,14 @@ class Exception
 
     if @custom_backtrace
       io.puts "\nUser defined backtrace:"
+      io.puts
       @custom_backtrace.each do |line|
         io.puts "    #{line}"
       end
     end
 
     io.puts "\nBacktrace:"
+    io.puts
     io.puts awesome_backtrace.show("\n", color)
 
     extra = @parent
@@ -75,12 +78,14 @@ class Exception
 
       if @custom_backtrace
         io.puts "\nUser defined backtrace:"
+        io.puts
         @custom_backtrace.each do |line|
           io.puts "    #{line}"
         end
       end
 
       io.puts "\nBacktrace:"
+      io.puts
       io.puts extra.awesome_backtrace.show
 
       extra = extra.parent

--- a/kernel/loader.rb
+++ b/kernel/loader.rb
@@ -856,13 +856,14 @@ to rebuild the compiler.
       show_syntax_error(e)
 
       STDERR.puts "\nBacktrace:"
+      STDERR.puts
       STDERR.puts e.awesome_backtrace.show
       epilogue
     rescue Interrupt => e
       @exit_code = 1
 
       write_last_error(e)
-      e.render "An exception occurred #{@stage}"
+      e.render "An exception occurred #{@stage}:"
       epilogue
     rescue SignalException => e
       Signal.trap(e.signo, "SIG_DFL")
@@ -872,7 +873,7 @@ to rebuild the compiler.
       @exit_code = 1
 
       write_last_error(e)
-      e.render "An exception occurred #{@stage}"
+      e.render "An exception occurred #{@stage}:"
       epilogue
     else
       # We do this, run epilogue both in the rescue blocks and also here,


### PR DESCRIPTION
Opening a pull-request for this to get some feedback on it. The primary reason for this was because I personally feel that the message is a bit easier to read using this new format.

Example of the old format:

``` text
An exception occurred running /tmp/test.rb
    undefined local variable or method `number' on Foo::Bar (Module) (NameError)

Backtrace:
  Kernel(Module)#number (method_missing) at kernel/delta/kernel.rb:81
                           Foo::Bar.test at /tmp/test.rb:4
                       Object#__script__ at /tmp/test.rb:9
        Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:68
        Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:119
                 Rubinius::Loader#script at kernel/loader.rb:645
                   Rubinius::Loader#main at kernel/loader.rb:846
```

Example of the new format:

``` text
An exception occurred running /tmp/test.rb:

    undefined local variable or method `number' on Foo::Bar (Module) (NameError)

Backtrace:

  Kernel(Module)#number (method_missing) at kernel/delta/kernel.rb:81
                           Foo::Bar.test at /tmp/test.rb:4
                       Object#__script__ at /tmp/test.rb:9
        Rubinius::CodeLoader#load_script at kernel/delta/codeloader.rb:68
        Rubinius::CodeLoader.load_script at kernel/delta/codeloader.rb:119
                 Rubinius::Loader#script at kernel/loader.rb:645
                   Rubinius::Loader#main at kernel/loader.rb:846
```
