### PR TITLE
Ensure readline/readline.h is available during the configure process

### DIFF
--- a/configure
+++ b/configure
@@ -1473,6 +1473,10 @@ int main() { return tgetnum(""); }
       failure "openssl/ssl.h is required"
     end
 
+    unless has_header("readline/readline.h")
+      failure "readline/readline.h is required"
+    end
+
     if has_header("alloca.h")
       @defines << "HAVE_ALLOCA_H"
     end


### PR DESCRIPTION
... for readhline/readline.h

Without this patch, compilation of extensions will fail down the line. While I realize this is
often normal behavior, I think it makes sense to error out quickly so people don't waste time
just staring at stdout before an obvious error rears its head. There are probably other headers
we should eventually add, like openssl and zlib, but I figured this would be useful just to get
the basics in place.
