### PR TITLE
Search PATH for "port" command.

### DIFF
--- a/configure
+++ b/configure
@@ -1994,9 +1994,9 @@ Available commands are:
     end
   end
 
-  # Returns true if MacPorts is installed in its default location.
+  # Returns true if the MacPorts *port* command is found in the PATH.
   def macports?
-    File.exists? '/opt/local/bin/port'
+    system 'which port > /dev/null'
   end
 
   # Query MacPorts for the path to the latest installed version of

--- a/configure
+++ b/configure
@@ -1995,9 +1995,9 @@ Available commands are:
   end
 
   # Returns true if the *port* command is in the PATH and identifies
-  # itself as "MacPorts <semantic_version>" when run interactively.
+  # itself with "MacPorts" when run interactively.
   def macports?
-    !! ( `echo quit | port 2>&-` =~ /^MacPorts (?:\d+\.){2}\d+$/ )
+    `echo quit | port 2>&-`.start_with? 'MacPorts'
   end
 
   # Query MacPorts for the path to the latest installed version of

--- a/configure
+++ b/configure
@@ -1994,9 +1994,10 @@ Available commands are:
     end
   end
 
-  # Returns true if the MacPorts *port* command is found in the PATH.
+  # Returns true if the *port* command is in the PATH and identifies
+  # itself as "MacPorts <semantic_version>" when run interactively.
   def macports?
-    system 'which port > /dev/null'
+    !! ( `echo quit | port 2>&-` =~ /^MacPorts (?:\d+\.){2}\d+$/ )
   end
 
   # Query MacPorts for the path to the latest installed version of


### PR DESCRIPTION
- Make the test for the MacPorts *port* command more flexible by searching the PATH rather than assuming it resides at /opt/local/bin/port. This feature was requested in the line notes for https://github.com/rubinius/rubinius/pull/3297.
- Explicitly test that the *port* command is really MacPorts. This improves reliability beyond the previous reliance on a canonical filesystem location.
- Contrary to expectations, `port version` will return a version string that fails to identify itself as MacPorts. String-matching the interactive prompt is therefore more reliable for validating the executable.