### PR TITLE
Implement Array#count instead of falling back to Enumerable#count

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -415,6 +415,18 @@ class Array
     concat other
   end
 
+  def count(item = undefined)
+    seq = 0
+    if !undefined.equal?(item)
+      each { |o| seq += 1 if item == o }
+    elsif block_given?
+      each { |o| seq += 1 if yield(o) }
+    else
+      return @total
+    end
+    seq
+  end
+
   def cycle(n=nil)
     return to_enum(:cycle, n) unless block_given?
     return nil if empty?


### PR DESCRIPTION
This avoids iteration with `#each` if no arguments are given to `#count`.

This is an easy win for performance for large arrays, and MRI and JRuby already have this optimization.

In addition to performance, the implementing Module as given by introspection now matches MRI, meaning behavior will be consistent if some silly user deems to monkey-patch `Enumerable#count`.

``` ruby
Array.instance_method(:count).owner #=> Array (not Enumerable)
```
