### PR TITLE
Remove 'register' keyword from st.h in C API

### DIFF
--- a/vm/include/capi/ruby/st.h
+++ b/vm/include/capi/ruby/st.h
@@ -133,7 +133,7 @@ static const struct st_hash_type type_st_internal_strcasehash = {
 };
 
 static void st_internal_rehash(st_table *);
-static int st_insert(register st_table *, register st_data_t, st_data_t);
+static int st_insert(st_table *, st_data_t, st_data_t);
 
 #define st_internal_numberof(array) (int)(sizeof(array) / sizeof((array)[0]))
 
@@ -268,7 +268,7 @@ st_init_strcasetable_with_size(st_index_t size)
 static void
 st_clear(st_table *table)
 {
-    register st_table_entry *ptr, *next;
+    st_table_entry *ptr, *next;
     st_index_t i;
 
     if (table->entries_packed) {
@@ -324,10 +324,10 @@ st_memsize(const st_table *table)
 } while (0)
 
 static int
-st_lookup(st_table *table, register st_data_t key, st_data_t *value)
+st_lookup(st_table *table, st_data_t key, st_data_t *value)
 {
     st_index_t hash_val, bin_pos;
-    register st_table_entry *ptr;
+    st_table_entry *ptr;
 
     if (table->entries_packed) {
         st_index_t i;
@@ -353,10 +353,10 @@ st_lookup(st_table *table, register st_data_t key, st_data_t *value)
 }
 
 static int
-st_get_key(st_table *table, register st_data_t key, st_data_t *result)
+st_get_key(st_table *table, st_data_t key, st_data_t *result)
 {
     st_index_t hash_val, bin_pos;
-    register st_table_entry *ptr;
+    st_table_entry *ptr;
 
     if (table->entries_packed) {
         st_index_t i;
@@ -413,7 +413,7 @@ do {\
 } while (0)
 
 static void
-st_internal_unpack_entries(register st_table *table)
+st_internal_unpack_entries(st_table *table)
 {
     st_index_t i;
     struct st_table_entry *packed_bins[ST_MAX_PACKED_NUMHASH*2];
@@ -431,10 +431,10 @@ st_internal_unpack_entries(register st_table *table)
 }
 
 static int
-st_insert(register st_table *table, register st_data_t key, st_data_t value)
+st_insert(st_table *table, st_data_t key, st_data_t value)
 {
     st_index_t hash_val, bin_pos;
-    register st_table_entry *ptr;
+    st_table_entry *ptr;
 
     if (table->entries_packed) {
         st_index_t i;
@@ -469,11 +469,11 @@ st_insert(register st_table *table, register st_data_t key, st_data_t value)
 }
 
 static int
-st_insert2(register st_table *table, register st_data_t key, st_data_t value,
+st_insert2(st_table *table, st_data_t key, st_data_t value,
      st_data_t (*func)(st_data_t))
 {
     st_index_t hash_val, bin_pos;
-    register st_table_entry *ptr;
+    st_table_entry *ptr;
 
     if (table->entries_packed) {
         st_index_t i;
@@ -532,9 +532,9 @@ st_add_direct(st_table *table, st_data_t key, st_data_t value)
 }
 
 static void
-st_internal_rehash(register st_table *table)
+st_internal_rehash(st_table *table)
 {
-    register st_table_entry *ptr, **new_bins;
+    st_table_entry *ptr, **new_bins;
     st_index_t i, new_num_bins, hash_val;
 
     new_num_bins = st_internal_new_size(table->num_bins+1);
@@ -620,11 +620,11 @@ st_copy(st_table *old_table)
     } while (0)
 
 static int
-st_delete(register st_table *table, register st_data_t *key, st_data_t *value)
+st_delete(st_table *table, st_data_t *key, st_data_t *value)
 {
     st_index_t hash_val;
     st_table_entry **prev;
-    register st_table_entry *ptr;
+    st_table_entry *ptr;
 
     if (table->entries_packed) {
         st_index_t i;
@@ -659,10 +659,10 @@ st_delete(register st_table *table, register st_data_t *key, st_data_t *value)
 }
 
 static int
-st_delete_safe(register st_table *table, register st_data_t *key, st_data_t *value, st_data_t never)
+st_delete_safe(st_table *table, st_data_t *key, st_data_t *value, st_data_t never)
 {
     st_index_t hash_val;
-    register st_table_entry *ptr;
+    st_table_entry *ptr;
 
     if (table->entries_packed) {
         st_index_t i;
@@ -897,8 +897,8 @@ st_foreach(st_table *table, int (*func)(ANYARGS), st_data_t arg)
 static st_index_t
 st_internal_strhash(st_data_t arg)
 {
-    register const char *string = (const char *)arg;
-    register st_index_t hval = ST_FNV1_32A_INIT;
+    const char *string = (const char *)arg;
+    st_index_t hval = ST_FNV1_32A_INIT;
 
     /*
      * FNV-1a hash each octet in the buffer
@@ -965,8 +965,8 @@ st_strncasecmp(const char *s1, const char *s2, size_t n)
 static st_index_t
 st_internal_strcasehash(st_data_t arg)
 {
-    register const char *string = (const char *)arg;
-    register st_index_t hval = ST_FNV1_32A_INIT;
+    const char *string = (const char *)arg;
+    st_index_t hval = ST_FNV1_32A_INIT;
 
     /*
      * FNV-1a hash each octet in the buffer


### PR DESCRIPTION
The `register` keyword is meaningless in modern compilers and it causes
deprecation warnings in C++11 compilers.
