### PR TITLE
Note that not all standard libraries are implemented

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 1. What is Rubinius
 
-Rubinius is an implementation of the Ruby programming language. Rubinius is
-compatible with Ruby version 2.1.
+Rubinius is an implementation of the Ruby programming language. Rubinius aims
+to be compatible with Ruby version 2.1.
 
 Rubinius includes a Ruby parser, bytecode virtual machine, bytecode compiler,
 generational garbage collector, and just-in-time (JIT) native machine code
@@ -10,7 +10,10 @@ Rubinius also provides C-API compatibility for native C extensions.
 
 The Ruby core library is written almost entirely in Ruby. Rubinius tools, such
 as the bytecode compiler and debugger, are also written in Ruby.  Rubinius
-provides the same standard libraries as Matz's Ruby implementation (MRI). 
+provides the same standard libraries as Matz's Ruby implementation (MRI) with
+the following exceptions:
+
+* Ripper
 
 Rubinius runs on Mac OS X and many Unix/Linux operating systems.  Microsoft
 Windows is not yet supported.


### PR DESCRIPTION
This was the cause of my confusion about https://github.com/rubysl/rubysl-ripper/issues/1.
