### PR TITLE
changes to make custom program name work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -133,7 +133,7 @@ class SpecRunner
   def run(suite=:ci_files, flags=nil)
     self.class.set_at_exit_handler
 
-    sh("bin/mspec ci :#{suite} #{ENV['CI_MODE_FLAG'] || flags} -d --agent --background", &@handler)
+    sh("bin/mspec ci :#{suite} #{ENV['CI_MODE_FLAG'] || flags} -t bin/#{BUILD_CONFIG[:program_name]} -d --agent --background", &@handler)
   end
 end
 

--- a/spec/library/config/rbconfig_spec.rb
+++ b/spec/library/config/rbconfig_spec.rb
@@ -65,7 +65,7 @@ describe "RbConfig::CONFIG" do
 
   entries = {
     "RUBY_SO_NAME"      => "rubinius-#{Rubinius::VERSION}",
-    "ruby_install_name" => "rbx",
+    "ruby_install_name" => Rubinius::PROGRAM_NAME,
     "rubyhdrdir"        => Rubinius::HDR_PATH
   }
 


### PR DESCRIPTION
Fix two minor bugs that cause the build to break if you specify a custom program name. 

call mspec with -t and custom program name.
fix spec to check custom program name.
