### PR TITLE
Remove use of 'register' keyword

### DIFF
--- a/vm/builtin/byte_array.cpp
+++ b/vm/builtin/byte_array.cpp
@@ -177,7 +177,7 @@ namespace rubinius {
 
     uint8_t* pos1 = this->bytes + start;
     uint8_t* pos2 = this->bytes + total - 1;
-    register uint8_t tmp;
+    uint8_t tmp;
 
     while(pos1 < pos2) {
       tmp = *pos1;

--- a/vm/builtin/mono_inline_cache.cpp
+++ b/vm/builtin/mono_inline_cache.cpp
@@ -66,7 +66,7 @@ namespace rubinius {
     MonoInlineCache* cache = reinterpret_cast<MonoInlineCache*>(call_site);
     Class* const recv_class = args.recv()->direct_class(state);
 
-    register uint64_t recv_data = recv_class->data_raw();
+    uint64_t recv_data = recv_class->data_raw();
 
     if(likely(cache->receiver_.raw == recv_data)) {
       cache->hits_++;
@@ -82,7 +82,7 @@ namespace rubinius {
 
     Class* const recv_class = args.recv()->direct_class(state);
 
-    register uint64_t recv_data = recv_class->data_raw();
+    uint64_t recv_data = recv_class->data_raw();
 
     if(likely(cache->receiver_.raw == recv_data)) {
       cache->hits_++;

--- a/vm/builtin/poly_inline_cache.hpp
+++ b/vm/builtin/poly_inline_cache.hpp
@@ -107,7 +107,7 @@ namespace rubinius {
     }
 
     InlineCacheEntry* get_entry(Class* const recv_class) const {
-      register uint64_t recv_data = recv_class->data_raw();
+      uint64_t recv_data = recv_class->data_raw();
       for(int i = 0; i < cTrackedICHits; ++i) {
         InlineCacheEntry* ice = entries_[i];
         if(likely(ice && ice->receiver_data_raw() == recv_data)) return ice;

--- a/vm/builtin/respond_to_cache.cpp
+++ b/vm/builtin/respond_to_cache.cpp
@@ -50,7 +50,7 @@ namespace rubinius {
         visibility            = args.get_argument(1);
       }
 
-      register uint64_t recv_data = recv_class->data_raw();
+      uint64_t recv_data = recv_class->data_raw();
       if(likely(recv_data == cache->receiver_data_raw() && message == cache->message_ && visibility == cache->visibility_)) {
         cache->hit();
         return cache->responds_;

--- a/vm/builtin/tuple.cpp
+++ b/vm/builtin/tuple.cpp
@@ -287,7 +287,7 @@ namespace rubinius {
     Object** pos1 = field + start;
     Object** pos2 = field + end;
 
-    register Object* tmp;
+    Object* tmp;
     while(pos1 < pos2) {
       tmp = *pos1;
       *pos1++ = *pos2;

--- a/vm/instructions.cpp
+++ b/vm/instructions.cpp
@@ -86,8 +86,8 @@ Object* MachineCode::interpreter(STATE,
   InterpreterState is;
   GCTokenImpl gct;
 
-  register opcode* ip_ptr = mcode->opcodes;
-  register Object** stack_ptr = call_frame->stk - 1;
+  opcode* ip_ptr = mcode->opcodes;
+  Object** stack_ptr = call_frame->stk - 1;
 
   UnwindInfoSet unwinds;
 

--- a/vm/oop.cpp
+++ b/vm/oop.cpp
@@ -765,7 +765,7 @@ step2:
     void** dst = this->__body__;
     size_t field_count = bytes_to_fields(bytes);
 
-    for(register size_t counter = 0; counter < field_count; ++counter) {
+    for(size_t counter = 0; counter < field_count; ++counter) {
       dst[counter] = cNil;
     }
   }

--- a/vm/oop.hpp
+++ b/vm/oop.hpp
@@ -426,7 +426,7 @@ Object* const cUndef = reinterpret_cast<Object*>(0x22L);
 
     /* The whole point of this is inlining */
     size_t size_in_bytes(VM* vm) const {
-      register size_t size = TypeInfo::instance_sizes[type_id()];
+      size_t size = TypeInfo::instance_sizes[type_id()];
       if(size != 0) {
         return size;
       } else {


### PR DESCRIPTION
The 'register' keyword is not used by modern compilers and it is
depracted in C++11.  When compiling with clang++ and the -std=c++11
flag the depracated keyword triggers a warning which causes compilation
to fail since warnings are treated as errors.
