### PR TITLE
Allow compiling with clang++ using -std=c++11 flag

### DIFF
--- a/configure
+++ b/configure
@@ -1279,7 +1279,7 @@ int main() { return tgetnum(""); }
       includes.each do |i|
         src.puts "#include <#{i}>"
       end
-      src.puts "int main() { void* ptr = &#{name}; }"
+      src.puts "int main() { void* ptr = (void *) &#{name}; }"
     end
   end
 
@@ -1334,7 +1334,7 @@ int main() { return tgetnum(""); }
 
     @log.log string
 
-    cmd = "#{@cxx} -S -o - -x c #{defines.join(" ")} #{@user_cppflags} #{@user_cxxflags} #{@user_cflags} #{@user_ldflags} #{@system_cppflags} #{@system_cxxflags} #{@system_cflags} #{@system_ldflags} #{file.path} >>#{@log.path} 2>&1"
+    cmd = "#{@cxx} -S -o - -x c++ #{defines.join(" ")} #{@user_cppflags} #{@user_cxxflags} #{@user_cflags} #{@user_ldflags} #{@system_cppflags} #{@system_cxxflags} #{@system_cflags} #{@system_ldflags} #{file.path} >>#{@log.path} 2>&1"
     @log.log cmd
     system cmd
 


### PR DESCRIPTION
I need to use c++11 features for something I'm working on, and I usually build with clang.  I had to
make a couple of changes for this to work and I thought they might also be useful for the mainline.

Patch includes changes needed for `CXXFLAGS=-std=c++11` to work
with clang++.

1) configure script should run in c++ mode when checking functions
otherwise clang++ gives an error.

2)`typeof` operator doesn't work in c++11 mode with clang++.  But
`__typeof__` is a valid replacement.
