### PR TITLE
Array inspect should take the encoding of the first element

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -925,21 +925,6 @@ class Array
     self
   end
 
-  def inspect
-    return "[]" if @total == 0
-
-    comma = ", "
-    result = "["
-
-    return "[...]" if Thread.detect_recursion self do
-      each { |o| result << o.inspect << comma }
-    end
-
-    Rubinius::Type.infect(result, self)
-    result.shorten!(2)
-    result << "]"
-  end
-
   def transpose
     return [] if empty?
 

--- a/kernel/common/array18.rb
+++ b/kernel/common/array18.rb
@@ -495,6 +495,21 @@ class Array
     dup.sort_inplace(&block)
   end
 
+  def inspect
+    return "[]" if @total == 0
+
+    comma = ", "
+    result = "["
+
+    return "[...]" if Thread.detect_recursion self do
+      each { |o| result << o.inspect << comma }
+    end
+
+    Rubinius::Type.infect(result, self)
+    result.shorten!(2)
+    result << "]"
+  end
+
   def to_s
     join
   end

--- a/kernel/common/array19.rb
+++ b/kernel/common/array19.rb
@@ -677,6 +677,25 @@ class Array
     replace sort_by(&block)
   end
 
+  def inspect
+    return "[]" if @total == 0
+    comma = ", "
+    result = "["
+
+    return "[...]" if Thread.detect_recursion self do
+      each_with_index do |element, index|
+        temp = element.inspect
+        result.force_encoding(temp.encoding) if index == 0
+        result << temp << comma
+      end
+    end
+
+    Rubinius::Type.infect(result, self)
+    result.shorten!(2)
+    result << "]"
+    result
+  end
+
   alias_method :to_s, :inspect
 
   def uniq(&block)

--- a/spec/tags/19/ruby/core/array/inspect_tags.txt
+++ b/spec/tags/19/ruby/core/array/inspect_tags.txt
@@ -1,2 +1,0 @@
-fails:Array#inspect copies the ASCII-compatible encoding of the result of inspecting the first element
-fails:Array#inspect copies the ASCII-incompatible encoding of the result of inspecting the first element

--- a/spec/tags/19/ruby/core/array/to_s_tags.txt
+++ b/spec/tags/19/ruby/core/array/to_s_tags.txt
@@ -1,2 +1,0 @@
-fails:Array#to_s copies the ASCII-compatible encoding of the result of inspecting the first element
-fails:Array#to_s copies the ASCII-incompatible encoding of the result of inspecting the first element


### PR DESCRIPTION
Inspected array will take the encoding of the first element of the array, default encoding is also set the default external or internal

Also satisfies the spec for calling to_s on a array
