### PR TITLE
Creates --use-gemfile-git option to use git repos for runtime gems

### DIFF
--- a/configure
+++ b/configure
@@ -497,6 +497,10 @@ class Configure
       @stagingdir = expand dir
     end
 
+    o.on "--use-gemfile-git", "Use Git sources listed in Gemfile for runtime gems cached in vendor/cache" do
+      @use_gemfile_git= true
+    end
+
     o.doc "\n Optional features"
 
     feature "stdlib", true
@@ -1986,7 +1990,12 @@ int main() { return tgetnum(""); }
       gems.each do |name, version|
         gem = "#{name}-#{version}.gem"
         next if File.exist? gem
-
+        if @use_gemfile_git && Bundler.load.gems[name].first
+          if Bundler.load.gems[name].first.source.respond_to? :app_cache_dirname
+            next
+          end
+        end
+            
         failed = true unless download "https://rubygems.org/gems/#{gem}", "./#{gem}"
       end
     end
@@ -2039,6 +2048,15 @@ int main() { return tgetnum(""); }
       list.each do |name, version|
         gem_name = "#{name}-#{version}"
         unless File.directory? gem_name
+          if @use_gemfile_git && Bundler.load.gems[name].first
+            if Bundler.load.gems[name].first.source.respond_to? :app_cache_dirname
+              gem_src = source + "/" + Bundler.load.gems[name].first.source.app_cache_dirname.to_s
+              FileUtils.cp_r gem_src, gem_name
+              @log.write "Copied   gem: '#{gem_src}'"
+              next
+            end
+          end
+
           gem = "#{source}/#{gem_name}.gem"
           system("#{@gem} unpack #{gem}")
 

--- a/rakelib/gems.rake
+++ b/rakelib/gems.rake
@@ -27,6 +27,7 @@ namespace :gems do
       begin
         ENV["RBX_RUN_COMPILED"] = "1"
         bootstrap_rubinius "./extconf.rbc"
+        sh "#{BUILD_CONFIG[:build_make]} clean"
         sh "#{BUILD_CONFIG[:build_make]} && #{BUILD_CONFIG[:build_make]} install"
       ensure
         ENV.delete "RBX_RUN_COMPILED"


### PR DESCRIPTION
This patch adds the --use-gemfile-git option which causes the
configure script to use the git repo directories in vendor/cache
directory when copying gems to the runtime/gems directory.

This can be used along with `bundle package --all` to use git
gems specified in the Gemfile instead of downloading the gems
from rubygems.org.

Also adds `make clean` command when building rubinius-melbourne
because copied files for this gem don't always trigger rebuild.
