### PR TITLE
Fix X86 MACRO

### DIFF
--- a/vm/include/capi/rbxti/atomic.hpp
+++ b/vm/include/capi/rbxti/atomic.hpp
@@ -31,7 +31,7 @@
 #if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4))
 #define GCC_BARRIER 1
 
-#elif defined(_LP64) || defined(__LP64__) || defined(__x86_64__) || defined(__amd64__)
+#elif (defined(_LP64) || defined(__LP64__)) && (defined(__x86_64__) || defined(__amd64__))
 #define X86_BARRIER 1
 
 #elif defined(i386) || defined(__i386) || defined(__i386__)


### PR DESCRIPTION
It is necessary to not consider all the
64bit architectures as always X86.
