### PR TITLE
Spec size method calls on Enumerator instances returned by Enumerable methods.

### DIFF
--- a/spec/ruby/core/array/cycle_spec.rb
+++ b/spec/ruby/core/array/cycle_spec.rb
@@ -91,4 +91,12 @@ describe "Array#cycle" do
   it "raises a TypeError if passed false" do
     lambda { @array.cycle(false) { } }.should raise_error(TypeError)
   end
+
+  it "returns Float::INFINITY as size when passed no argument and no block is given" do
+    @array.cycle.size.should == Float::INFINITY
+  end
+
+  it "returns the correct size when passed a number n as argument and no block is given" do
+    @array.cycle(2).size.should == 6
+  end
 end

--- a/spec/ruby/core/array/delete_if_spec.rb
+++ b/spec/ruby/core/array/delete_if_spec.rb
@@ -58,4 +58,8 @@ describe "Array#delete_if" do
     @a.delete_if{ true }
     @a.untrusted?.should be_true
   end
+
+  it "returns the correct size when no block is given" do
+    [1, 2, 3].delete_if.size.should == 3
+  end
 end

--- a/spec/ruby/core/array/each_index_spec.rb
+++ b/spec/ruby/core/array/each_index_spec.rb
@@ -36,5 +36,9 @@ describe "Array#each_index" do
     ScratchPad.recorded.should == [0]
   end
 
+  it "returns the correct size when no block is given" do
+    [1, 2, 3].each_index.size.should == 3
+  end
+
   it_behaves_like :enumeratorize, :each_index
 end

--- a/spec/ruby/core/array/each_spec.rb
+++ b/spec/ruby/core/array/each_spec.rb
@@ -26,5 +26,9 @@ describe "Array#each" do
     b.should == [2, nil, 4]
   end
 
+  it "returns the correct size when no block is given" do
+    [1, 2, 3].each.size.should == 3
+  end
+
   it_behaves_like :enumeratorize, :each
 end

--- a/spec/ruby/core/array/reject_spec.rb
+++ b/spec/ruby/core/array/reject_spec.rb
@@ -41,6 +41,10 @@ describe "Array#reject" do
     array.reject { false }.instance_variable_get("@variable").should == nil
   end
 
+  it "returns the correct size when no block is given" do
+    [1, 2, 3, 4, 5, 6].reject.size.should == 6
+  end
+
   it_behaves_like :enumeratorize, :reject
 end
 
@@ -106,6 +110,10 @@ describe "Array#reject!" do
 
   it "raises a RuntimeError on an empty frozen array" do
     lambda { ArraySpecs.empty_frozen_array.reject! {} }.should raise_error(RuntimeError)
+  end
+
+  it "returns the correct size when no block is given" do
+    [1, 2, 3, 4, 5, 6].reject!.size.should == 6
   end
 
   it_behaves_like :enumeratorize, :reject!

--- a/spec/ruby/core/array/reverse_each_spec.rb
+++ b/spec/ruby/core/array/reverse_each_spec.rb
@@ -33,5 +33,9 @@ describe "Array#reverse_each" do
     ScratchPad.recorded.should == [array, array, array, array, array, 3.0, 'two', 1]
   end
 
+  it "returns the correct size when no block is given" do
+    [1, 2, 3].reverse_each.size.should == 3
+  end
+
   it_behaves_like :enumeratorize, :reverse_each
 end

--- a/spec/ruby/core/array/shared/keep_if.rb
+++ b/spec/ruby/core/array/shared/keep_if.rb
@@ -9,6 +9,10 @@ describe :keep_if, :shared => true do
     [1, 2, 3].send(@method).should be_an_instance_of(enumerator_class)
   end
 
+  it "returns the correct size when no block is given" do
+    [1, 2, 3].send(@method).size.should == 3
+  end
+
   describe "on frozen objects" do
     before(:each) do
       @origin = [true, false]

--- a/spec/ruby/core/array/sort_by_spec.rb
+++ b/spec/ruby/core/array/sort_by_spec.rb
@@ -42,4 +42,8 @@ describe "Array#sort_by!" do
     }
     partially_sorted.any?{|ary| ary != [1, 2, 3, 4, 5]}.should be_true
   end
+
+  it "returns the correct size when no block is given" do
+    [1, 2, 3, 4, 5, 6].sort_by!.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/cycle_spec.rb
+++ b/spec/ruby/core/enumerable/cycle_spec.rb
@@ -39,6 +39,11 @@ describe "Enumerable#cycle" do
       enum.cycle { |x| break if x == 20}
       enum.times_yielded.should == 2
     end
+
+    it "returns Float::INFINITY as size when no block is given" do
+      enum = EnumerableSpecs::NumerousWithSize.new(*['a', 'b', 'c'])
+      enum.cycle.size.should == Float::INFINITY
+    end
   end
 
   describe "passed a number n as an argument" do
@@ -81,6 +86,11 @@ describe "Enumerable#cycle" do
     it "gathers whole arrays as elements when each yields multiple" do
       multi = EnumerableSpecs::YieldsMulti.new
       multi.cycle(2).to_a.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9], [1, 2], [3, 4, 5], [6, 7, 8, 9]]
+    end
+
+    it "returns the correct size when no block is given" do
+      enum = EnumerableSpecs::NumerousWithSize.new('a', 'b', 'c')
+      enum.cycle(2).size.should == 6
     end
   end
 end

--- a/spec/ruby/core/enumerable/drop_while_spec.rb
+++ b/spec/ruby/core/enumerable/drop_while_spec.rb
@@ -45,7 +45,7 @@ describe "Enumerable#drop_while" do
     multi.drop_while {|e| e != [6, 7, 8, 9] }.should == [[6, 7, 8, 9]]
   end
 
-  it "returns the nil as size when no block is given" do
+  it "returns nil as size when no block is given" do
     enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 0)
     enum.drop_while.size.should == nil
   end

--- a/spec/ruby/core/enumerable/drop_while_spec.rb
+++ b/spec/ruby/core/enumerable/drop_while_spec.rb
@@ -44,4 +44,9 @@ describe "Enumerable#drop_while" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.drop_while {|e| e != [6, 7, 8, 9] }.should == [[6, 7, 8, 9]]
   end
+
+  it "returns the nil as size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 0)
+    enum.drop_while.size.should == nil
+  end
 end

--- a/spec/ruby/core/enumerable/each_cons_spec.rb
+++ b/spec/ruby/core/enumerable/each_cons_spec.rb
@@ -56,4 +56,9 @@ describe "Enumerable#each_cons" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.each_cons(2).to_a.should == [[[1, 2], [3, 4, 5]], [[3, 4, 5], [6, 7, 8, 9]]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    enum.each_cons(3).size.should == 8
+  end
 end

--- a/spec/ruby/core/enumerable/each_with_index_spec.rb
+++ b/spec/ruby/core/enumerable/each_with_index_spec.rb
@@ -47,4 +47,9 @@ describe "Enumerable#each_with_index" do
     e.to_a.should == [[:apple, 0]]
     count.arguments_passed.should == [:foo, :bar]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3)
+    enum.each_with_index.size.should == 3
+  end
 end

--- a/spec/ruby/core/enumerable/each_with_object_spec.rb
+++ b/spec/ruby/core/enumerable/each_with_object_spec.rb
@@ -35,4 +35,9 @@ describe "Enumerable#each_with_object" do
     multi.each_with_object(array) { |elem, obj| obj << elem }
     array.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    enum.each_with_object([]).size.should == 10
+  end
 end

--- a/spec/ruby/core/enumerable/find_index_spec.rb
+++ b/spec/ruby/core/enumerable/find_index_spec.rb
@@ -51,6 +51,11 @@ describe "Enumerable#find_index" do
     it "gathers whole arrays as elements when each yields multiple" do
       @yieldsmixed.find_index([0, 1, 2]).should == 3
     end
+
+    it "returns nil as size" do
+      enum = EnumerableSpecs::NumerousWithSize.new(*@elements)
+      enum.find_index.size.should == nil
+    end
   end
 
   describe "with block" do

--- a/spec/ruby/core/enumerable/fixtures/classes.rb
+++ b/spec/ruby/core/enumerable/fixtures/classes.rb
@@ -11,6 +11,12 @@ module EnumerableSpecs
     end
   end
 
+  class NumerousWithSize < Numerous
+    def size
+      @list.size
+    end
+  end
+
   class EachCounter < Numerous
     attr_reader :times_called, :times_yielded, :arguments_passed
     def initialize(*list)

--- a/spec/ruby/core/enumerable/group_by_spec.rb
+++ b/spec/ruby/core/enumerable/group_by_spec.rb
@@ -39,4 +39,9 @@ describe "Enumerable#group_by" do
   it "returns an untrusted hash if self is untrusted" do
     EnumerableSpecs::Empty.new.untrust.group_by {}.untrusted?.should be_true
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.group_by.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/max_by_spec.rb
+++ b/spec/ruby/core/enumerable/max_by_spec.rb
@@ -37,4 +37,9 @@ describe "Enumerable#max_by" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.max_by {|e| e.size}.should == [6, 7, 8, 9]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.max_by.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/min_by_spec.rb
+++ b/spec/ruby/core/enumerable/min_by_spec.rb
@@ -38,4 +38,9 @@ describe "Enumerable#min_by" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.min_by {|e| e.size}.should == [1, 2]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.min_by.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/minmax_by_spec.rb
+++ b/spec/ruby/core/enumerable/minmax_by_spec.rb
@@ -38,4 +38,9 @@ describe "Enumerable#minmax_by" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.minmax_by {|e| e.size}.should == [[1, 2], [6, 7, 8, 9]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.minmax_by.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/partition_spec.rb
+++ b/spec/ruby/core/enumerable/partition_spec.rb
@@ -14,4 +14,9 @@ describe "Enumerable#partition" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.partition {|e| e == [3, 4, 5] }.should == [[[3, 4, 5]], [[1, 2], [6, 7, 8, 9]]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.partition.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/reject_spec.rb
+++ b/spec/ruby/core/enumerable/reject_spec.rb
@@ -19,4 +19,9 @@ describe "Enumerable#reject" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.reject {|e| e == [3, 4, 5] }.should == [[1, 2], [6, 7, 8, 9]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.reject.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/shared/collect.rb
+++ b/spec/ruby/core/enumerable/shared/collect.rb
@@ -25,4 +25,9 @@ describe :enumerable_collect, :shared => true do
     enum.should be_an_instance_of(enumerator_class)
     enum.each { |i| -i }.should == [-2, -5, -3, -6, -1, -4]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4)
+    enum.send(@method).size.should == 4
+  end
 end

--- a/spec/ruby/core/enumerable/shared/collect_concat.rb
+++ b/spec/ruby/core/enumerable/shared/collect_concat.rb
@@ -47,4 +47,9 @@ describe :enumerable_collect_concat, :shared => true do
     enum.should be_an_instance_of(enumerator_class)
     enum.each{ |i| [i] * i }.should == [1, 2, 2]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new([1, 2], [3, 4], [5, 6])
+    enum.send(@method).size.should == 3
+  end
 end

--- a/spec/ruby/core/enumerable/shared/find.rb
+++ b/spec/ruby/core/enumerable/shared/find.rb
@@ -67,4 +67,8 @@ describe :enumerable_find, :shared => true do
     multi.send(@method) {|e| e == [1, 2] }.should == [1, 2]
   end
 
+  it "returns the nil as size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(*@elements)
+    enum.send(@method).size.should == nil
+  end
 end

--- a/spec/ruby/core/enumerable/shared/find_all.rb
+++ b/spec/ruby/core/enumerable/shared/find_all.rb
@@ -24,4 +24,9 @@ describe :enumerable_find_all, :shared => true do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.send(@method) {|e| e == [3, 4, 5] }.should == [[3, 4, 5]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(*@elements)
+    enum.send(@method).size.should == 10
+  end
 end

--- a/spec/ruby/core/enumerable/slice_before_spec.rb
+++ b/spec/ruby/core/enumerable/slice_before_spec.rb
@@ -28,6 +28,11 @@ describe "Enumerable#slice_before" do
       e = @enum.slice_before(arg)
       e.to_a.should == [[7], [6, 5, 4, 3], [2, 1]]
     end
+
+    it "returns nil as size" do
+      enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+      enum.slice_before(3).size.should == nil
+    end
   end
 
   describe "when given a block" do

--- a/spec/ruby/core/enumerable/sort_by_spec.rb
+++ b/spec/ruby/core/enumerable/sort_by_spec.rb
@@ -25,4 +25,9 @@ describe "Enumerable#sort_by" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.sort_by {|e| e.size}.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
   end
+
+  it "returns the correct size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.sort_by.size.should == 6
+  end
 end

--- a/spec/ruby/core/enumerable/take_while_spec.rb
+++ b/spec/ruby/core/enumerable/take_while_spec.rb
@@ -45,4 +45,9 @@ describe "Enumerable#take_while" do
     EnumerableSpecs::YieldsMixed.new.take_while{ |v| yields << v }
     yields.should == [1, [2], 3, 5, [8, 9], nil, []]
   end
+
+  it "returns nil as size when no block is given" do
+    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
+    enum.take_while.size.should == nil
+  end
 end

--- a/spec/tags/ruby/core/array/cycle_tags.txt
+++ b/spec/tags/ruby/core/array/cycle_tags.txt
@@ -1,0 +1,2 @@
+fails:Array#cycle returns Float::INFINITY as size when passed no argument and no block is given
+fails:Array#cycle returns the correct size when passed a number n as argument and no block is given

--- a/spec/tags/ruby/core/array/delete_if_tags.txt
+++ b/spec/tags/ruby/core/array/delete_if_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#delete_if returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/each_index_tags.txt
+++ b/spec/tags/ruby/core/array/each_index_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#each_index returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/each_tags.txt
+++ b/spec/tags/ruby/core/array/each_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#each returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/keep_if_tags.txt
+++ b/spec/tags/ruby/core/array/keep_if_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#keep_if returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/reject_tags.txt
+++ b/spec/tags/ruby/core/array/reject_tags.txt
@@ -1,0 +1,2 @@
+fails:Array#reject returns the correct size when no block is given
+fails:Array#reject! returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/reverse_each_tags.txt
+++ b/spec/tags/ruby/core/array/reverse_each_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#reverse_each returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/select_tags.txt
+++ b/spec/tags/ruby/core/array/select_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#select! returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/sort_by_tags.txt
+++ b/spec/tags/ruby/core/array/sort_by_tags.txt
@@ -1,0 +1,1 @@
+fails:Array#sort_by! returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/collect_concat_tags.txt
+++ b/spec/tags/ruby/core/enumerable/collect_concat_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#collect_concat returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/collect_tags.txt
+++ b/spec/tags/ruby/core/enumerable/collect_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#collect returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/cycle_tags.txt
+++ b/spec/tags/ruby/core/enumerable/cycle_tags.txt
@@ -1,0 +1,2 @@
+fails:Enumerable#cycle passed no argument or nil returns Float::INFINITY as size when no block is given
+fails:Enumerable#cycle passed a number n as an argument returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/detect_tags.txt
+++ b/spec/tags/ruby/core/enumerable/detect_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#detect returns the nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/drop_while_tags.txt
+++ b/spec/tags/ruby/core/enumerable/drop_while_tags.txt
@@ -1,1 +1,1 @@
-fails:Enumerable#drop_while returns the nil as size when no block is given
+fails:Enumerable#drop_while returns nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/drop_while_tags.txt
+++ b/spec/tags/ruby/core/enumerable/drop_while_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#drop_while returns the nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/each_cons_tags.txt
+++ b/spec/tags/ruby/core/enumerable/each_cons_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#each_cons returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/each_with_index_tags.txt
+++ b/spec/tags/ruby/core/enumerable/each_with_index_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#each_with_index returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/each_with_object_tags.txt
+++ b/spec/tags/ruby/core/enumerable/each_with_object_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#each_with_object returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/find_all_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_all_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#find_all returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/find_index_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_index_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#find_index without block returns nil as size

--- a/spec/tags/ruby/core/enumerable/find_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#find returns the nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/flat_map_tags.txt
+++ b/spec/tags/ruby/core/enumerable/flat_map_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#flat_map returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/group_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/group_by_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#group_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/map_tags.txt
+++ b/spec/tags/ruby/core/enumerable/map_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#map returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/max_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/max_by_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#max_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/min_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/min_by_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#min_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/minmax_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/minmax_by_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#minmax_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/partition_tags.txt
+++ b/spec/tags/ruby/core/enumerable/partition_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#partition returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/reject_tags.txt
+++ b/spec/tags/ruby/core/enumerable/reject_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#reject returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/select_tags.txt
+++ b/spec/tags/ruby/core/enumerable/select_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#select returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/sort_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/sort_by_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#sort_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/take_while_tags.txt
+++ b/spec/tags/ruby/core/enumerable/take_while_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerable#take_while returns nil as size when no block is given


### PR DESCRIPTION
Hi,

A few days ago I've opened [this issue](https://github.com/rubinius/rubinius/issues/3306) regarding calling size on the Enumerator instance that results on calling the Enumerable#each_slice without a block.

At the time I only checked that method. A few days after I thought on checking other similar Enumerable methods that return an Enumerator, on MRI 2.1.5, Rubinius 2.5.2 and JRuby 9.0.0.0 pre1.
Rubinius returns nil on all the calls which is not the behavior of MRI. JRuby was only failing on each_slide.
Unfortunately I wasn't able to finish it and inform you guys of it before the issue was handled and closed.

I took a look at the tests that were added for the each_slice fix [pull request](https://github.com/rubinius/rubinius/pull/3315) and, based on it, decided to transform the checks I made in specs that could be useful.

I tried to cover all the Enumerable methods that I could find. I also checked the Array class and added similar tests to the methods implemented/overridden by the Array class that are on the same situation.

I hope it helps.

Thank you!