### PR TITLE
Update instructions & rubinius version num: 2.2.7

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -3,7 +3,7 @@ rubinius-2.2 for Debian
 
 Debian Stable Package files for Rubinius 
 
-This is for version 2.2.6 of rubinius. Version prior to 2.2.4 requires patches
+This is for version 2.2.7 of rubinius. Version prior to 2.2.4 requires patches
 to complete the package build. This is for Wheezy/Stable of Debian. Oldstable
 patches exist elsewhere.
 
@@ -24,11 +24,10 @@ To build the deb on Wheezy/Stable.
     cd rubinius-2.2.2
 
 # REQUIRED!
-# install bundler on to the system. 
-    sudo gem install vendor/cache/bundler-1.3.5.gem 
-# If using MRI 1.9 you MUST 
-# install the newer verion of rake into the system.
-    sudo gem install vendor/cache/rake-10.1.1.gem 
+# install bundler on to the system.
+    sudo gem install bundler --version=1.6.2
+# Install required gems from the Rubinius Gemfile:
+    bundle install
 
 # build package as usual
     dpkg-buildpackage -rfakeroot 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rubinius-2.2 (2.2.7) stable; urgency=low
+
+  * stable build of 2.2.7
+
+ -- slaught <chad.slaughter+debian@gmail.com>  Wed, 21 May 2014 11:40:57 -0500
+
 rubinius-2.2 (2.2.6) stable; urgency=low
 
   * stable build of 2.2.6


### PR DESCRIPTION
Pull request updates the version number of Rubinius that is generated when creating a Debian package from the /debian directory. Also a slight tweak to the instructions. 
