### PR TITLE
clean up syntax in enum.rb

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,11 +59,12 @@
 - Daniel Lucraft:       { irc: dan_lucraft }
 - Daniel Luz:
 - David Altenburg:
+- David Boot            { github: kodnin, twitter: kodnin, email: kodnin@gmail.com }
 - David Salamon:
 - David Waite:          { irc: ddubs }
 - David Whittington:    { irc: djwhitt }
 - David Yip:
-- Davor Babic:           { irc: davorb, github: davorb, email: davor@davor.se }
+- Davor Babic:          { irc: davorb, github: davorb, email: davor@davor.se }
 - Defn:
 - Dirkjan Bussink:      { irc: dbussink }
 - Drew Olson:

--- a/kernel/platform/enum.rb
+++ b/kernel/platform/enum.rb
@@ -1,61 +1,55 @@
 module Rubinius
-module FFI
+  module FFI
+    # Represents a C enum.
+    class Enum
+      attr_reader :tag
+      attr_reader :kv_map
 
-  # Represents a C enum.
-  class Enum
+      def initialize(info, tag=nil)
+        @tag = tag
+        @kv_map = Hash.new
 
-    attr_reader :tag
-    attr_reader :kv_map
-
-    def initialize(info, tag=nil)
-      @tag = tag
-      @kv_map = Hash.new
-
-      unless info.nil?
-        last_cst = nil
-        value = 0
-        info.each do |i|
-          case i
-          when Symbol
-            @kv_map[i] = value
-            last_cst = i
-            value += 1
-          when Integer
-            @kv_map[last_cst] = i
-            value = i+1
+        unless info.nil?
+          last_cst = nil
+          value = 0
+          info.each do |i|
+            case i
+            when Symbol
+              @kv_map[i] = value
+              last_cst = i
+              value += 1
+            when Integer
+              @kv_map[last_cst] = i
+              value = i + 1
+            end
           end
-
         end
-
       end
 
-    end
+      def inspect
+        "#<%s:0x%x %s=>%s>" % [self.class, self.object_id, @tag, @kv_map.inspect]
+      end
 
-    def inspect
-      "#<%s:0x%x %s=>%s>" % [self.class,self.object_id,@tag,@kv_map.inspect]
-    end
+      def anonym?
+        @tag.nil?
+      end
 
-    def anonym?
-      @tag.nil?
-    end
+      def values
+        @kv_map.values
+      end
 
-    def values
-      @kv_map.values
-    end
+      def symbols
+        @kv_map.keys
+      end
 
-    def symbols
-      @kv_map.keys
-    end
+      def [](sym)
+        @kv_map[sym]
+      end
 
-    def [](sym)
-      @kv_map[sym]
+      def symbol(value)
+        key, val = @kv_map.detect { |key, val| val == value }
+        key
+      end
     end
-
-    def symbol(value)
-      key,val = @kv_map.detect { |key,val| val==value }
-      return key
-    end
-
   end
-end
 end


### PR DESCRIPTION
Cleaned up the syntax of enum.rb and removed a `return` on line 56.
