### PR TITLE
Allow RUBYLIB in build scripts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,23 +4,6 @@ require './rakelib/configure'
 
 include Rake::DSL if Rake.const_defined? :DSL
 
-if ENV["RUBYLIB"]
-  STDERR.puts <<-EOM
-WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
-WARNING                                                                 WARNING
-WARNING   You have the RUBYLIB environment variable set. This can       WARNING
-WARNING   cause serious problems building Rubinius, including but       WARNING
-WARNING   not limited to causing the build to fail or specs to fail     WARNING
-WARNING   or your computer to randomly emit strange beeping sounds      WARNING
-WARNING   or burst into flames. Not all these possible catastrophic     WARNING
-WARNING   effects have been observed in the wild, but you have been     WARNING
-WARNING   warned. We recommend unsetting this environment variable      WARNING
-WARNING   and running the build again.                                  WARNING
-WARNING                                                                 WARNING
-WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
-  EOM
-end
-
 # Wipe out CDPATH, it interferes with building in some cases,
 # see http://github.com/rubinius/rubinius/issues#issue/555
 if ENV["CDPATH"]

--- a/configure
+++ b/configure
@@ -1,10 +1,4 @@
 #!/usr/bin/env ruby
-
-if ENV["RUBYLIB"]
-  STDERR.puts "ERROR: Please unset RUBYLIB to configure Rubinius"
-  exit 1
-end
-
 require 'bundler/setup'
 require './rakelib/configure'
 require './rakelib/release'


### PR DESCRIPTION
These checks were added to guard against the case where a user might have e.g. "lib:test" in their RUBYLIB at build time, which would result in erraneously loading Rubinius' local `lib/rbconfig.rb` or `lib/rubygems.rb` instead of ones from MRI that's doing the build.

The above was my understanding of those checks. Please correct me if I'm wrong.

At first my idea was to make a more precise guard that the `$LOAD_PATH` doesn't contain the local `lib/` directory:

``` rb
libdir = File.expand_path('../lib', __FILE__)
if $:.map{ |p| File.expand_path(p) }.include?(libdir)
  STDERR.puts "Your RUBYLIB contains the local `lib' directory. Please unset it and try again."
  exit 1
end
```

However with `RUBYLIB=lib` in my environment, the `./configure` script never even reaches this check with MRI 1.9+.

Since `lib/rbconfig.rb` already has a guard against this, and MRI 1.9+ loads `rubygems.rb` automatically at runtime, tripping over the guard in `rbconfig.rb` immediately _before_ the RUBYLIB check even happens, the explicit `ENV["RUBYLIB"]` check is both unnecessary and unwanted since it prevents valid uses of RUBYLIB. The check also failed to account for the fact that extra load paths might have been added via RUBYOPT as well.

I have several valid uses of RUBYLIB in my environment, one of which is an rbenv plugin that sets RUBYLIB each time the ruby interpreter is invoked, and it hurts me that Rubinius decides to abort the build process, forcing me to unset RUBYLIB in both my shell and by manually disabling the rbenv plugin.

Reverts af5cae6519169841ca8bc97d7501e2ac707b47d7, 16d3c35a46455157581188f6766b722c98c659fa
References d4793b518bfd8f6c52553ff5694263c577230359
