### PR TITLE
Fix Array#sample when pass count argument

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -1260,9 +1260,10 @@ class Array
 
     rng = options[:random] if options
     rng = Kernel unless rng and rng.respond_to? :rand
+    random_range = (0...size)
 
     unless count
-      random = Rubinius::Type.coerce_to rng.rand, Fixnum, :to_int
+      random = Rubinius::Type.coerce_to rng.rand(random_range), Fixnum, :to_int
       raise RangeError, "random value must be >= 0" if random < 0
       raise RangeError, "random value must be less than Array size" unless random < size
 
@@ -1273,7 +1274,7 @@ class Array
     result = Array.new self
 
     count.times do |i|
-      random = Rubinius::Type.coerce_to rng.rand, Fixnum, :to_int
+      random = Rubinius::Type.coerce_to rng.rand(random_range), Fixnum, :to_int
       raise RangeError, "random value must be >= 0" if random < 0
       raise RangeError, "random value must be less than Array size" unless random < size
 


### PR DESCRIPTION
Array#sample when pass count argument returns first count elements always

``` ruby
arr = [1, 2, 3, 4, 5]
arr.sample(3) # => [3, 1, 2]
arr.sample(3) # => [3, 1, 2]
arr.sample(3) # => [3, 1, 2]
```
