### PR TITLE
Fix require compiler/iseq to use path on gem.

### DIFF
--- a/kernel/common/compiled_code.rb
+++ b/kernel/common/compiled_code.rb
@@ -430,7 +430,7 @@ module Rubinius
     # exactly match the bytecode currently held by the CompiledCode, typically
     # as a result of substituting yield_debugger instructions into the bytecode.
     def decode(bytecodes = @iseq)
-      require 'compiler/iseq'
+      require 'rubinius/compiler/iseq'
 
       decoder = Rubinius::InstructionDecoder.new(bytecodes)
       stream = decoder.decode(false)


### PR DESCRIPTION
I just downloaded current rubinius and after building, tried to execute `rbx compile -P hello.rb` 

Failed with 

```
    no such file to load -- compiler/iseq (LoadError)
```

this path was used when the compiler files were inside rubinius codebase, now it's distributed as a separate gem and the path has changed to rubinius/compiler/iseq. This pull request fixes this tiny error. 

Also needed to apply rubinius/rubinius-compiler#1 for it to work.
