### PR TITLE
Fix IO#gets(limit) for encoding-related corner case

### DIFF
--- a/kernel/common/io.rb
+++ b/kernel/common/io.rb
@@ -171,6 +171,28 @@ class IO
       end
     end
 
+    PEEK_AHEAD_LIMIT = 16
+
+    def read_to_char_boundary(io, str)
+      str.force_encoding(io.external_encoding || Encoding.default_external)
+      return IO.read_encode(io, str) if str.valid_encoding?
+
+      peek_ahead = 0
+      while size > 0 and peek_ahead < PEEK_AHEAD_LIMIT
+        str.force_encoding Encoding::ASCII_8BIT
+        str << @storage[@start]
+        @start += 1
+        peek_ahead += 1
+
+        str.force_encoding(io.external_encoding || Encoding.default_external)
+        if str.valid_encoding?
+          return IO.read_encode io, str
+        end
+      end
+
+      IO.read_encode io, str
+    end
+
     ##
     # Returns one Fixnum as the start byte.
     def getbyte(io)
@@ -1243,7 +1265,7 @@ class IO
           if wanted < available
             str << @buffer.shift(wanted)
 
-            str = IO.read_encode(@io, str)
+            str = @buffer.read_to_char_boundary(@io, str)
             str.taint
 
             $. = @io.increment_lineno
@@ -1294,7 +1316,7 @@ class IO
         if wanted < available
           str << @buffer.shift(wanted)
 
-          str = IO.read_encode(@io, str)
+          str = @buffer.read_to_char_boundary(@io, str)
           str.taint
 
           $. = @io.increment_lineno

--- a/spec/ruby/core/io/gets_spec.rb
+++ b/spec/ruby/core/io/gets_spec.rb
@@ -223,6 +223,27 @@ ruby_version_is "1.9" do
 
   describe "IO#gets" do
     before :each do
+      @name = tmp("io_gets")
+      touch(@name) { |f| f.write "朝日" + "\xE3\x81" * 100 }
+      @io = new_io @name, fmode("r:utf-8")
+    end
+
+    it "reads limit bytes and extra bytes when limit is reached not at character boundary" do
+      [@io.gets(1), @io.gets(1)].should == ["朝", "日"]
+    end
+
+    it "read limit bytes and extra bytes with maximum of 16" do
+      @io.gets(7).should == "朝日\xE3" + "\x81\xE3" * 8
+    end
+
+    after :each do
+      rm_r @name
+      @io.close
+    end
+  end
+
+  describe "IO#gets" do
+    before :each do
       @external = Encoding.default_external
       @internal = Encoding.default_internal
 


### PR DESCRIPTION
I'm aware repeatedly calling String#valid_encoding? is slow. So I request for better solutions.

This bug is found when just using the rubysl-csv. So this bug is causing errors in the wild.

Encoding nightmare. :p
