### PR TITLE
String#include? no longer accepts a Fixnum.

### DIFF
--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -360,14 +360,7 @@ class String
   end
 
   def include?(needle)
-    if needle.kind_of? Fixnum
-      needle = needle % 256
-      str_needle = needle.chr
-    else
-      str_needle = StringValue(needle)
-    end
-
-    !!find_string(str_needle, 0)
+    !!find_string(StringValue(needle), 0)
   end
 
   ControlCharacters = [10, 9, 7, 11, 12, 13, 27, 8]

--- a/spec/ruby/core/string/include_spec.rb
+++ b/spec/ruby/core/string/include_spec.rb
@@ -22,6 +22,7 @@ describe "String#include? with String" do
 
   it "raises a TypeError if other can't be converted to string" do
     lambda { "hello".include?([])       }.should raise_error(TypeError)
+    lambda { "hello".include?('h'.ord)  }.should raise_error(TypeError)
     lambda { "hello".include?(mock('x')) }.should raise_error(TypeError)
   end
 end


### PR DESCRIPTION
I think back in 1.8 it would turn the lower 8 bits of a Fixnum into a
String using .chr, but that doesn't seem to be the case any more, and
it's now a TypeError to pass in a Fixnum.