### PR TITLE
Search for llvm-config on OSX using brew

### DIFF
--- a/configure
+++ b/configure
@@ -599,6 +599,29 @@ Unsupported language version requested: #{version}. Options are #{@supported_ver
       end
       if which
         config = File.join(which, "llvm-config")
+      elsif @darwin
+        @log.print "  Checking for brew package manager: "
+        brew = `command -v brew`.chomp
+        if $?.success?
+          @log.write "found! #{brew}"
+          @log.print "  Checking for brew llvm: "
+          formula = `brew list --versions llvm | head 1`.chomp
+          if $?.success?
+            @log.write "found! #{formula}"
+            @log.print "  Checking for brew llvm-config: "
+            path = `brew list llvm | grep '/llvm-config$'`.chomp
+            if $?.success?
+              @log.write "found! #{path}"
+              config = path
+            else
+              @log.write "found! #{formula}"
+            end
+          else
+            @log.write "not found"
+          end
+        else
+          @log.write "not found"
+        end
       end
     end
 


### PR DESCRIPTION
On Mac OSX, this command fails: `ruby-install rbx`.

The reason is that the OSX LLVM does not show up as expected. 

Many OSX developers install an additional LLVM by using the `brew` package manager: `brew install llvm`.

The `brew` manager does not replace the existing system LLVM because that would cause problems with other OSX software, for example XCode. Any approach that uses `brew link` is potentially dangerous on OSX.

Therefore, this patch adds a search for llvm-config: if the system is Darwin, and the system says that `brew` is installed, and `brew` says the formula for LLVM is installed, then the code searches for the `llvm-config` file.

I expect this code will solve the `ruby-install rbx` issue for the majority of OSX brew users. 

If this code is accepted, then subsequent improvements could add logging, advice, and corner cases such as multiple brew LLVM installations.