### PR TITLE
fix typo in authors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,7 +59,7 @@
 - Daniel Lucraft:       { irc: dan_lucraft }
 - Daniel Luz:
 - David Altenburg:
-- David Boot            { github: kodnin, twitter: kodnin, email: kodnin@gmail.com }
+- David Boot:           { github: kodnin, twitter: kodnin, email: kodnin@gmail.com }
 - David Salamon:
 - David Waite:          { irc: ddubs }
 - David Whittington:    { irc: djwhitt }


### PR DESCRIPTION
In my previous commit I added my name to the authors list, but did not respect the YAML format. Excusé.
