### PR TITLE
uninitialized constant Find for rake todo task

### DIFF
--- a/rakelib/todo.rake
+++ b/rakelib/todo.rake
@@ -1,4 +1,5 @@
 # -*- ruby -*-
+require 'find'
 
 task :todo do
   excludes = Hash.new 0


### PR DESCRIPTION
On a fresh rbx installation -> rake todo ends with following error

``` bash
benny@benny-X55C:/var/www/rubiniusdev$ rake todo
rake aborted!
uninitialized constant Find
/var/www/rubiniusdev/rakelib/todo.rake:5:in `block in <top (required)>'
/home/benny/.rvm/gems/ruby-2.0.0-p353@developing/bin/ruby_executable_hooks:15:in `eval'
/home/benny/.rvm/gems/ruby-2.0.0-p353@developing/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => todo
(See full trace by running task with --trace)
```

Added require 'find' for task todo in todo.rake
