### PR TITLE
adding file readable and writable to Kernel.test

### DIFF
--- a/kernel/common/kernel.rb
+++ b/kernel/common/kernel.rb
@@ -760,6 +760,14 @@ module Kernel
       File.file? file1
     when ?l
       File.symlink? file1
+    when ?r
+      File.readable? file1
+    when ?R
+      File.readable_real? file1
+    when ?w
+      File.writable? file1
+    when ?W
+      File.writable_real? file1
     else
       raise NotImplementedError, "command ?#{cmd.chr} not implemented"
     end

--- a/spec/ruby/core/kernel/test_spec.rb
+++ b/spec/ruby/core/kernel/test_spec.rb
@@ -36,6 +36,22 @@ describe "Kernel#test" do
     Kernel.test(?l, @link).should be_true
   end
 
+  it "returns true when passed ?r if the argument is readable by the effective uid" do
+    Kernel.test(?r, @file).should be_true
+  end
+
+  it "returns true when passed ?R if the argument is readable by the real uid" do
+    Kernel.test(?R, @file).should be_true
+  end
+
+  it "returns true when passed ?w if the argument is readable by the effective uid" do
+    Kernel.test(?w, @file).should be_true
+  end
+
+  it "returns true when passed ?W if the argument is readable by the real uid" do
+    Kernel.test(?W, @file).should be_true
+  end
+
   ruby_version_is "1.9" do
     it "calls #to_path on second argument when passed ?f and a filename" do
       p = mock('path')


### PR DESCRIPTION
This pull request adds four more flags to `Kernel.test`, but the majority still have not been implemented. I can continue working on the rest if that would help.

I added the `?w`, `?W`, `?r`, and `?R` Kernel file tests according to the current Ruby 2.0 Spec:

```
"w"  | boolean | True if file1 exists and is writable by
     |         | the effective uid/gid
"W"  | boolean | True if file1 exists and is writable by
     |         | the real uid/gid
"r"  | boolean | True if file1 is readable by the effective
     |         | uid/gid of the caller
"R"  | boolean | True if file is readable by the real
     |         | uid/gid of the caller
```

This pull request brings the number of `Kernel.test` commands up to 8 (`?d`, `?e`, `?f`, `?l`, `?r`, `?R`, `?w`, `?W`).

According to the Ruby 2.0 Spec the currently supported flags are:

```
Cmd    Returns   Meaning
"A"  | Time    | Last access time for file1
"b"  | boolean | True if file1 is a block device
"c"  | boolean | True if file1 is a character device
"C"  | Time    | Last change time for file1
"d"  | boolean | True if file1 exists and is a directory
"e"  | boolean | True if file1 exists
"f"  | boolean | True if file1 exists and is a regular file
"g"  | boolean | True if file1 has the \CF{setgid} bit
     |         | set (false under NT)
"G"  | boolean | True if file1 exists and has a group
     |         | ownership equal to the caller's group
"k"  | boolean | True if file1 exists and has the sticky bit set
"l"  | boolean | True if file1 exists and is a symbolic link
"M"  | Time    | Last modification time for file1
"o"  | boolean | True if file1 exists and is owned by
     |         | the caller's effective uid
"O"  | boolean | True if file1 exists and is owned by
     |         | the caller's real uid
"p"  | boolean | True if file1 exists and is a fifo
"r"  | boolean | True if file1 is readable by the effective
     |         | uid/gid of the caller
"R"  | boolean | True if file is readable by the real
     |         | uid/gid of the caller
"s"  | int/nil | If file1 has nonzero size, return the size,
     |         | otherwise return nil
"S"  | boolean | True if file1 exists and is a socket
"u"  | boolean | True if file1 has the setuid bit set
"w"  | boolean | True if file1 exists and is writable by
     |         | the effective uid/gid
"W"  | boolean | True if file1 exists and is writable by
     |         | the real uid/gid
"x"  | boolean | True if file1 exists and is executable by
     |         | the effective uid/gid
"X"  | boolean | True if file1 exists and is executable by
     |         | the real uid/gid
"z"  | boolean | True if file1 exists and has a zero length
Tests that take two files:

"-"  | boolean | True if file1 and file2 are identical
"="  | boolean | True if the modification times of file1
     |         | and file2 are equal
"<"  | boolean | True if the modification time of file1
     |         | is prior to that of file2
">"  | boolean | True if the modification time of file1
     |         | is after that of file2
```
