### PR TITLE
Add failing specs for code loading with wrapping

### DIFF
--- a/spec/ruby/fixtures/code/load_wrap_method_fixture.rb
+++ b/spec/ruby/fixtures/code/load_wrap_method_fixture.rb
@@ -1,0 +1,9 @@
+def top_level_method
+  ::ScratchPad << :load_wrap_loaded
+end
+
+begin
+  top_level_method
+rescue NameError
+  ::ScratchPad << :load_wrap_error
+end

--- a/spec/tags/ruby/core/kernel/load_tags.txt
+++ b/spec/tags/ruby/core/kernel/load_tags.txt
@@ -1,0 +1,2 @@
+fails:Kernel#load when passed true for 'wrap' with top-level methods allows calling top-level methods
+fails:Kernel.load when passed true for 'wrap' with top-level methods allows calling top-level methods


### PR DESCRIPTION
Specs the expected behaviour for issue #3276 and splits up an existing spec into multiple asserts.