### PR TITLE
Changes to make Process::Status compatible with MRI

### DIFF
--- a/kernel/common/process.rb
+++ b/kernel/common/process.rb
@@ -522,36 +522,39 @@ module Process
 
   class Status
 
-    attr_reader :exitstatus
     attr_reader :termsig
     attr_reader :stopsig
 
-    def initialize(pid=nil, exitstatus=nil, termsig=nil, stopsig=nil)
+    def initialize(pid=nil, status=nil, termsig=nil, stopsig=nil)
       @pid = pid
-      @exitstatus = exitstatus
+      @status = status
       @termsig = termsig
       @stopsig = stopsig
     end
 
+    def exitstatus
+      return @status
+    end
+
     def to_i
-      @exitstatus
+      @status
     end
 
     def to_s
-      @exitstatus.to_s
+      @status.to_s
     end
 
     def &(num)
-      @exitstatus & num
+      @status & num
     end
 
     def ==(other)
       other = other.to_i if other.kind_of? Process::Status
-      @exitstatus == other
+      @status == other
     end
 
     def >>(num)
-      @exitstatus >> num
+      @status >> num
     end
 
     def coredump?
@@ -559,7 +562,7 @@ module Process
     end
 
     def exited?
-      @exitstatus != nil
+      @status != nil
     end
 
     def pid
@@ -576,7 +579,7 @@ module Process
 
     def success?
       if exited?
-        @exitstatus == 0
+        @status == 0
       else
         nil
       end

--- a/kernel/common/process.rb
+++ b/kernel/common/process.rb
@@ -533,7 +533,7 @@ module Process
     end
 
     def exitstatus
-      return @status
+      @status
     end
 
     def to_i

--- a/kernel/common/process.rb
+++ b/kernel/common/process.rb
@@ -526,7 +526,7 @@ module Process
     attr_reader :termsig
     attr_reader :stopsig
 
-    def initialize(pid, exitstatus, termsig=nil, stopsig=nil)
+    def initialize(pid=nil, exitstatus=nil, termsig=nil, stopsig=nil)
       @pid = pid
       @exitstatus = exitstatus
       @termsig = termsig

--- a/spec/ruby/core/process/exitstatus_spec.rb
+++ b/spec/ruby/core/process/exitstatus_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe 'Process::Status#exitstatus' do
+  it 'returns the exit status as a Fixnum' do
+    Process::Status.new(42, 1).exitstatus.should == 1
+  end
+end

--- a/spec/ruby/core/process/initialize_spec.rb
+++ b/spec/ruby/core/process/initialize_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe 'Process::Status#initialize' do
+  it 'initializes a new Process::Status instance' do
+    Process::Status.new.should be_an_instance_of(Process::Status)
+  end
+end

--- a/spec/ruby/core/process/initialize_spec.rb
+++ b/spec/ruby/core/process/initialize_spec.rb
@@ -4,4 +4,28 @@ describe 'Process::Status#initialize' do
   it 'initializes a new Process::Status instance' do
     Process::Status.new.should be_an_instance_of(Process::Status)
   end
+
+  it 'initializes Process::Status with a PID' do
+    status = Process::Status.new(42)
+
+    status.pid.should == 42
+  end
+
+  it 'initializes Process::Status with a PID and status' do
+    status = Process::Status.new(42, 1)
+
+    status.exitstatus.should == 1
+  end
+
+  it 'initializes Process::Status with a PID, status and term signal' do
+    status = Process::Status.new(42, 1, 2)
+
+    status.termsig.should == 2
+  end
+
+  it 'initializes Process::Status with a PID, status, term signal and stop signal' do
+    status = Process::Status.new(42, 1, 2, 3)
+
+    status.stopsig.should == 3
+  end
 end


### PR DESCRIPTION
See https://github.com/rubinius/rubinius/issues/3268 for the issue that led to these changes. Before we merge this I'd like some feedback on this, in particular abotut the renaming of `@exitstatus` to `@status`. I don't think there's a way around this, but just in case there's something better for this I'm creating a PR instead of pushing this straight to the master branch.