### PR TITLE
Added CompiledCode#to_sym, which returns #name

### DIFF
--- a/kernel/common/compiled_code.rb
+++ b/kernel/common/compiled_code.rb
@@ -641,6 +641,17 @@ module Rubinius
 
         return str
       end
+      
+      ##
+      # Returns the name symbol.
+      #
+      # When a method is defined and the CompiledCode object is returned,
+      # it can be used to coerce for compatibility with the MRI 2.1 behavior
+      # of returning the defined method name as a symbol.
+      #
+      def to_sym
+        name
+      end
     end
   end
 end


### PR DESCRIPTION
In MRI 2.1, defining a method returns the method name as a symbol.  This symbol can then be used for any number of things, one exciting one being implementing a clean-looking decorator pattern such as:

``` ruby
my_decorator def foo(*args); end
```

The decorator method can pass the symbol to `instance_method(name)` to get a reference to the UnboundMethod object a bind it up and call it later within a new method that encases with a decorating wrapper.

Rubinius, however, returns the CompiledCode object, which in my opinion is far more useful and I don't particularly want it changed to return only the symbol.  

To this end, I wanted to make an effort for compatibility without giving up the power of having the CompiledCode object, so I added #to_sym, which will return the #name.  For methods, this will be the same symbol that would have been returned by MRI.

To make compatibility matters even better, #to_sym need not explicity be called before passing to methods like `instance_method(name)`, because such methods try to implicitly coerce the value, so the CompiledCode object can be passed directly in without platform checking, object type checking, or even duck typing. 
