### PR TITLE
Make gc survivor benchmarks use non-trivial objs

### DIFF
--- a/benchmark/gc/survivor_rate/bench_survivor_rate_000.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_000.rb
@@ -8,25 +8,28 @@ Benchmark.ips do |x|
   x.report "0% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_010.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_010.rb
@@ -8,28 +8,31 @@ Benchmark.ips do |x|
   x.report "10% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 10 == 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_020.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_020.rb
@@ -8,28 +8,31 @@ Benchmark.ips do |x|
   x.report "20% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 5 == 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_025.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_025.rb
@@ -8,28 +8,31 @@ Benchmark.ips do |x|
   x.report "25% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 4 == 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_033.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_033.rb
@@ -8,28 +8,31 @@ Benchmark.ips do |x|
   x.report "33% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 3 == 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_050.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_050.rb
@@ -8,28 +8,31 @@ Benchmark.ips do |x|
   x.report "50% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 2 == 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_075.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_075.rb
@@ -5,31 +5,34 @@ require 'benchmark/helpers'
 Benchmark.ips do |x|
 
   gatherer = []
-  x.report "75% survivor rate" do |times|
+  x.report "100% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 4 != 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+

--- a/benchmark/gc/survivor_rate/bench_survivor_rate_100.rb
+++ b/benchmark/gc/survivor_rate/bench_survivor_rate_100.rb
@@ -8,28 +8,31 @@ Benchmark.ips do |x|
   x.report "100% survivor rate" do |times|
     i = 0
     while i < times
-      obj = Object.new
+      obj = [1,i]
       if i % 1 == 0
-        gatherer << Object.new
+        gatherer << obj
       end
       i += 1
     end
   end
 end
 
-require 'rubinius/agent'
-agent = Rubinius::Agent.loopback
-young_size  = agent.get('system.memory.young.bytes').last
-mature_size = agent.get('system.memory.mature.bytes').last
-large_size  = agent.get('system.memory.large.bytes').last
-code_size   = agent.get('system.memory.code.bytes').last
-symbol_size = agent.get('system.memory.symbols.bytes').last
+if "rubinius" ==  `ruby -v`.split(' ')[0]
+  require 'rubinius/agent'
+  agent = Rubinius::Agent.loopback
+  young_size  = agent.get('system.memory.young.bytes').last
+  mature_size = agent.get('system.memory.mature.bytes').last
+  large_size  = agent.get('system.memory.large.bytes').last
+  code_size   = agent.get('system.memory.code.bytes').last
+  symbol_size = agent.get('system.memory.symbols.bytes').last
 
-puts "Young  GC size:  #{young_size / 1024}kB"
-puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
-puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
+  puts "Young  GC size:  #{young_size / 1024}kB"
+  puts "Young  GC count: #{agent.get('system.gc.young.count').last}"
+  puts "Young  GC time:  #{agent.get('system.gc.young.total_wallclock').last}ms"
 
-puts "Mature GC size:  #{mature_size / 1024}kB"
-puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
-puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
-puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+  puts "Mature GC size:  #{mature_size / 1024}kB"
+  puts "Mature GC count: #{agent.get('system.gc.full.count').last}"
+  puts "Mature GC time:  #{agent.get('system.gc.full.total_stop_wallclock').last}ms"
+  puts "Young  GC waste: #{(young_size.to_f / 2) / (young_size + mature_size + large_size + code_size + symbol_size) * 100}%"
+end
+


### PR DESCRIPTION
only one line makes a new object to fix the survivor rates
if statement added so that it can also run on MRI for comparison
