### PR TITLE
PowerPC64 support for LibTomMath

### DIFF
--- a/vendor/libtommath/tommath.h
+++ b/vendor/libtommath/tommath.h
@@ -49,7 +49,7 @@ extern "C" {
 
 
 /* detect 64-bit mode if possible */
-#if defined(__x86_64__) 
+#if defined(__x86_64__) || defined(__powerpc64__)
    #if !(defined(MP_64BIT) && defined(MP_16BIT) && defined(MP_8BIT))
       #define MP_64BIT
    #endif


### PR DESCRIPTION
This adds architecture-specific support for the ppc64 of the LibTomMath.
