### PR TITLE
Remove unused -Xthread.debug option

### DIFF
--- a/library/rubinius/configuration.rb
+++ b/library/rubinius/configuration.rb
@@ -181,8 +181,5 @@ Rubinius::ConfigurationVariables.define do |c|
   c.vm_variable "vm.crash_report_path", :string,
     :as => "report_path",
     :description => "Set a custom path to write crash reports"
-
-  c.vm_variable "thread.debug", false,
-    "Print threading notices when they occur"
 end
 

--- a/vm/oop.cpp
+++ b/vm/oop.cpp
@@ -578,11 +578,6 @@ step2:
       case eAuxWordEmpty:
       case eAuxWordObjID:
       case eAuxWordHandle:
-        // Um. well geez. We don't have this object locked.
-        if(state->shared().config.thread_debug) {
-          std::cerr << "[THREAD] Attempted to unlock an unlocked object.\n";
-        }
-
         if(cDebugThreading) {
           std::cerr << "[LOCK " << state->vm()->thread_id() << " attempted to unlock an unlocked header]\n";
         }
@@ -598,13 +593,6 @@ step2:
               << "]\n";
           }
 
-          if(state->shared().config.thread_debug) {
-            std::cerr
-              << "[THREAD] Attempted to unlock an object locked by other thread."
-              << "locker=" << locker_tid
-              << ", current=" << state->vm()->thread_id()
-              << "\n";
-          }
           return eLockError;
         }
 


### PR DESCRIPTION
Debugging information for threads is set at compile time
not runtime. This patch removes the unused -Xthread.debug option
along with two redundant messages that were already controlled
by the cDebugThreading variable set at compile time.
