### PR TITLE
Updated platform.rake to generate the same socket constants that Ruby 2.1 generates.

### DIFF
--- a/rakelib/platform.rake
+++ b/rakelib/platform.rake
@@ -275,6 +275,7 @@ file 'runtime/platform.conf' => deps do |task|
         AF_NETGRAPH
         AF_NS
         AF_OSI
+        AF_PACKET
         AF_PPP
         AF_PUP
         AF_ROUTE
@@ -290,6 +291,7 @@ file 'runtime/platform.conf' => deps do |task|
         AI_DEFAULT
         AI_MASK
         AI_NUMERICHOST
+        AI_NUMERICSERV
         AI_PASSIVE
         AI_V4MAPPED
         AI_V4MAPPED_CFG
@@ -304,10 +306,74 @@ file 'runtime/platform.conf' => deps do |task|
         EAI_MEMORY
         EAI_NODATA
         EAI_NONAME
+        EAI_OVERFLOW
         EAI_PROTOCOL
         EAI_SERVICE
         EAI_SOCKTYPE
         EAI_SYSTEM
+
+        IF_NAMESIZE
+
+        IFF_802_1Q_VLAN
+        IFF_ALLMULTI
+        IFF_ALTPHYS
+        IFF_AUTOMEDIA
+        IFF_BONDING
+        IFF_BRIDGE_PORT
+        IFF_BROADCAST
+        IFF_CANTCHANGE
+        IFF_CANTCONFIG
+        IFF_DEBUG
+        IFF_DISABLE_NETPOLL
+        IFF_DONT_BRIDGE
+        IFF_DORMANT
+        IFF_DRV_OACTIVE
+        IFF_DRV_RUNNING
+        IFF_DYING
+        IFF_DYNAMIC
+        IFF_EBRIDGE
+        IFF_ECHO
+        IFF_ISATAP
+        IFF_LINK0
+        IFF_LINK1
+        IFF_LINK2
+        IFF_LIVE_ADDR_CHANGE
+        IFF_LOOPBACK
+        IFF_LOWER_UP
+        IFF_MACVLAN_PORT
+        IFF_MASTER
+        IFF_MASTER_8023AD
+        IFF_MASTER_ALB
+        IFF_MASTER_ARPMON
+        IFF_MONITOR
+        IFF_MULTICAST
+        IFF_NOARP
+        IFF_NOTRAILERS
+        IFF_OACTIVE
+        IFF_OVS_DATAPATH
+        IFF_POINTOPOINT
+        IFF_PORTSEL
+        IFF_PPROMISC
+        IFF_PROMISC
+        IFF_RENAMING
+        IFF_ROUTE
+        IFF_RUNNING
+        IFF_SIMPLEX
+        IFF_SLAVE
+        IFF_SLAVE_INACTIVE
+        IFF_SLAVE_NEEDARP
+        IFF_SMART
+        IFF_STATICARP
+        IFF_SUPP_NOFCS
+        IFF_TEAM_PORT
+        IFF_TX_SKB_SHARING
+        IFF_UNICAST_FLT
+        IFF_UP
+        IFF_VOLATILE
+        IFF_WAN_HDLC
+        IFF_XMIT_DST_RELEASE
+
+        IFNAMSIZ
 
         INADDR_ALLHOSTS_GROUP
         INADDR_ANY
@@ -317,59 +383,149 @@ file 'runtime/platform.conf' => deps do |task|
         INADDR_NONE
         INADDR_UNSPEC_GROUP
 
+        INET6_ADDRSTRLEN
+        INET_ADDRSTRLEN
+
+        IP_ADD_MEMBERSHIP
+        IP_ADD_SOURCE_MEMBERSHIP
+        IP_BLOCK_SOURCE
+        IP_DEFAULT_MULTICAST_LOOP
+        IP_DEFAULT_MULTICAST_TTL
+        IP_DONTFRAG
+        IP_DROP_MEMBERSHIP
+        IP_DROP_SOURCE_MEMBERSHIP
+        IP_FREEBIND
+        IP_HDRINCL
+        IP_IPSEC_POLICY
+        IP_MAX_MEMBERSHIPS
+        IP_MINTTL
+        IP_MSFILTER
+        IP_MTU
+        IP_MTU_DISCOVER
+        IP_MULTICAST_IF
+        IP_MULTICAST_LOOP
+        IP_MULTICAST_TTL
+        IP_ONESBCAST
+        IP_OPTIONS
+        IP_PASSSEC
+        IP_PKTINFO
+        IP_PKTOPTIONS
+        IP_PMTUDISC_DO
+        IP_PMTUDISC_DONT
+        IP_PMTUDISC_WANT
+        IP_PORTRANGE
+        IP_RECVDSTADDR
+        IP_RECVERR
+        IP_RECVIF
+        IP_RECVOPTS
+        IP_RECVRETOPTS
+        IP_RECVSLLA
+        IP_RECVTOS
+        IP_RECVTTL
+        IP_RETOPTS
+        IP_ROUTER_ALERT
+        IP_SENDSRCADDR
+        IP_TOS
+        IP_TTL
+        IP_UNBLOCK_SOURCE
+        IP_XFRM_POLICY
+
         IPPORT_RESERVED
         IPPORT_USERRESERVED
 
+        IPPROTO_AH
         IPPROTO_BIP
+        IPPROTO_DSTOPTS
         IPPROTO_EGP
         IPPROTO_EON
+        IPPROTO_ESP
+        IPPROTO_FRAGMENT
         IPPROTO_GGP
         IPPROTO_HELLO
+        IPPROTO_HOPOPTS
         IPPROTO_ICMP
+        IPPROTO_ICMPV6
         IPPROTO_IDP
         IPPROTO_IGMP
         IPPROTO_IP
+        IPPROTO_IPV6
         IPPROTO_MAX
         IPPROTO_ND
+        IPPROTO_NONE
         IPPROTO_PUP
         IPPROTO_RAW
+        IPPROTO_ROUTING
         IPPROTO_TCP
         IPPROTO_TP
         IPPROTO_UDP
         IPPROTO_XTP
 
+        IPV6_CHECKSUM
+        IPV6_DONTFRAG
+        IPV6_DSTOPTS
+        IPV6_HOPLIMIT
+        IPV6_HOPOPTS
+        IPV6_JOIN_GROUP
+        IPV6_LEAVE_GROUP
+        IPV6_MULTICAST_HOPS
+        IPV6_MULTICAST_IF
+        IPV6_MULTICAST_LOOP
+        IPV6_NEXTHOP
+        IPV6_PATHMTU
+        IPV6_PKTINFO
+        IPV6_RECVDSTOPTS
+        IPV6_RECVHOPLIMIT
+        IPV6_RECVHOPOPTS
+        IPV6_RECVPATHMTU
+        IPV6_RECVPKTINFO
+        IPV6_RECVRTHDR
+        IPV6_RECVTCLASS
+        IPV6_RTHDR
+        IPV6_RTHDR_TYPE_0
+        IPV6_RTHDRDSTOPTS
+        IPV6_TCLASS
+        IPV6_UNICAST_HOPS
+        IPV6_USE_MIN_MTU
+        IPV6_V6ONLY
+
         IPX_TYPE
 
-        IP_ADD_MEMBERSHIP
-        IP_DEFAULT_MULTICAST_LOOP
-        IP_DEFAULT_MULTICAST_TTL
-        IP_DROP_MEMBERSHIP
-        IP_HDRINCL
-        IP_MAX_MEMBERSHIPS
-        IP_MULTICAST_IF
-        IP_MULTICAST_LOOP
-        IP_MULTICAST_TTL
-        IP_OPTIONS
-        IP_RECVDSTADDR
-        IP_RECVOPTS
-        IP_RECVRETOPTS
-        IP_RETOPTS
-        IP_TOS
-        IP_TTL
+        LOCAL_CONNWAIT
+        LOCAL_CREDS
+        LOCAL_PEERCRED
+
+        MCAST_BLOCK_SOURCE
+        MCAST_EXCLUDE
+        MCAST_INCLUDE
+        MCAST_JOIN_GROUP
+        MCAST_JOIN_SOURCE_GROUP
+        MCAST_LEAVE_GROUP
+        MCAST_LEAVE_SOURCE_GROUP
+        MCAST_MSFILTER
+        MCAST_UNBLOCK_SOURCE
 
         MSG_COMPAT
+        MSG_CONFIRM
         MSG_CTRUNC
         MSG_DONTROUTE
         MSG_DONTWAIT
         MSG_EOF
         MSG_EOR
+        MSG_ERRQUEUE
+        MSG_FASTOPEN
+        MSG_FIN
         MSG_FLUSH
         MSG_HAVEMORE
         MSG_HOLD
+        MSG_MORE
+        MSG_NOSIGNAL
         MSG_OOB
         MSG_PEEK
+        MSG_PROXY
         MSG_RCVMORE
+        MSG_RST
         MSG_SEND
+        MSG_SYN
         MSG_TRUNC
         MSG_WAITALL
 
@@ -382,12 +538,14 @@ file 'runtime/platform.conf' => deps do |task|
         NI_NUMERICSERV
 
         PF_APPLETALK
+        PF_ATM
         PF_AX25
         PF_CCITT
         PF_CHAOS
         PF_CNT
         PF_COIP
         PF_DATAKIT
+        PF_DEC
         PF_DLI
         PF_ECMA
         PF_HYLINK
@@ -408,6 +566,7 @@ file 'runtime/platform.conf' => deps do |task|
         PF_NETGRAPH
         PF_NS
         PF_OSI
+        PF_PACKET
         PF_PIP
         PF_PPP
         PF_PUP
@@ -420,9 +579,60 @@ file 'runtime/platform.conf' => deps do |task|
         PF_UNSPEC
         PF_XTP
 
+        SCM_BINTIME
+        SCM_CREDENTIALS
+        SCM_CREDS
+        SCM_RIGHTS
+        SCM_TIMESTAMP
+        SCM_TIMESTAMPNS
+        SCM_UCRED
+
         SHUT_RD
         SHUT_RDWR
         SHUT_WR
+
+        SO_ACCEPTCONN
+        SO_ACCEPTFILTER
+        SO_ALLZONES
+        SO_ATTACH_FILTER
+        SO_BINDTODEVICE
+        SO_BINTIME
+        SO_BROADCAST
+        SO_DEBUG
+        SO_DETACH_FILTER
+        SO_DONTROUTE
+        SO_DONTTRUNC
+        SO_ERROR
+        SO_KEEPALIVE
+        SO_LINGER
+        SO_MAC_EXEMPT
+        SO_NKE
+        SO_NO_CHECK
+        SO_NOSIGPIPE
+        SO_NREAD
+        SO_OOBINLINE
+        SO_PASSCRED
+        SO_PEERCRED
+        SO_PEERNAME
+        SO_PRIORITY
+        SO_RCVBUF
+        SO_RCVLOWAT
+        SO_RCVTIMEO
+        SO_RECVUCRED
+        SO_REUSEADDR
+        SO_REUSEPORT
+        SO_SECURITY_AUTHENTICATION
+        SO_SECURITY_ENCRYPTION_NETWORK
+        SO_SECURITY_ENCRYPTION_TRANSPORT
+        SO_SNDBUF
+        SO_SNDLOWAT
+        SO_SNDTIMEO
+        SO_TIMESTAMP
+        SO_TIMESTAMPNS
+        SO_TYPE
+        SO_USELOOPBACK
+        SO_WANTMORE
+        SO_WANTOOBFLAG
 
         SOCK_DGRAM
         SOCK_PACKET
@@ -439,50 +649,30 @@ file 'runtime/platform.conf' => deps do |task|
         SOL_TCP
         SOL_UDP
 
+        SOMAXCONN
+
         SOPRI_BACKGROUND
         SOPRI_INTERACTIVE
         SOPRI_NORMAL
 
-        SO_ACCEPTCONN
-        SO_ACCEPTFILTER
-        SO_ATTACH_FILTER
-        SO_BINDTODEVICE
-        SO_BROADCAST
-        SO_DEBUG
-        SO_DETACH_FILTER
-        SO_DONTROUTE
-        SO_DONTTRUNC
-        SO_ERROR
-        SO_KEEPALIVE
-        SO_LINGER
-        SO_NKE
-        SO_NOSIGPIPE
-        SO_NO_CHECK
-        SO_NREAD
-        SO_OOBINLINE
-        SO_PASSCRED
-        SO_PEERCRED
-        SO_PEERNAME
-        SO_PRIORITY
-        SO_RCVBUF
-        SO_RCVLOWAT
-        SO_RCVTIMEO
-        SO_REUSEADDR
-        SO_REUSEPORT
-        SO_SECURITY_AUTHENTICATION
-        SO_SECURITY_ENCRYPTION_NETWORK
-        SO_SECURITY_ENCRYPTION_TRANSPORT
-        SO_SNDBUF
-        SO_SNDLOWAT
-        SO_SNDTIMEO
-        SO_TIMESTAMP
-        SO_TYPE
-        SO_USELOOPBACK
-        SO_WANTMORE
-        SO_WANTOOBFLAG
-
+        TCP_CORK
+        TCP_DEFER_ACCEPT
+        TCP_FASTOPEN
+        TCP_INFO
+        TCP_KEEPCNT
+        TCP_KEEPIDLE
+        TCP_KEEPINTVL
+        TCP_LINGER2
         TCP_MAXSEG
+        TCP_MD5SIG
         TCP_NODELAY
+        TCP_NOOPT
+        TCP_NOPUSH
+        TCP_QUICKACK
+        TCP_SYNCNT
+        TCP_WINDOW_CLAMP
+
+        UDP_CORK
       ]
 
       socket_constants.each { |c| cg.const c }


### PR DESCRIPTION
This change will fix the following issues:
rubysl/rubysl-socket#2
rubinius/rubinius#2729

And will allow to apply this pull request: puma/puma#393
