### PR TITLE
Add spec for String#match calling Regexp#match

### DIFF
--- a/spec/ruby/core/string/fixtures/classes.rb
+++ b/spec/ruby/core/string/fixtures/classes.rb
@@ -46,4 +46,24 @@ module StringSpecs
       self.replace(str)
     end
   end
+
+  class RegexpHasBeenCalled < Regexp
+    attr_reader :match_called
+
+    def initialize *args
+      super *args
+      @match_called = 'no'
+    end
+
+    def match *args
+      super *args
+      @match_called = 'yes'
+    end
+  end
+
+  class RegexpChangeMatch < Regexp
+    def match *args
+      "regexp_match"
+    end
+  end
 end

--- a/spec/ruby/core/string/match_spec.rb
+++ b/spec/ruby/core/string/match_spec.rb
@@ -137,4 +137,17 @@ describe "String#match" do
     $~.should == nil
     Regexp.last_match.should == nil
   end
+
+  it "calls the Regexp's match function" do
+    reg = StringSpecs::RegexpHasBeenCalled.new("foo")
+
+    reg.match_called.should == 'no'
+    "bar".match(reg)
+    reg.match_called.should == 'yes'
+  end
+
+  it "returns the Regexp's match result" do
+    reg = StringSpecs::RegexpChangeMatch.new("foo")
+    "bar".match(reg).should == "regexp_match"
+  end
 end


### PR DESCRIPTION
I've added in two tests to check that Rubinius's String#match behavior matches the spec. In MRI, String#match creates a Regexp object and delegates to that object's Regexp#match function, but Rubinius bypasses creating the Regexp object entirely. This leads to divergent behavior if the Regexp#match function is modified but String#match is called.

Spec for convenience: http://ruby-doc.org/core-2.0.0/String.html#method-i-match

Running tests under MRI 2.0.0 and then rbx2.1.1 example: https://gist.github.com/pH14/7275834

Simple example: https://gist.github.com/pH14/7275913

My environment: Darwin pwh-argon.local 13.0.0 Darwin Kernel Version 13.0.0: Thu Sep 19 22:22:27 PDT 2013; root:xnu-2422.1.72~6/RELEASE_X86_64 x86_64
