### PR TITLE
Adding RBXOPT information to help on -X options

### DIFF
--- a/kernel/loader.rb
+++ b/kernel/loader.rb
@@ -426,6 +426,10 @@ VM Options
      All variables, even ones that the VM doesn't understand, are available
      in Rubinius::Config.
 
+     These options can also be passed via the RBXOPT environment variable:
+
+       RBXOPT=-Xint rbx
+
      A number of Rubinius features are driven by setting these variables.
       DOC
 


### PR DESCRIPTION
Would this work for surfacing a bit more info on RBXOPT? I had looked at the
--help output and found -Xhelp, but I didn't know clearly how I could pass
those options in.