### PR TITLE
Use FileUtils.rm_r to cleanup rbx-configure-test files

### DIFF
--- a/configure
+++ b/configure
@@ -1052,8 +1052,11 @@ Unsupported language version requested: #{version}. Options are #{@supported_ver
 
       system expand("./#{basename}")
       return $?.exitstatus
+    rescue => e
+      @log.log "Error in check_program: #{e.class} #{e.message}\n  #{e.backtrace.join("\n  ")}"
+      raise e
     ensure
-      File.delete(*Dir["#{basename}*"])
+      FileUtils.rm_r(Dir["#{basename}*"])
     end
   end
 


### PR DESCRIPTION
XCode on Mac OSX likes to create a rbx-configure-test.dSYM directory that File.delete can't remove while running ./configure. Using FIleUtils.rm_r fixes this issue.

Mac OSX 10.9.4
XCode 5.1.1
