### PR TITLE
Add support for automatic configuration of llvm-config under MacPorts.

### DIFF
--- a/configure
+++ b/configure
@@ -600,8 +600,12 @@ Unsupported language version requested: #{version}. Options are #{@supported_ver
       if which
         config = File.join(which, "llvm-config")
       elsif @darwin
-        out = `brew list llvm | grep '/llvm-config$'`
-        config = out.chomp if $?.success?
+        if macports?
+          config = macports_llvm_config
+        else
+          out = `brew list llvm | grep '/llvm-config$'`
+          config = out.chomp if $?.success?
+        end
       end
     end
 

--- a/configure
+++ b/configure
@@ -1989,6 +1989,11 @@ Available commands are:
       message.index("\n") != nil
     end
   end
+
+  # Returns true if MacPorts is installed in its default location.
+  def macports?
+    File.exists? '/opt/local/bin/port'
+  end
 end
 
 STDOUT.sync = true

--- a/configure
+++ b/configure
@@ -2000,18 +2000,17 @@ Available commands are:
   end
 
   # Query MacPorts for the path to the latest installed version of
-  # llvm-config.
+  # llvm-config that is within the range of supported LLVM versions.
   def macports_llvm_config
-    # Select latest installed port, as MacPorts can have multiple
-    # versions installed.
-    llvm_port   =
-      %x(port installed | egrep -o 'llvm-[^ ]+' | tail -1).chomp
-    # Query MacPorts for an array of all llvm-config* binaries.
-    llvm_config =
-      %x(port contents #{llvm_port} | fgrep llvm-config).split
-    # Use the binary installed by the port into /opt/local/bin rather
-    # than /opt/local/libexec/<version>/bin.
-    llvm_config.reject { |fname| fname.include? 'libexec' }.last
+    supported_versions = (3.0 .. 3.5)
+    installed_ports    = %x(port installed | egrep -o 'llvm-[^ ]+' ).split
+    latest_usable_port = installed_ports.sort.select do |fname|
+                           version = fname.match(/-\K.*/)[0].to_f
+                           supported_versions.include? version
+                         end.last
+    avail_binaries     = %x(port contents #{latest_usable_port} |
+                            fgrep llvm-config).split
+    avail_binaries.reject { |fname| fname.include? 'libexec' }.last
   end
 end
 

--- a/configure
+++ b/configure
@@ -1994,6 +1994,21 @@ Available commands are:
   def macports?
     File.exists? '/opt/local/bin/port'
   end
+
+  # Query MacPorts for the path to the latest installed version of
+  # llvm-config.
+  def macports_llvm_config
+    # Select latest installed port, as MacPorts can have multiple
+    # versions installed.
+    llvm_port   =
+      %x(port installed | egrep -o 'llvm-[^ ]+' | tail -1).chomp
+    # Query MacPorts for an array of all llvm-config* binaries.
+    llvm_config =
+      %x(port contents #{llvm_port} | fgrep llvm-config).split
+    # Use the binary installed by the port into /opt/local/bin rather
+    # than /opt/local/libexec/<version>/bin.
+    llvm_config.reject { |fname| fname.include? 'libexec' }.last
+  end
 end
 
 STDOUT.sync = true

--- a/configure
+++ b/configure
@@ -2003,13 +2003,13 @@ Available commands are:
   # llvm-config that is within the range of supported LLVM versions.
   def macports_llvm_config
     supported_versions = (3.0 .. 3.5)
-    installed_ports    = %x(port installed | egrep -o 'llvm-[^ ]+' ).split
+    installed_ports    = `port installed | egrep -o 'llvm-[^ ]+'`.split
     latest_usable_port = installed_ports.sort.select do |fname|
                            version = fname.match(/-\K.*/)[0].to_f
                            supported_versions.include? version
                          end.last
-    avail_binaries     = %x(port contents #{latest_usable_port} |
-                            fgrep llvm-config).split
+    avail_binaries     = `port contents #{latest_usable_port} |
+                          fgrep llvm-config`.split
     avail_binaries.reject { |fname| fname.include? 'libexec' }.last
   end
 end


### PR DESCRIPTION
## What does this pull request do?
- Adds support for finding a the latest usable _llvm-config*_ binary under MacPorts.
    - Enable detection of MacPorts via `Configure#macports?`.
    - Enable automatic detection of a MacPorts version of _llvm-config_ when MacPorts is installed.
    - Query MacPorts for the latest usable version of _llvm-config_ via `Configure#macports_llvm_config`.
- Addresses the _llvm-config_ portion of https://github.com/postmodern/ruby-install/issues/181, although `CC=clang` must still be passed explicitly.

## How were the changes tested?
- Tested build of configuration on Yosemite with `CC=clang ./configure`:

    > Detected old configuration settings, forcing a clean build
    >  Checking for 'llvm-config': found! (version 3.3 - api: 303)
    > [...]
    > Rubinius (f85e0a30) has been configured.

- Tested new Rubinius build with with test suite using `bundle exec rake`:

    > 2162 files, 20146 examples, 153473 expectations, 0 failures, 0 errors