### PR TITLE
fix unusual interpreter references on #! line.

### DIFF
--- a/benchmark/app/rdoc-2.4.3/lib/rdoc/generator/darkfish.rb
+++ b/benchmark/app/rdoc-2.4.3/lib/rdoc/generator/darkfish.rb
@@ -1,4 +1,4 @@
-#!ruby
+#
 # vim: noet ts=2 sts=8 sw=2
 
 require 'rubygems'

--- a/benchmark/yarv/bm_app_pentomino.rb
+++ b/benchmark/yarv/bm_app_pentomino.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby
+#!/usr/bin/ruby
 # This program is contributed by Shin Nishiyama
 
 

--- a/library/bin/irb.rb
+++ b/library/bin/irb.rb
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
+#!/usr/bin/ruby
 #
 #   irb.rb - intaractive ruby
 #   	$Release Version: 0.9.5 $

--- a/library/bin/rar.rb
+++ b/library/bin/rar.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rubinius
+#!/usr/bin/ruby
 
 require 'bytecode/compiler'
 require 'bytecode/rubinius'


### PR DESCRIPTION
lintian found several unusal interpreters and paths on #! lines.

I removed the line from darkfish.rb as no other file in that library had a #! line.
The others I set to /usr/bin/ruby as that appear to be the most used but
perhaps /usr/bin/env ruby would be better.
