### PR TITLE
PowerPC64 support for LLVM and Atomic

### DIFF
--- a/vm/llvm/detection.cpp
+++ b/vm/llvm/detection.cpp
@@ -463,6 +463,9 @@ std::string rubinius::getHostCPUName() {
     .Case("A2", "a2")
     .Case("POWER6", "pwr6")
     .Case("POWER7", "pwr7")
+    .Case("POWER7+", "pwr7")
+    .Case("POWER8", "pwr8")
+    .Case("POWER8E", "pwr8")
     .Default(generic);
 }
 #elif defined(__linux__) && defined(__arm__)

--- a/vm/util/atomic.hpp
+++ b/vm/util/atomic.hpp
@@ -17,7 +17,7 @@
 #elif defined(__APPLE__)
 #define APPLE_SYNC 1
 
-#elif defined(_LP64) || defined(__LP64__) || defined(__x86_64__) || defined(__amd64__)
+#elif (defined(_LP64) || defined(__LP64__)) && (defined(__x86_64__) || defined(__amd64__))
 #define X86_SYNC 1
 #define X86_64_SYNC 1
 
@@ -43,7 +43,7 @@
 
 #endif
 
-#if defined(_LP64) || defined(__LP64__) || defined(__x86_64__) || defined(__amd64__)
+#if (defined(_LP64) || defined(__LP64__)) && (defined(__x86_64__) || defined(__amd64__))
 #define X86_PAUSE 1
 
 #elif defined(i386) || defined(__i386) || defined(__i386__)


### PR DESCRIPTION
This adds architecture-specific support for the ppc64 of the following components below:
- LLVM Host CPU Name
- Atomic macros
