### PR TITLE
fix build failure when RUBYGEMS_GEMDEPS is set to -

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,12 @@ if ENV["CDPATH"]
   ENV.delete("CDPATH")
 end
 
+# Wipe out RUBYGEMS_GEMDEPS, it causes the build to fail with
+# "no such file to load -- tsort" when running rbx extconf.rb
+if ENV["RUBYGEMS_GEMDEPS"]
+  ENV.delete("RUBYGEMS_GEMDEPS")
+end
+
 $trace ||= false
 $VERBOSE = true
 $verbose = Rake.application.options.trace || ARGV.delete("-v")


### PR DESCRIPTION
When RUBYGEMS_GEMDEPS is set to - so that "bundle exec" isn't needed when running ruby programs, the rubinius build fails with:

```
compiling encoding_compat.cpp
linking shared-object melbourne.so
/tmp/rubinius/staging/bin/rbx extconf.rb
An exception occurred loading Rubygems:

no such file to load -- tsort (LoadError)

Backtrace:

                Rubinius::CodeLoader#load_error at kernel/common/code_loader.rb:445
      Rubinius::CodeLoader#resolve_require_path at kernel/common/code_loader.rb:429
            { } in Rubinius::CodeLoader#require at kernel/common/code_loader.rb:103
                           Rubinius.synchronize at kernel/bootstrap/rubinius.rb:127
                   Rubinius::CodeLoader#require at kernel/common/code_loader.rb:102
                   Rubinius::CodeLoader.require at kernel/common/code_loader.rb:241
  Kernel(Object)#gem_original_require (require) at kernel/common/kernel.rb:755
 ```
I've reproduced this with MRI 2.1.5 (rubygems 2.2.2) and MRI 2.2.0 (rubygems 2.4.5) as the build ruby, and confirmed the problem exists when building rbx versions 2.4.1, 2.5.0, and current master. I'm using Ubuntu 13.04 but I suspect that's irrelevant.

Unsetting the environment variable in the Rakefile fixes the issue.