### PR TITLE
Fixed download of https urls under proxy

### DIFF
--- a/configure
+++ b/configure
@@ -558,13 +558,12 @@ Unsupported language version requested: #{version}. Options are #{@supported_ver
       uri = url.kind_of?(URI) ? url : URI(url)
 
       if ENV['http_proxy']
-        protocol, userinfo, host, port  = URI::split(ENV['http_proxy'])
-        proxy_user, proxy_pass = userinfo.split(/:/) if userinfo
-        http = Net::HTTP::Proxy(host, port, proxy_user, proxy_pass)
+        protocol, userinfo, p_host, p_port  = URI::split(ENV['http_proxy'])
+        p_user, p_pass = userinfo.split(/:/) if userinfo
+        http = Net::HTTP.new(uri.host, uri.port, p_host, p_port, p_user, p_pass)
       else
         http = Net::HTTP.new(uri.host, uri.port)
       end
-
       http.use_ssl = true if uri.scheme == 'https'
       request = Net::HTTP::Get.new(uri.request_uri)
 


### PR DESCRIPTION
The [::Proxy class is obsolete](http://ruby-doc.org/stdlib-2.0.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-Proxy), thus it didn't had the `use_ssl` method, which was causing the error. So, I updated the download method to use the new way (pass the proxy parameters in constructor).

I'm not sure if this is the best impl, but it works.

This PR also fixes #2660, which contains 2 bugs reported (one related to SSL itself, other is this proxy issue).

Thanks
