### PR TITLE
Alternative changes to make Process::Status compatible with MRI

### DIFF
--- a/vm/builtin/system.cpp
+++ b/vm/builtin/system.cpp
@@ -772,19 +772,7 @@ namespace rubinius {
       return cNil;
     }
 
-    Object* output  = cNil;
-    Object* termsig = cNil;
-    Object* stopsig = cNil;
-
-    if(WIFEXITED(status)) {
-      output = Fixnum::from(WEXITSTATUS(status));
-    } else if(WIFSIGNALED(status)) {
-      termsig = Fixnum::from(WTERMSIG(status));
-    } else if(WIFSTOPPED(status)){
-      stopsig = Fixnum::from(WSTOPSIG(status));
-    }
-
-    return Tuple::from(state, 4, output, termsig, stopsig, Fixnum::from(pid));
+    return Tuple::from(state, 2, Fixnum::from(pid), Fixnum::from(status));
 #endif  // RBX_WINDOWS
   }
 


### PR DESCRIPTION
Alternative approach to issue #3268 instead of PR #3270.

Needs specs, still a WIP, please don't merge yet, etc.

I haven't compiled this yet on OS X due to LLVM issues (worked with ruby-build, doesn't work on the command line, I'm confused). Sorry about using Travis to do the heavy lifting.