### PR TITLE
Specifying MACRO for ppc64

### DIFF
--- a/vendor/oniguruma/regint.h
+++ b/vendor/oniguruma/regint.h
@@ -62,6 +62,7 @@
 
 #if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
     defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD86) || \
+    defined(__powerpc64__) || \
     defined(__mc68020__)
 #define PLATFORM_UNALIGNED_WORD_ACCESS
 #endif


### PR DESCRIPTION
To increase compatibility on ppc64 machines,
the MACRO "powerpc64" were specified for the architecture,
just like for x86_64 machines.
