### PR TITLE
Fix 64bit MACROs

### DIFF
--- a/vm/builtin/integer.cpp
+++ b/vm/builtin/integer.cpp
@@ -79,7 +79,7 @@ namespace rubinius {
   }
 
   Integer* Integer::from(STATE, int num) {
-#ifndef IS_X8664
+#ifndef IS_64BIT_ARCH
     if(num > FIXNUM_MAX || num < FIXNUM_MIN) {
       /* Number is too big for Fixnum. Use Bignum. */
       return Bignum::from(state, (native_int)num);
@@ -89,7 +89,7 @@ namespace rubinius {
   }
 
   Integer* Integer::from(STATE, unsigned int num) {
-#ifndef IS_X8664
+#ifndef IS_64BIT_ARCH
     if(num > FIXNUM_MAX) {
       return Bignum::from(state, (unsigned long)num);
     }

--- a/vm/builtin/object.cpp
+++ b/vm/builtin/object.cpp
@@ -350,7 +350,7 @@ namespace rubinius {
   hashval Object::hash(STATE) {
     if(!reference_p()) {
 
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
       uintptr_t key = reinterpret_cast<uintptr_t>(this);
       key = (~key) + (key << 21); // key = (key << 21) - key - 1;
       key = key ^ (key >> 24);

--- a/vm/builtin/string.cpp
+++ b/vm/builtin/string.cpp
@@ -646,7 +646,7 @@ namespace rubinius {
 
   hashval String::hash_str(const unsigned char *bp, unsigned int sz, uint32_t seed) {
 #ifdef USE_MURMUR3
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
     hashval hv[2];
     MurmurHash3_x64_128(bp, sz, seed, hv);
 #else

--- a/vm/detection.hpp
+++ b/vm/detection.hpp
@@ -33,7 +33,11 @@
 #define IS_X86
 #endif
 
-#if defined(_LP64) || defined(__LP64__) || defined(__x86_64__) || defined(__amd64__)
+#if defined(_LP64) || defined(__LP64__)
+#define IS_64BIT_ARCH
+#endif
+
+#if defined(__x86_64__) || defined(__amd64__)
 #define IS_X8664
 
 #elif defined(IS_X86)

--- a/vm/llvm/autotypes.cpp
+++ b/vm/llvm/autotypes.cpp
@@ -39,7 +39,7 @@ namespace llvm {
 #endif
 
 namespace autogen_types {
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
 #include "llvm/types64.cpp.gen"
 #else
 #include "llvm/types32.cpp.gen"

--- a/vm/llvm/inline.cpp
+++ b/vm/llvm/inline.cpp
@@ -721,7 +721,7 @@ remember:
 
       case RBX_FFI_TYPE_LONG:
       case RBX_FFI_TYPE_ULONG:
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
         return ops_.context()->Int64Ty;
 #else
         return ops_.context()->Int32Ty;
@@ -954,7 +954,7 @@ remember:
     case RBX_FFI_TYPE_USHORT:
     case RBX_FFI_TYPE_INT:
     case RBX_FFI_TYPE_UINT:
-#ifndef IS_X8664
+#ifndef IS_64BIT_ARCH
     case RBX_FFI_TYPE_LONG:
     case RBX_FFI_TYPE_ULONG:
 #endif
@@ -973,7 +973,7 @@ remember:
 
     case RBX_FFI_TYPE_LONG_LONG:
     case RBX_FFI_TYPE_ULONG_LONG:
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
     case RBX_FFI_TYPE_LONG:
     case RBX_FFI_TYPE_ULONG:
 #endif

--- a/vm/llvm/inline_primitive.cpp
+++ b/vm/llvm/inline_primitive.cpp
@@ -6,7 +6,7 @@
 // We use the i64 and i32 versions here. We do the bounds checking
 // manually later on, because using i63 / i31 is buggy in LLVM, also
 // see http://llvm.org/bugs/show_bug.cgi?id=13991
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
 #define MUL_WITH_OVERFLOW "llvm.smul.with.overflow.i64"
 #else
 #define MUL_WITH_OVERFLOW "llvm.smul.with.overflow.i32"

--- a/vm/llvm/jit_context.cpp
+++ b/vm/llvm/jit_context.cpp
@@ -52,7 +52,7 @@ namespace rubinius {
     Int32Ty = Type::getInt32Ty(ctx_);
     Int64Ty = Type::getInt64Ty(ctx_);
 
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
     IntPtrTy = Int64Ty;
 #else
     IntPtrTy = Int32Ty;

--- a/vm/llvm/jit_operations.hpp
+++ b/vm/llvm/jit_operations.hpp
@@ -140,7 +140,7 @@ namespace rubinius {
       zero_ = ConstantInt::get(ctx_->Int32Ty, 0);
       one_ =  ConstantInt::get(ctx_->Int32Ty, 1);
 
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
       FixnumTy = llvm::IntegerType::get(ctx_->llvm_context(), 63);
 #else
       FixnumTy = llvm::IntegerType::get(ctx_->llvm_context(), 31);

--- a/vm/llvm/state.cpp
+++ b/vm/llvm/state.cpp
@@ -916,7 +916,7 @@ halt:
     ud_t ud;
 
     ud_init(&ud);
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
     ud_set_mode(&ud, 64);
 #else
     ud_set_mode(&ud, 32);

--- a/vm/test/test_fixnum.hpp
+++ b/vm/test/test_fixnum.hpp
@@ -19,7 +19,7 @@ class TestFixnum : public CxxTest::TestSuite, public VMTest {
   }
 
   void test_init() {
-#ifdef IS_X8664
+#ifdef IS_64BIT_ARCH
     size_t max_size =  4611686018427387903U;
     size_t min_size = -4611686018427387903U;
 #else


### PR DESCRIPTION
In vm/detection.hpp, it considers the macro LP64 as IS_X8664,
being necessary to separate the macro IS_64BIT_ARCH and the macro IS_X8664.
