### PR TITLE
Remove unused main_thread parameter from Thread::create.

### DIFF
--- a/vm/agent.cpp
+++ b/vm/agent.cpp
@@ -444,7 +444,7 @@ auth_error:
 
     vm_ = state->shared().new_vm();
     exit_ = false;
-    thread_.set(Thread::create(state, vm_, G(thread), query_agent_tramp, false, true));
+    thread_.set(Thread::create(state, vm_, G(thread), query_agent_tramp, true));
     run(state);
   }
 

--- a/vm/builtin/thread.cpp
+++ b/vm/builtin/thread.cpp
@@ -46,7 +46,7 @@ namespace rubinius {
   }
 
   Thread* Thread::create(STATE, VM* target, Object* self, Run runner,
-                         bool main_thread, bool system_thread)
+                         bool system_thread)
   {
     Thread* thr = state->vm()->new_object_mature<Thread>(G(thread));
 

--- a/vm/builtin/thread.hpp
+++ b/vm/builtin/thread.hpp
@@ -287,7 +287,7 @@ namespace rubinius {
      *  @see  Thread::allocate().
      */
     static Thread* create(STATE, VM* target, Object* self, Run runner,
-                          bool main_thread = false, bool system_thread = false);
+                          bool system_thread = false);
 
     int start_new_thread(STATE, const pthread_attr_t &attrs);
     static void* in_new_thread(void*);

--- a/vm/gc/finalize.cpp
+++ b/vm/gc/finalize.cpp
@@ -126,7 +126,7 @@ namespace rubinius {
     self_ = state->shared().new_vm();
     paused_ = false;
     exit_ = false;
-    thread_.set(Thread::create(state, self_, G(thread), finalizer_handler_tramp, false, true));
+    thread_.set(Thread::create(state, self_, G(thread), finalizer_handler_tramp, true));
     run(state);
   }
 

--- a/vm/gc/immix_marker.cpp
+++ b/vm/gc/immix_marker.cpp
@@ -52,7 +52,7 @@ namespace rubinius {
     self_ = state->shared().new_vm();
     paused_ = false;
     exit_ = false;
-    thread_.set(Thread::create(state, self_, G(thread), immix_marker_tramp, false, true));
+    thread_.set(Thread::create(state, self_, G(thread), immix_marker_tramp, true));
     run(state);
   }
 

--- a/vm/signal.cpp
+++ b/vm/signal.cpp
@@ -69,7 +69,7 @@ namespace rubinius {
     self_ = state->shared().new_vm();
     paused_ = false;
     exit_ = false;
-    thread_.set(Thread::create(state, self_, G(thread), signal_handler_tramp, false, true));
+    thread_.set(Thread::create(state, self_, G(thread), signal_handler_tramp, true));
     run(state);
   }
 

--- a/vm/vm.cpp
+++ b/vm/vm.cpp
@@ -134,7 +134,7 @@ namespace rubinius {
 
     // Setup the main Thread, which is wrapper of the main native thread
     // when the VM boots.
-    thread.set(Thread::create(&state, this, G(thread), 0, true), &globals().roots);
+    thread.set(Thread::create(&state, this, G(thread), 0), &globals().roots);
     thread->alive(&state, cTrue);
     thread->sleep(&state, cFalse);
 


### PR DESCRIPTION
The `main_thread` parameter for `Thread::create` looks like it is old code that is not used anymore.
