### PR TITLE
Added missing rexml/document standard library stub.

### DIFF
--- a/library/rexml/document.rb
+++ b/library/rexml/document.rb
@@ -1,0 +1,2 @@
+Rubinius::CodeLoader.standard_library "rubysl/rexml"
+require 'rexml/document'


### PR DESCRIPTION
Required by rails, as seen on https://travis-ci.org/rails/rails/jobs/13340927. There are many more stubs that should be added to `rexml/`, but I don't know if you have something else in mind to solve this problem in the long term.
