### PR TITLE
Update stale spec/README link

### DIFF
--- a/spec/README
+++ b/spec/README
@@ -58,5 +58,5 @@ spec/libraries with the parallel directories under spec/ruby/. These
 directories serve different purposes.
 
 For more information, please refer to:
-  http://rubinius.lighthouseapp.com/projects/5089/specs-overview
+  http://rubini.us/doc/en/specs/
 


### PR DESCRIPTION
Updates the old lighthouse url to what I think is the equivalent on rubini.us
