### PR TITLE
Accept a nil argument for Array#flatten.

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -745,7 +745,7 @@ class Array
   end
 
   def flatten(level=-1)
-    level = Rubinius::Type.coerce_to_collection_index level
+    level = level ? Rubinius::Type.coerce_to_collection_index(level) : -1
     return self.dup if level == 0
 
     out = new_reserved size
@@ -757,7 +757,7 @@ class Array
   def flatten!(level=-1)
     Rubinius.check_frozen
 
-    level = Rubinius::Type.coerce_to_collection_index level
+    level = level ? Rubinius::Type.coerce_to_collection_index(level) : -1
     return nil if level == 0
 
     out = new_reserved size

--- a/spec/ruby/core/array/flatten_spec.rb
+++ b/spec/ruby/core/array/flatten_spec.rb
@@ -10,6 +10,10 @@ describe "Array#flatten" do
     [ 1, 2, [3, [4, 5] ] ].flatten(1).should == [1, 2, 3, [4, 5]]
   end
 
+  it "flattens all levels when the argument is nil" do
+    [[[1, [2, 3]],[2, 3, [4, [4, [5, 5]], [1, 2, 3]]], [4]], []].flatten(nil).should == [1, 2, 3, 2, 3, 4, 4, 5, 5, 1, 2, 3, 4]
+  end
+
   it "returns dup when the level of recursion is 0" do
     a = [ 1, 2, [3, [4, 5] ] ]
     a.flatten(0).should == a
@@ -138,6 +142,10 @@ describe "Array#flatten!" do
 
   it "takes an optional argument that determines the level of recursion" do
     [ 1, 2, [3, [4, 5] ] ].flatten!(1).should == [1, 2, 3, [4, 5]]
+  end
+
+  it "flattens all levels when the argument is nil" do
+    [[[1, [2, 3]],[2, 3, [4, [4, [5, 5]], [1, 2, 3]]], [4]], []].flatten(nil).should == [1, 2, 3, 2, 3, 4, 4, 5, 5, 1, 2, 3, 4]
   end
 
   # redmine #1440


### PR DESCRIPTION
In order to mirror MRI's behaviour, nil is allowed as the argument of
Array#flatten and Array#flatten!.  It is treated as -1 which means
endless recursive flatenning of the Array.

MRI:

```
> RUBY_DESCRIPTION
 => "ruby 2.1.3p242 (2014-09-19 revision 47630) [x86_64-linux]" 
> [].flatten(nil)
 => [] 
```

Rubinius 2.3.0 before this fix:

```
> RUBY_DESCRIPTION
 => "rubinius 2.3.0.n307 (2.1.0 5cd0c42e 2014-11-03) [x86_64-linux-gnu]" 
> [].flatten(nil)
TypeError: Coercion error: nil.to_int => Fixnum failed
    from kernel/common/type.rb:36:in `coerce_to_failed'
    from kernel/common/type.rb:132:in `coerce_to_collection_index'
    from kernel/common/array.rb:748:in `flatten'
    from (irb):1
    from kernel/common/block_environment.rb:53:in `call_on_instance'
    from kernel/common/eval.rb:176:in `eval'
    from kernel/common/kernel.rb:478:in `loop'
    from kernel/bootstrap/proc.rb:20:in `call'
    from kernel/common/throw_catch.rb:30:in `catch'
    from kernel/common/throw_catch.rb:8:in `register'
    from kernel/common/throw_catch.rb:29:in `catch'
    from kernel/bootstrap/proc.rb:20:in `call'
    from kernel/common/throw_catch.rb:30:in `catch'
    from kernel/common/throw_catch.rb:8:in `register'
    from kernel/common/throw_catch.rb:29:in `catch'
    from kernel/delta/code_loader.rb:66:in `load_script'
    from kernel/delta/code_loader.rb:152:in `load_script'
    from kernel/loader.rb:645:in `script'
    from kernel/loader.rb:799:in `main'
```

OS: 

```
Linux dmurik 2.6.32-431.30.1.el6.x86_64 #1 SMP Wed Jul 30 14:44:26 EDT 2014 x86_64 x86_64 x86_64 GNU/Linux
```
