### PR TITLE
Rewrite tr_trans mehold to improve performance

### DIFF
--- a/spec/ruby/core/string/tr_s_spec.rb
+++ b/spec/ruby/core/string/tr_s_spec.rb
@@ -70,6 +70,22 @@ describe "String#tr_s" do
       b.encoding.should == Encoding::UTF_8
     end
 
+    it "can replace a 7-bit ASCII character with a multibye one in invert mode" do
+      a = "abc"
+      a.encoding.should == Encoding::UTF_8
+      b = a.tr_s("^bc", "我")
+      b.should == "我bc"
+      b.encoding.should == Encoding::UTF_8
+    end
+
+    it "can replace a multibyte character with another multibyte one and replace a 7-bit ASCII character with a multibye one" do
+      a = "我abc"
+      a.encoding.should == Encoding::UTF_8
+      b = a.tr_s("我a", "你")
+      b.should == "你bc"
+    end
+
+
     it "can replace multiple 7-bit ASCII characters with a multibyte one" do
       a = "uuuber"
       a.encoding.should == Encoding::UTF_8

--- a/spec/ruby/core/string/tr_spec.rb
+++ b/spec/ruby/core/string/tr_spec.rb
@@ -82,6 +82,21 @@ describe "String#tr" do
       b.encoding.should == Encoding::UTF_8
     end
 
+    it "can replace a 7-bit ASCII character with a multibye one in invert mode" do
+      a = "abc"
+      a.encoding.should == Encoding::UTF_8
+      b = a.tr("^bc", "我")
+      b.should == "我bc"
+      b.encoding.should == Encoding::UTF_8
+    end
+
+    it "can replace a multibyte character with another multibyte one and replace a 7-bit ASCII character with a multibye one" do
+      a = "我abc"
+      a.encoding.should == Encoding::UTF_8
+      b = a.tr("我a", "你")
+      b.should == "你你bc"
+    end
+
     it "can replace a multibyte character with a single byte one" do
       a = "über"
       a.encoding.should == Encoding::UTF_8


### PR DESCRIPTION
```
- I had add a new private method tr_trans_ascii_only to deal
  with ascii only string.
- In order to get the best performance, I did not follow the DRY
  rule.
- I also did some benchmark. you can check them.
  (https://gist.github.com/felix125/11235967)
- Solve multiple char issue also.
  (https://github.com/rubinius/rubinius/issues/3015)
- Add some specs, and i think we need more specs!!
```
