### PR TITLE
Optimize flat_map to iterate once instead of twice

### DIFF
--- a/kernel/common/enumerable.rb
+++ b/kernel/common/enumerable.rb
@@ -89,7 +89,10 @@ module Enumerable
 
   def flat_map(&block)
     return to_enum(:flat_map) unless block_given?
-    map(&block).flatten(1)
+    inject([]) do |a, e|
+      result = block.call(e)
+      Rubinius::Type.object_respond_to_ary?(result) ? a.concat(result) : a.push(result)
+    end
   end
   alias_method :collect_concat, :flat_map
 


### PR DESCRIPTION
``` ruby
require 'benchmark/ips'

ARRAY = [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
PROC  = proc { |x| x }

def slow(enum, &block)
  enum.map(&block).flatten(1)
end

def fast(enum, &block)
  enum.inject([]) { |a, e| e.is_a?(Array) ? a.concat(block.call(e)) : a.push(block.call(e)) }
end

Benchmark.ips do |x|
  x.report("slow") { slow(ARRAY, &PROC) }
  x.report("fast") { fast(ARRAY, &PROC) }
end
```

```
slow 289362.8 (±7.2%) i/s - 1440698 in 5.004836s
fast 450063.1 (±6.7%) i/s - 2244970 in 5.010861s
```
