### PR TITLE
Configure script attempts to modify frozen strings from ARGV

### DIFF
--- a/configure
+++ b/configure
@@ -316,7 +316,7 @@ class Configure
     end
 
     o.on "--llvm-path", "PATH", "File system path to the directory containing LLVM" do |dir|
-      @llvm_path = dir
+      @llvm_path = dir.dup
     end
 
     o.on "--llvm-config", "PROGRAM", "File system path to the llvm-config program" do |program|
@@ -384,7 +384,7 @@ class Configure
 
     o.on "-P", "--prefix", "PATH", "Install Rubinius in subdirectories of PATH" do |dir|
       warn_prefix dir
-      @prefixdir = dir
+      @prefixdir = dir.dup
     end
 
     o.on "-B", "--bindir", "PATH", "Install Rubinius executable in PATH" do |dir|
@@ -396,11 +396,11 @@ class Configure
     end
 
     o.on "-A", "--appdir", "PATH", "Install Ruby runtime and libraries in PATH" do |dir|
-      @appdir = dir
+      @appdir = dir.dup
     end
 
     o.on "-L", "--libdir", "PATH", "Install Rubinius shared library in PATH" do |dir|
-      @libdir = dir
+      @libdir = dir.dup
     end
 
     o.on "-M", "--mandir", "PATH", "Install man pages in PATH" do |dir|


### PR DESCRIPTION
The strings contained in ARGV are frozen (and tainted) by default. While most of the ARGV strings that Rubinius reads in are expanded into non-frozen strings before anything is done with them, a few Configure instance variables are assigned from ARGV directly, and that leads to issues if the configure script later tries to modify the same string.

For example, on [lines 219-238](https://github.com/rubinius/rubinius/blob/master/configure#L219-L238), configure iterates over several of the string instance variables and runs `#replace` on them. Since one of the values is a frozen string, this raises an exception:

```
$ ./configure --libdir /tmp
./configure:238:in `replace': can't modify frozen String (RuntimeError)
    from ./configure:238:in `block in set_filesystem_paths'
    from ./configure:238:in `each'
    from ./configure:238:in `set_filesystem_paths'
    from ./configure:2024:in `run'
    from ./configure:2206:in `<main>'
```

In practice this means that at least `--libdir`, and probably other options, don't work at all.

This commit makes sure that any values taken directly from ARV are `#dup`ed before the strings are used.
