### PR TITLE
Fix enumerator size

### DIFF
--- a/kernel/bootstrap/array.rb
+++ b/kernel/bootstrap/array.rb
@@ -66,7 +66,7 @@ class Array
   # Passes each element in the Array to the given block
   # and returns self.
   def each
-    return to_enum(:each) unless block_given?
+    return to_enum(:each) { size } unless block_given?
 
     i = @start
     total = i + @total
@@ -83,7 +83,7 @@ class Array
   # Creates a new Array from the return values of passing
   # each element in self to the supplied block.
   def map
-    return to_enum :map unless block_given?
+    return to_enum(:map) { size } unless block_given?
     out = Array.new size
 
     i = @start
@@ -105,7 +105,7 @@ class Array
   # Replaces each element in self with the return value
   # of passing that element to the supplied block.
   def map!
-    return to_enum(:map!) unless block_given?
+    return to_enum(:map!) { size } unless block_given?
 
     Rubinius.check_frozen
 

--- a/kernel/bootstrap/array_mirror.rb
+++ b/kernel/bootstrap/array_mirror.rb
@@ -40,6 +40,58 @@ module Rubinius
       def start=(value)
         Rubinius.invoke_primitive :object_set_ivar, @object, :@start, value
       end
+
+      # Implementation based on the binomial_coefficient
+      # implemented on MRI array.c.
+      def binomial_coefficient(comb, size)
+        comb = size-comb if (comb > size-comb)
+        return 0 if comb < 0
+        descending_factorial(size, comb) / descending_factorial(comb, comb)
+      end
+
+      # Implementation based on the rb_ary_combination_size
+      # implemented on MRI array.c.
+      def combination_size(num)
+        binomial_coefficient(num, @object.size)
+      end
+
+      # Implementation based on the descending_factorial
+      # implemented on MRI array.c.
+      # Comment from there:
+      # Returns the product of from, from-1, ..., from - how_many + 1.
+      # http://en.wikipedia.org/wiki/Pochhammer_symbol
+      def descending_factorial(from, how_many)
+        cnt = how_many >= 0 ? 1 : 0
+        while (how_many) > 0
+          cnt = cnt*(from)
+          from -= 1
+          how_many -= 1
+        end
+        cnt
+      end
+
+      # Implementation based on the rb_ary_permutation_size
+      # implemented on MRI array.c.
+      def permutation_size(num)
+        n = @object.size
+        if undefined.equal? num
+          k = @object.size
+        else
+          k = Rubinius::Type.coerce_to_collection_index num
+        end
+        descending_factorial(n, k)
+      end
+
+      def repeated_combination_size(combination_size)
+        return 1 if combination_size == 0
+        return binomial_coefficient(combination_size, @object.size + combination_size - 1)
+      end
+
+      def repeated_permutation_size(combination_size)
+        return 0 if combination_size < 0
+        @object.size ** combination_size
+      end
+
     end
   end
 end

--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -392,7 +392,12 @@ class Array
 
   def combination(num)
     num = Rubinius::Type.coerce_to_collection_index num
-    return to_enum(:combination, num) unless block_given?
+
+    unless block_given?
+      return to_enum(:combination, num) do
+        Rubinius::Mirror::Array.reflect(self).combination_size(num)
+      end
+    end
 
     if num == 0
       yield []
@@ -470,7 +475,12 @@ class Array
   end
 
   def cycle(n=nil)
-    return to_enum(:cycle, n) unless block_given?
+    unless block_given?
+      return to_enum(:cycle, n) do
+        Rubinius::EnumerableHelper.cycle_size(size, n)
+      end
+    end
+
     return nil if empty?
 
     # Don't use nil? because, historically, lame code has overridden that method
@@ -546,7 +556,7 @@ class Array
   end
 
   def delete_if
-    return to_enum(:delete_if) unless block_given?
+    return to_enum(:delete_if) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -574,7 +584,7 @@ class Array
   end
 
   def each_index
-    return to_enum(:each_index) unless block_given?
+    return to_enum(:each_index) { size } unless block_given?
 
     i = 0
     total = @total
@@ -938,7 +948,7 @@ class Array
   end
 
   def keep_if(&block)
-    return to_enum :keep_if unless block_given?
+    return to_enum(:keep_if) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -982,7 +992,11 @@ class Array
   end
 
   def permutation(num=undefined, &block)
-    return to_enum(:permutation, num) unless block_given?
+    unless block_given?
+      return to_enum(:permutation, num) do 
+        Rubinius::Mirror::Array.reflect(self).permutation_size(num)
+      end
+    end
 
     if undefined.equal? num
       num = @total
@@ -1134,12 +1148,12 @@ class Array
   end
 
   def reject(&block)
-    return to_enum(:reject) unless block_given?
+    return to_enum(:reject) { size } unless block_given?
     Array.new(self).delete_if(&block)
   end
 
   def reject!(&block)
-    return to_enum(:reject!) unless block_given?
+    return to_enum(:reject!) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -1153,7 +1167,9 @@ class Array
   def repeated_combination(combination_size, &block)
     combination_size = combination_size.to_i
     unless block_given?
-      return Enumerator.new(self, :repeated_combination, combination_size)
+      return to_enum(:repeated_combination, combination_size) do
+        Rubinius::Mirror::Array.reflect(self).repeated_combination_size(combination_size)
+      end
     end
 
     if combination_size < 0
@@ -1183,7 +1199,9 @@ class Array
   def repeated_permutation(combination_size, &block)
     combination_size = combination_size.to_i
     unless block_given?
-      return Enumerator.new(self, :repeated_permutation, combination_size)
+      return to_enum(:repeated_permutation, combination_size) do
+        Rubinius::Mirror::Array.reflect(self).repeated_permutation_size(combination_size)
+      end
     end
 
     if combination_size < 0
@@ -1227,7 +1245,7 @@ class Array
   end
 
   def reverse_each
-    return to_enum(:reverse_each) unless block_given?
+    return to_enum(:reverse_each) { size } unless block_given?
 
     stop = @start - 1
     i = stop + @total
@@ -1334,7 +1352,7 @@ class Array
   end
 
   def select!(&block)
-    return to_enum :select! unless block_given?
+    return to_enum(:select!) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -1620,7 +1638,7 @@ class Array
   def sort_by!(&block)
     Rubinius.check_frozen
 
-    return to_enum :sort_by! unless block_given?
+    return to_enum(:sort_by!) { size } unless block_given?
 
     replace sort_by(&block)
   end

--- a/kernel/common/enumerable_helper.rb
+++ b/kernel/common/enumerable_helper.rb
@@ -1,0 +1,13 @@
+module Rubinius
+  module EnumerableHelper
+    def self.cycle_size(enum_size, many)
+      if many
+        many = Rubinius::Type.coerce_to_collection_index many
+        many = 0 if many < 0
+        (_size = enum_size).nil? ? nil : _size * many
+      else
+        enum_size.nil? ? nil : Float::INFINITY
+      end
+    end
+  end
+end

--- a/kernel/common/enumerator.rb
+++ b/kernel/common/enumerator.rb
@@ -83,7 +83,7 @@ module Enumerable
     private :each_with_block
 
     def each_with_index
-      return to_enum(:each_with_index) unless block_given?
+      return to_enum(:each_with_index) { size } unless block_given?
 
       idx = 0
 
@@ -159,7 +159,7 @@ module Enumerable
         offset = 0
       end
 
-      return to_enum(:with_index, offset) unless block_given?
+      return to_enum(:with_index, offset) { size } unless block_given?
 
       each do
         o = Rubinius.single_block_arg

--- a/kernel/common/env.rb
+++ b/kernel/common/env.rb
@@ -30,19 +30,19 @@ module Rubinius
     alias_method :store, :[]=
 
     def each_key
-      return to_enum(:each_key) unless block_given?
+      return to_enum(:each_key) { size } unless block_given?
 
       each { |k, v| yield k }
     end
 
     def each_value
-      return to_enum(:each_value) unless block_given?
+      return to_enum(:each_value) { size } unless block_given?
 
       each { |k, v| yield v }
     end
 
     def each
-      return to_enum(:each) unless block_given?
+      return to_enum(:each) { size } unless block_given?
 
       env = environ()
       ptr_size = FFI.type_size FFI.find_type(:pointer)
@@ -81,7 +81,7 @@ module Rubinius
     end
 
     def delete_if(&block)
-      return to_enum(:delete_if) unless block_given?
+      return to_enum(:delete_if) { size } unless block_given?
       reject!(&block)
       self
     end
@@ -127,7 +127,7 @@ module Rubinius
     end
 
     def reject!
-      return to_enum(:reject!) unless block_given?
+      return to_enum(:reject!) { size } unless block_given?
 
       # Avoid deleting from environ while iterating because the
       # OS can handle that in a million different bad ways.
@@ -211,7 +211,7 @@ module Rubinius
     end
 
     def select(&blk)
-      return to_enum unless block_given?
+      return to_enum { size } unless block_given?
       to_hash.select(&blk)
     end
 
@@ -262,13 +262,13 @@ module Rubinius
     end
 
     def keep_if(&block)
-      return to_enum(:keep_if) unless block_given?
+      return to_enum(:keep_if) { size } unless block_given?
       select!(&block)
       self
     end
 
     def select!
-      return to_enum(:select!) unless block_given?
+      return to_enum(:select!) { size } unless block_given?
       reject! { |k, v| !yield(k, v) }
     end
 

--- a/kernel/common/hash.rb
+++ b/kernel/common/hash.rb
@@ -333,7 +333,7 @@ class Hash
   end
 
   def each
-    return to_enum(:each) unless block_given?
+    return to_enum(:each) { size } unless block_given?
 
     return unless @state
 
@@ -377,7 +377,7 @@ class Hash
   end
 
   def keep_if
-    return to_enum(:keep_if) unless block_given?
+    return to_enum(:keep_if) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -509,7 +509,7 @@ class Hash
   private :initialize_copy
 
   def select
-    return to_enum(:select) unless block_given?
+    return to_enum(:select) { size } unless block_given?
 
     selected = Hash.allocate
 
@@ -523,7 +523,7 @@ class Hash
   end
 
   def select!
-    return to_enum(:select!) unless block_given?
+    return to_enum(:select!) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -635,7 +635,7 @@ class Hash
   end
 
   def delete_if(&block)
-    return to_enum(:delete_if) unless block_given?
+    return to_enum(:delete_if) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -644,14 +644,14 @@ class Hash
   end
 
   def each_key
-    return to_enum(:each_key) unless block_given?
+    return to_enum(:each_key) { size } unless block_given?
 
     each_item { |item| yield item.key }
     self
   end
 
   def each_value
-    return to_enum(:each_value) unless block_given?
+    return to_enum(:each_value) { size } unless block_given?
 
     each_item { |item| yield item.value }
     self
@@ -751,7 +751,7 @@ class Hash
   end
 
   def reject(&block)
-    return to_enum(:reject) unless block_given?
+    return to_enum(:reject) { size } unless block_given?
 
     hsh = dup.delete_if(&block)
     hsh.taint if tainted?
@@ -759,7 +759,7 @@ class Hash
   end
 
   def reject!(&block)
-    return to_enum(:reject!) unless block_given?
+    return to_enum(:reject!) { size } unless block_given?
 
     Rubinius.check_frozen
 

--- a/kernel/common/hash_hamt.rb
+++ b/kernel/common/hash_hamt.rb
@@ -496,7 +496,7 @@ class Hash
   end
 
   def delete_if
-    return to_enum(:delete_if) unless block_given?
+    return to_enum(:delete_if) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -506,7 +506,7 @@ class Hash
   end
 
   def each
-    return to_enum(:each) unless block_given?
+    return to_enum(:each) { size } unless block_given?
 
     if @state
       item = @state.head
@@ -532,7 +532,7 @@ class Hash
   end
 
   def each_key
-    return to_enum(:each_key) unless block_given?
+    return to_enum(:each_key) { size } unless block_given?
 
     each_item { |e| yield e.key }
 
@@ -540,7 +540,7 @@ class Hash
   end
 
   def each_value
-    return to_enum(:each_value) unless block_given?
+    return to_enum(:each_value) { size } unless block_given?
 
     each_item { |e| yield e.value }
 
@@ -666,7 +666,7 @@ class Hash
   end
 
   def keep_if
-    return to_enum(:keep_if) unless block_given?
+    return to_enum(:keep_if) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -767,7 +767,7 @@ class Hash
   end
 
   def reject(&block)
-    return to_enum(:reject) unless block_given?
+    return to_enum(:reject) { size } unless block_given?
 
     hsh = dup.delete_if(&block)
     hsh.taint if tainted?
@@ -775,7 +775,7 @@ class Hash
   end
 
   def reject!(&block)
-    return to_enum(:reject!) unless block_given?
+    return to_enum(:reject!) { size } unless block_given?
 
     Rubinius.check_frozen
 
@@ -812,7 +812,7 @@ class Hash
   end
 
   def select
-    return to_enum(:select) unless block_given?
+    return to_enum(:select) { size } unless block_given?
 
     hsh = Hash.allocate
 
@@ -826,7 +826,7 @@ class Hash
   end
 
   def select!
-    return to_enum(:select!) unless block_given?
+    return to_enum(:select!) { size } unless block_given?
 
     Rubinius.check_frozen
 

--- a/kernel/common/integer.rb
+++ b/kernel/common/integer.rb
@@ -189,7 +189,7 @@ class Integer < Numeric
   end
 
   def times
-    return to_enum(:times) unless block_given?
+    return to_enum(:times) { self } unless block_given?
 
     i = 0
     while i < self
@@ -200,7 +200,7 @@ class Integer < Numeric
   end
 
   def upto(val)
-    return to_enum(:upto, val) unless block_given?
+    return to_enum(:upto, val) { self <= val ? val - self + 1 : 0 } unless block_given?
 
     i = self
     while i <= val
@@ -211,7 +211,7 @@ class Integer < Numeric
   end
 
   def downto(val)
-    return to_enum(:downto, val) unless block_given?
+    return to_enum(:downto, val) { self >= val ? self - val + 1 : 0 } unless block_given?
 
     i = self
     while i >= val

--- a/kernel/common/kernel.rb
+++ b/kernel/common/kernel.rb
@@ -504,7 +504,7 @@ module Kernel
   module_function :load
 
   def loop
-    return to_enum(:loop) unless block_given?
+    return to_enum(:loop) { Float::INFINITY } unless block_given?
 
     begin
       while true

--- a/kernel/common/load_order.txt
+++ b/kernel/common/load_order.txt
@@ -5,6 +5,7 @@ autoload.rbc
 module.rbc
 binding.rbc
 proc.rbc
+enumerable_helper.rbc
 enumerable.rbc
 enumerator.rbc
 argf.rbc

--- a/kernel/common/load_order.txt
+++ b/kernel/common/load_order.txt
@@ -65,6 +65,7 @@ native_method.rbc
 nil.rbc
 object_space.rbc
 string.rbc
+range_mirror.rbc
 range.rbc
 struct.rbc
 process.rbc

--- a/kernel/common/load_order.txt
+++ b/kernel/common/load_order.txt
@@ -22,6 +22,7 @@ loaded_features.rbc
 global.rbc
 backtrace.rbc
 comparable.rbc
+numeric_mirror.rbc
 numeric.rbc
 ctype.rbc
 integer.rbc

--- a/kernel/common/numeric_mirror.rb
+++ b/kernel/common/numeric_mirror.rb
@@ -1,0 +1,60 @@
+module Rubinius
+  class Mirror
+    class Numeric < Mirror
+      subject = ::Numeric
+
+      def step_float_size(value, limit, step, asc)
+        if (asc && value > limit) || (!asc && value < limit)
+          return 0
+        end
+
+        if step.infinite?
+          1
+        else
+          err = (value.abs + limit.abs + (limit - value).abs) / step.abs * Float::EPSILON
+          if err.finite?
+            err = 0.5 if err > 0.5
+            ((limit - value) / step + err).floor + 1
+          else
+            0
+          end
+        end
+      end
+
+      def step_size(limit, step)
+        values = step_fetch_args(limit, step)
+        value = values[0]
+        limit = values[1]
+        step = values[2]
+        asc = values[3]
+        is_float = values[4]
+
+        if is_float
+          # Ported from MRI
+
+          step_float_size(value, limit, step, asc)
+
+        else
+          if (asc && value > limit) || (!asc && value < limit)
+            0
+          else
+            ((value - limit).abs + 1).fdiv(step.abs).ceil
+          end
+        end
+      end
+
+      def step_fetch_args(limit, step)
+        raise ArgumentError, "step cannot be 0" if step == 0
+
+        value = @object
+        asc = step > 0
+        if value.kind_of? Float or limit.kind_of? Float or step.kind_of? Float
+          return FloatValue(value), FloatValue(limit), FloatValue(step), asc, true
+        else
+          return value, limit, step, asc, false
+        end
+      end
+
+    end
+  end
+end

--- a/kernel/common/range.rb
+++ b/kernel/common/range.rb
@@ -103,7 +103,7 @@ class Range
   end
 
   def each
-    return to_enum unless block_given?
+    return to_enum { size } unless block_given?
     first, last = @begin, @end
 
     unless first.respond_to?(:succ) && !first.kind_of?(Time)
@@ -213,44 +213,20 @@ class Range
   end
 
   def step(step_size=1) # :yields: object
-    return to_enum(:step, step_size) unless block_given?
+    return to_enum(:step, step_size) do
+      m = Rubinius::Mirror::Range.reflect(self)
+      m.step_iterations_size(*m.validate_step_size(@begin, @end, step_size))
+    end unless block_given?
 
-    first = @begin
-    last = @end
-
-    if step_size.kind_of? Float or first.kind_of? Float or last.kind_of? Float
-      # if any are floats they all must be
-      begin
-        step_size = Float(from = step_size)
-        first     = Float(from = first)
-        last      = Float(from = last)
-      rescue ArgumentError
-        raise TypeError, "no implicit conversion to float from #{from.class}"
-      end
-    else
-      step_size = Integer(from = step_size)
-
-      unless step_size.kind_of? Integer
-        raise TypeError, "can't convert #{from.class} to Integer (#{from.class}#to_int gives #{step_size.class})"
-      end
-    end
-
-    if step_size <= 0
-      raise ArgumentError, "step can't be negative" if step_size < 0
-      raise ArgumentError, "step can't be 0"
-    end
+    m = Rubinius::Mirror::Range.reflect(self)
+    values = m.validate_step_size(@begin, @end, step_size)
+    first = values[0]
+    last = values[1]
+    step_size = values[2]
 
     case first
     when Float
-      err = (first.abs + last.abs + (last - first).abs) / step_size.abs * Float::EPSILON
-      err = 0.5 if err > 0.5
-
-      if @excl
-        iterations = ((last - first) / step_size - err).floor
-        iterations += 1 if iterations * step_size + first < last
-      else
-        iterations = ((last - first) / step_size + err).floor + 1
-      end
+      iterations = m.step_float_iterations_size(first, last, step_size)
 
       i = 0
       while i < iterations

--- a/kernel/common/range_mirror.rb
+++ b/kernel/common/range_mirror.rb
@@ -1,0 +1,59 @@
+module Rubinius
+  class Mirror
+    class Range < Mirror
+      subject = ::Range
+
+      def excl
+        Rubinius.invoke_primitive :object_get_ivar, @object, :@excl
+      end
+
+      def step_float_iterations_size(first, last, step_size)
+        err = (first.abs + last.abs + (last - first).abs) / step_size.abs * Float::EPSILON
+        err = 0.5 if err > 0.5
+
+        if excl
+          iterations = ((last - first) / step_size - err).floor
+          iterations += 1 if iterations * step_size + first < last
+        else
+          iterations = ((last - first) / step_size + err).floor + 1
+        end
+      end
+
+      def step_iterations_size(first, last, step_size)
+        case first
+        when Float
+          step_float_iterations_size(first, last, step_size)
+        else
+          @object.size.nil? ? nil : (@object.size.fdiv(step_size)).ceil
+        end
+      end
+
+      def validate_step_size(first, last, step_size)
+        if step_size.kind_of? Float or first.kind_of? Float or last.kind_of? Float
+          # if any are floats they all must be
+          begin
+            step_size = Float(from = step_size)
+            first     = Float(from = first)
+            last      = Float(from = last)
+          rescue ArgumentError
+            raise TypeError, "no implicit conversion to float from #{from.class}"
+          end
+        else
+          step_size = Integer(from = step_size)
+
+          unless step_size.kind_of? Integer
+            raise TypeError, "can't convert #{from.class} to Integer (#{from.class}#to_int gives #{step_size.class})"
+          end
+        end
+
+        if step_size <= 0
+          raise ArgumentError, "step can't be negative" if step_size < 0
+          raise ArgumentError, "step can't be 0"
+        end
+
+        return first, last, step_size
+      end
+
+    end
+  end
+end

--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -297,7 +297,7 @@ class String
   end
 
   def each_char
-    return to_enum :each_char unless block_given?
+    return to_enum(:each_char) { size } unless block_given?
 
     bytes = 0
     while bytes < @num_bytes
@@ -310,7 +310,7 @@ class String
   end
 
   def each_byte
-    return to_enum :each_byte unless block_given?
+    return to_enum(:each_byte) { bytesize } unless block_given?
     i = 0
     while i < @num_bytes do
       yield @data.get_byte(i)
@@ -831,7 +831,7 @@ class String
   end
 
   def each_codepoint
-    return to_enum :each_codepoint unless block_given?
+    return to_enum(:each_codepoint) { size } unless block_given?
 
     each_char { |c| yield c.ord }
     self

--- a/kernel/common/string.rb
+++ b/kernel/common/string.rb
@@ -1169,7 +1169,7 @@ class String
 
     if undefined.equal? replacement
       unless block_given?
-        return to_enum(:sub, pattern, replacement)
+        raise ArgumentError, "method '#{__method__}': given 1, expected 2"
       end
       use_yield = true
       tainted = false
@@ -1236,7 +1236,7 @@ class String
 
     if undefined.equal? replacement
       unless block_given?
-        return to_enum(:sub, pattern, replacement)
+        raise ArgumentError, "method '#{__method__}': given 1, expected 2"
       end
       Rubinius.check_frozen
       use_yield = true

--- a/kernel/common/struct.rb
+++ b/kernel/common/struct.rb
@@ -67,7 +67,7 @@ class Struct
   private :_attrs
 
   def select
-    return to_enum(:select) unless block_given?
+    return to_enum(:select) { size } unless block_given?
 
     to_a.select do |v|
       yield v
@@ -200,7 +200,7 @@ class Struct
   end
 
   def each
-    return to_enum :each unless block_given?
+    return to_enum(:each) { size } unless block_given?
     values.each do |v|
       yield v
     end
@@ -208,7 +208,7 @@ class Struct
   end
 
   def each_pair
-    return to_enum :each_pair unless block_given?
+    return to_enum(:each_pair) { size } unless block_given?
     _attrs.each { |var| yield var, instance_variable_get(:"@#{var}") }
     self
   end

--- a/spec/ruby/core/argf/shared/each_byte.rb
+++ b/spec/ruby/core/argf/shared/each_byte.rb
@@ -36,4 +36,27 @@ describe :argf_each_byte, :shared => true do
       bytes.should == @bytes
     end
   end
+
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      argv [@file1_name, @file2_name] do
+        enum = ARGF.send(@method)
+        enum.should be_an_instance_of(enumerator_class)
+
+        bytes = []
+        enum.each { |b| bytes << b }
+        bytes.should == @bytes
+      end
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          argv [@file1_name, @file2_name] do
+            ARGF.send(@method).size.should == nil
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/argf/shared/each_char.rb
+++ b/spec/ruby/core/argf/shared/each_char.rb
@@ -36,4 +36,27 @@ describe :argf_each_char, :shared => true do
       chars.should == @chars
     end
   end
+
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      argv [@file1_name, @file2_name] do
+        enum = ARGF.send(@method)
+        enum.should be_an_instance_of(enumerator_class)
+
+        chars = []
+        enum.each { |c| chars << c }
+        chars.should == @chars
+      end
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          argv [@file1_name, @file2_name] do
+            ARGF.send(@method).size.should == nil
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/argf/shared/each_codepoint.rb
+++ b/spec/ruby/core/argf/shared/each_codepoint.rb
@@ -37,4 +37,22 @@ describe :argf_each_codepoint, :shared => true do
       ARGF.send(@method).to_a.should == @codepoints
     end
   end
+
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      argv @filenames do
+        ARGF.send(@method).should be_an_instance_of(enumerator_class)
+      end
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          argv @filenames do
+            ARGF.send(@method).size.should == nil
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/argf/shared/each_line.rb
+++ b/spec/ruby/core/argf/shared/each_line.rb
@@ -33,17 +33,29 @@ describe :argf_each_line, :shared => true do
     end
   end
 
-  it "returns an Enumerator when passed no block" do
-    argv [@file1_name, @file2_name] do
-      ARGF.send(@method).should be_an_instance_of(enumerator_class)
-    end
-  end
-
   describe "with a separator" do
     it "yields each separated section of all streams" do
       argv [@file1_name, @file2_name] do
         ARGF.send(@method, '.').to_a.should ==
           (File.readlines(@file1_name, '.') + File.readlines(@file2_name, '.'))
+      end
+    end
+  end
+
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      argv [@file1_name, @file2_name] do
+        ARGF.send(@method).should be_an_instance_of(enumerator_class)
+      end
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          argv [@file1_name, @file2_name] do
+            ARGF.send(@method).size.should == nil
+          end
+        end
       end
     end
   end

--- a/spec/ruby/core/array/bsearch_spec.rb
+++ b/spec/ruby/core/array/bsearch_spec.rb
@@ -1,9 +1,12 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#bsearch" do
   it "returns an Enumerator when not passed a block" do
     [1].bsearch.should be_an_instance_of(enumerator_class)
   end
+
+  it_behaves_like :enumeratorized_with_unknown_size, :bsearch, [1,2,3]
 
   it "raises a TypeError if the block returns an Object" do
     lambda { [1].bsearch { Object.new } }.should raise_error(TypeError)

--- a/spec/ruby/core/array/combination_spec.rb
+++ b/spec/ruby/core/array/combination_spec.rb
@@ -50,4 +50,25 @@ describe "Array#combination" do
     end
     accum.should == [[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "returns 0 when the number of combinations is < 0" do
+          @array.combination(-1).size.should == 0
+          [].combination(-2).size.should == 0
+        end
+        it "returns the binomial coeficient between the array size the number of combinations" do
+          @array.combination(5).size.should == 0
+          @array.combination(4).size.should == 1
+          @array.combination(3).size.should == 4
+          @array.combination(2).size.should == 6
+          @array.combination(1).size.should == 4
+          @array.combination(0).size.should == 1
+          [].combination(0).size.should == 1
+          [].combination(1).size.should == 0
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/array/cycle_spec.rb
+++ b/spec/ruby/core/array/cycle_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#cycle" do
   before :each do
@@ -92,11 +93,9 @@ describe "Array#cycle" do
     lambda { @array.cycle(false) { } }.should raise_error(TypeError)
   end
 
-  it "returns Float::INFINITY as size when passed no argument and no block is given" do
-    @array.cycle.size.should == Float::INFINITY
+  before :all do
+    @object = [1, 2, 3, 4]
+    @empty_object = []
   end
-
-  it "returns the correct size when passed a number n as argument and no block is given" do
-    @array.cycle(2).size.should == 6
-  end
+  it_should_behave_like :enumeratorized_with_cycle_size
 end

--- a/spec/ruby/core/array/delete_if_spec.rb
+++ b/spec/ruby/core/array/delete_if_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#delete_if" do
   before do
@@ -59,7 +60,5 @@ describe "Array#delete_if" do
     @a.untrusted?.should be_true
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3].delete_if.size.should == 3
-  end
+  it_behaves_like :enumeratorized_with_origin_size, :delete_if, [1,2,3]
 end

--- a/spec/ruby/core/array/each_index_spec.rb
+++ b/spec/ruby/core/array/each_index_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 # Modifying a collection while the contents are being iterated
 # gives undefined behavior. See
@@ -36,9 +37,6 @@ describe "Array#each_index" do
     ScratchPad.recorded.should == [0]
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3].each_index.size.should == 3
-  end
-
   it_behaves_like :enumeratorize, :each_index
+  it_behaves_like :enumeratorized_with_origin_size, :each_index, [1,2,3]
 end

--- a/spec/ruby/core/array/each_spec.rb
+++ b/spec/ruby/core/array/each_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 # Modifying a collection while the contents are being iterated
 # gives undefined behavior. See
@@ -26,9 +27,6 @@ describe "Array#each" do
     b.should == [2, nil, 4]
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3].each.size.should == 3
-  end
-
   it_behaves_like :enumeratorize, :each
+  it_behaves_like :enumeratorized_with_origin_size, :each, [1,2,3]
 end

--- a/spec/ruby/core/array/permutation_spec.rb
+++ b/spec/ruby/core/array/permutation_spec.rb
@@ -106,4 +106,33 @@ describe "Array#permutation" do
 
     accum.should == [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        describe "with an array size greater than 0" do
+          it "returns the descending factorial of array size and given length" do
+            @numbers.permutation(4).size.should == 0
+            @numbers.permutation(3).size.should == 6
+            @numbers.permutation(2).size.should == 6
+            @numbers.permutation(1).size.should == 3
+            @numbers.permutation(0).size.should == 1
+          end
+          it "returns the descending factorial of array size with array size when there's no param" do
+            @numbers.permutation.size.should == 6
+            [1,2,3,4].permutation.size.should == 24
+            [1].permutation.size.should == 1
+          end
+        end
+        describe "with an empty array" do
+          it "returns 1 when the given length is 0" do
+            [].permutation(0).size.should == 1
+          end
+          it "returns 1 when there's param" do
+            [].permutation.size.should == 1
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/array/reject_spec.rb
+++ b/spec/ruby/core/array/reject_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#reject" do
   it "returns a new array without elements for which block is true" do
@@ -41,11 +42,8 @@ describe "Array#reject" do
     array.reject { false }.instance_variable_get("@variable").should == nil
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3, 4, 5, 6].reject.size.should == 6
-  end
-
   it_behaves_like :enumeratorize, :reject
+  it_behaves_like :enumeratorized_with_origin_size, :reject, [1,2,3]
 end
 
 describe "Array#reject!" do
@@ -112,9 +110,6 @@ describe "Array#reject!" do
     lambda { ArraySpecs.empty_frozen_array.reject! {} }.should raise_error(RuntimeError)
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3, 4, 5, 6].reject!.size.should == 6
-  end
-
   it_behaves_like :enumeratorize, :reject!
+  it_behaves_like :enumeratorized_with_origin_size, :reject!, [1,2,3]
 end

--- a/spec/ruby/core/array/repeated_combination_spec.rb
+++ b/spec/ruby/core/array/repeated_combination_spec.rb
@@ -54,4 +54,31 @@ describe "Array#repeated_combination" do
     end
     accum.sort.should == [[10, 10], [10, 11], [10, 12], [11, 11], [11, 12], [12, 12]]
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "returns 0 when the combination_size is < 0" do
+          @array.repeated_combination(-1).size.should == 0
+          [].repeated_combination(-2).size.should == 0
+        end
+
+        it "returns 1 when the combination_size is 0" do
+          @array.repeated_combination(0).size.should == 1
+          [].repeated_combination(0).size.should == 1
+        end
+
+        it "returns the binomial coeficient between combination_size and array size + combination_size -1" do
+          @array.repeated_combination(5).size.should == 21
+          @array.repeated_combination(4).size.should == 15
+          @array.repeated_combination(3).size.should == 10
+          @array.repeated_combination(2).size.should == 6
+          @array.repeated_combination(1).size.should == 3
+          @array.repeated_combination(0).size.should == 1
+          [].repeated_combination(0).size.should == 1
+          [].repeated_combination(1).size.should == 0
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/array/repeated_permutation_spec.rb
+++ b/spec/ruby/core/array/repeated_permutation_spec.rb
@@ -67,4 +67,28 @@ describe "Array#repeated_permutation" do
        [1, 2, 2], [2, 1, 1], [2, 1, 2],
        [2, 2, 1], [2, 2, 2]]
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "returns 0 when combination_size is < 0" do
+          @numbers.repeated_permutation(-1).size.should == 0
+          [].repeated_permutation(-1).size.should == 0
+        end
+
+        it "returns array size ** combination_size" do
+          @numbers.repeated_permutation(4).size.should == 81
+          @numbers.repeated_permutation(3).size.should == 27
+          @numbers.repeated_permutation(2).size.should == 9
+          @numbers.repeated_permutation(1).size.should == 3
+          @numbers.repeated_permutation(0).size.should == 1
+          [].repeated_permutation(4).size.should == 0
+          [].repeated_permutation(3).size.should == 0
+          [].repeated_permutation(2).size.should == 0
+          [].repeated_permutation(1).size.should == 0
+          [].repeated_permutation(0).size.should == 1
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/array/reverse_each_spec.rb
+++ b/spec/ruby/core/array/reverse_each_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 # Modifying a collection while the contents are being iterated
 # gives undefined behavior. See
@@ -38,4 +39,5 @@ describe "Array#reverse_each" do
   end
 
   it_behaves_like :enumeratorize, :reverse_each
+  it_behaves_like :enumeratorized_with_origin_size, :reverse_each, [1,2,3]
 end

--- a/spec/ruby/core/array/rindex_spec.rb
+++ b/spec/ruby/core/array/rindex_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 # Modifying a collection while the contents are being iterated
 # gives undefined behavior. See
@@ -72,4 +73,6 @@ describe "Array#rindex" do
       enum.each { |x| x < 2 }.should == 4
     end
   end
+
+  it_behaves_like :enumeratorized_with_unknown_size, :bsearch, [1,2,3]
 end

--- a/spec/ruby/core/array/select_spec.rb
+++ b/spec/ruby/core/array/select_spec.rb
@@ -2,9 +2,11 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/enumeratorize', __FILE__)
 require File.expand_path('../shared/keep_if', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#select" do
   it_behaves_like :enumeratorize, :select
+  it_behaves_like :enumeratorized_with_origin_size, :select, [1,2,3]
 
   it "returns a new array of elements for which block is true" do
     [1, 3, 4, 5, 6, 9].select { |i| i % ((i + 1) / 2) == 0}.should == [1, 4, 6]

--- a/spec/ruby/core/array/shared/collect.rb
+++ b/spec/ruby/core/array/shared/collect.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../../../enumerable/shared/enumeratorized', __FILE__)
+
 describe :array_collect, :shared => true do
   it "returns a copy of array with each element replaced by the value returned by block" do
     a = ['a', 'b', 'c', 'd']
@@ -44,6 +46,11 @@ describe :array_collect, :shared => true do
     a.untrust
     a.send(@method){|x| x}.untrusted?.should be_false
   end
+
+  before :all do
+    @object = [1, 2, 3, 4]
+  end
+  it_should_behave_like :enumeratorized_with_origin_size
 end
 
 describe :array_collect_b, :shared => true do
@@ -114,4 +121,9 @@ describe :array_collect_b, :shared => true do
       lambda { enumerator.each {|x| x } }.should raise_error(RuntimeError)
     end
   end
+
+  before :all do
+    @object = [1, 2, 3, 4]
+  end
+  it_should_behave_like :enumeratorized_with_origin_size
 end

--- a/spec/ruby/core/array/shared/keep_if.rb
+++ b/spec/ruby/core/array/shared/keep_if.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../../../enumerable/shared/enumeratorized', __FILE__)
+
 describe :keep_if, :shared => true do
   it "deletes elements for which the block returns a false value" do
     array = [1, 2, 3, 4, 5]
@@ -9,9 +11,10 @@ describe :keep_if, :shared => true do
     [1, 2, 3].send(@method).should be_an_instance_of(enumerator_class)
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3].send(@method).size.should == 3
+  before :all do
+    @object = [1,2,3]
   end
+  it_should_behave_like :enumeratorized_with_origin_size
 
   describe "on frozen objects" do
     before(:each) do

--- a/spec/ruby/core/array/sort_by_spec.rb
+++ b/spec/ruby/core/array/sort_by_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Array#sort_by!" do
   it "sorts array in place by passing each element to the given block" do
@@ -43,7 +44,5 @@ describe "Array#sort_by!" do
     partially_sorted.any?{|ary| ary != [1, 2, 3, 4, 5]}.should be_true
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3, 4, 5, 6].sort_by!.size.should == 6
-  end
+  it_behaves_like :enumeratorized_with_origin_size, :sort_by!, [1,2,3]
 end

--- a/spec/ruby/core/dir/each_spec.rb
+++ b/spec/ruby/core/dir/each_spec.rb
@@ -35,9 +35,19 @@ describe "Dir#each" do
     ls.should include(@dir.read)
   end
 
-  it "returns an Enumerator if no block given" do
-    @dir.each.should be_an_instance_of(enumerator_class)
-    @dir.each.to_a.sort.should == DirSpecs.expected_paths
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      @dir.each.should be_an_instance_of(enumerator_class)
+      @dir.each.to_a.sort.should == DirSpecs.expected_paths
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          @dir.each.size.should == nil
+        end
+      end
+    end
   end
 end
 

--- a/spec/ruby/core/dir/foreach_spec.rb
+++ b/spec/ruby/core/dir/foreach_spec.rb
@@ -38,4 +38,19 @@ describe "Dir.foreach" do
     Dir.foreach(DirSpecs.mock_dir).should be_an_instance_of(enumerator_class)
     Dir.foreach(DirSpecs.mock_dir).to_a.sort.should == DirSpecs.expected_paths
   end
+
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      Dir.foreach(DirSpecs.mock_dir).should be_an_instance_of(enumerator_class)
+      Dir.foreach(DirSpecs.mock_dir).to_a.sort.should == DirSpecs.expected_paths
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          Dir.foreach(DirSpecs.mock_dir).size.should == nil
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/enumerable/chunk_spec.rb
+++ b/spec/ruby/core/enumerable/chunk_spec.rb
@@ -69,4 +69,10 @@ describe "Enumerable#chunk" do
       ScratchPad.recorded.should == [[1]]
     end
   end
+
+  it 'returned Enumerator size returns nil' do
+    e = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 2, 1)
+    enum = e.chunk { |x| true }
+    enum.size.should == nil
+  end
 end

--- a/spec/ruby/core/enumerable/cycle_spec.rb
+++ b/spec/ruby/core/enumerable/cycle_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumeratorized', __FILE__)
 
 describe "Enumerable#cycle" do
   describe "passed no argument or nil" do
@@ -38,11 +39,6 @@ describe "Enumerable#cycle" do
       enum = EnumerableSpecs::EachCounter.new(10, 20, 30)
       enum.cycle { |x| break if x == 20}
       enum.times_yielded.should == 2
-    end
-
-    it "returns Float::INFINITY as size when no block is given" do
-      enum = EnumerableSpecs::NumerousWithSize.new(*['a', 'b', 'c'])
-      enum.cycle.size.should == Float::INFINITY
     end
   end
 
@@ -87,10 +83,22 @@ describe "Enumerable#cycle" do
       multi = EnumerableSpecs::YieldsMulti.new
       multi.cycle(2).to_a.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9], [1, 2], [3, 4, 5], [6, 7, 8, 9]]
     end
-
-    it "returns the correct size when no block is given" do
-      enum = EnumerableSpecs::NumerousWithSize.new('a', 'b', 'c')
-      enum.cycle(2).size.should == 6
-    end
   end
+
+  describe "Enumerable with size" do
+    before :all do
+      @object = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4)
+      @empty_object = EnumerableSpecs::EmptyWithSize.new
+    end
+    it_should_behave_like :enumeratorized_with_cycle_size
+  end
+
+  describe "Enumerable with no size" do
+    before :all do
+      @object = EnumerableSpecs::Numerous.new(1, 2, 3, 4)
+      @method = :cycle
+    end
+    it_should_behave_like :enumeratorized_with_unknown_size
+  end
+
 end

--- a/spec/ruby/core/enumerable/drop_while_spec.rb
+++ b/spec/ruby/core/enumerable/drop_while_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#drop_while" do
   before :each do
@@ -45,8 +46,5 @@ describe "Enumerable#drop_while" do
     multi.drop_while {|e| e != [6, 7, 8, 9] }.should == [[6, 7, 8, 9]]
   end
 
-  it "returns nil as size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 0)
-    enum.drop_while.size.should == nil
-  end
+  it_behaves_like :enumerable_enumeratorized_with_unknown_size, :drop_while
 end

--- a/spec/ruby/core/enumerable/each_cons_spec.rb
+++ b/spec/ruby/core/enumerable/each_cons_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumeratorized', __FILE__)
 
 describe "Enumerable#each_cons" do
   before :each do
@@ -50,19 +51,45 @@ describe "Enumerable#each_cons" do
     cnt.times_yielded.should == 3
   end
 
-  it "returns an enumerator if no block" do
-    e = @enum.each_cons(3)
-    e.should be_an_instance_of(enumerator_class)
-    e.to_a.should == @in_threes
-  end
-
   it "gathers whole arrays as elements when each yields multiple" do
     multi = EnumerableSpecs::YieldsMulti.new
     multi.each_cons(2).to_a.should == [[[1, 2], [3, 4, 5]], [[3, 4, 5], [6, 7, 8, 9]]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-    enum.each_cons(3).size.should == 8
+  describe "when no block is given" do
+    it "returns an enumerator" do
+      e = @enum.each_cons(3)
+      e.should be_an_instance_of(enumerator_class)
+      e.to_a.should == @in_threes
+    end
+
+    describe "Enumerable with size" do
+      describe "returned Enumerator" do
+        describe "size" do
+          it "returns enum size - each_cons argument + 1" do
+            enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            enum.each_cons(10).size.should == 1
+            enum.each_cons(9).size.should == 2
+            enum.each_cons(3).size.should == 8
+            enum.each_cons(2).size.should == 9
+            enum.each_cons(1).size.should == 10
+          end
+
+          it "returns 0 when the enum is empty" do
+            enum = EnumerableSpecs::EmptyWithSize.new
+            enum.each_cons(10).size.should == 0
+          end
+        end
+      end
+    end
+
+    describe "Enumerable with no size" do
+      before :all do
+        @object = EnumerableSpecs::Numerous.new(1, 2, 3, 4)
+        @method = :each_cons
+        @method_args = [8]
+      end
+      it_should_behave_like :enumeratorized_with_unknown_size
+    end
   end
 end

--- a/spec/ruby/core/enumerable/each_cons_spec.rb
+++ b/spec/ruby/core/enumerable/each_cons_spec.rb
@@ -18,6 +18,10 @@ describe "Enumerable#each_cons" do
     lambda{ @enum.each_cons(-2){}   }.should raise_error(ArgumentError)
     lambda{ @enum.each_cons{}       }.should raise_error(ArgumentError)
     lambda{ @enum.each_cons(2,2){}  }.should raise_error(ArgumentError)
+    lambda{ @enum.each_cons(0)      }.should raise_error(ArgumentError)
+    lambda{ @enum.each_cons(-2)     }.should raise_error(ArgumentError)
+    lambda{ @enum.each_cons         }.should raise_error(ArgumentError)
+    lambda{ @enum.each_cons(2,2)    }.should raise_error(ArgumentError)
   end
 
   it "tries to convert n to an Integer using #to_int" do

--- a/spec/ruby/core/enumerable/each_entry_spec.rb
+++ b/spec/ruby/core/enumerable/each_entry_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#each_entry" do
   before :each do
@@ -35,4 +36,6 @@ describe "Enumerable#each_entry" do
     enum.each_entry(:foo, "bar").to_a.should == [1,2]
     enum.arguments_passed.should == [:foo, "bar"]
   end
+
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :each_entry
 end

--- a/spec/ruby/core/enumerable/each_slice_spec.rb
+++ b/spec/ruby/core/enumerable/each_slice_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumeratorized', __FILE__)
 
 describe "Enumerable#each_slice" do
   before :each do
@@ -61,9 +62,41 @@ describe "Enumerable#each_slice" do
     multi.each_slice(2).to_a.should == [[[1, 2], [3, 4, 5]], [[6, 7, 8, 9]]]
   end
 
-  it "returns the correct size when no block is given" do
-    [1, 2, 3, 5].each_slice(2).size.should == 2
-  end
+  describe "when no block is given" do
+    it "returns an enumerator" do
+      e = @enum.each_slice(3)
+      e.should be_an_instance_of(enumerator_class)
+      e.to_a.should == @sliced
+    end
 
+    describe "Enumerable with size" do
+      describe "returned Enumerator" do
+        describe "size" do
+          it "returns the ceil of Enumerable size divided by the argument value" do
+            enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            enum.each_slice(10).size.should == 1
+            enum.each_slice(9).size.should == 2
+            enum.each_slice(3).size.should == 4
+            enum.each_slice(2).size.should == 5
+            enum.each_slice(1).size.should == 10
+          end
+
+          it "returns 0 when the Enumerable is empty" do
+            enum = EnumerableSpecs::EmptyWithSize.new
+            enum.each_slice(10).size.should == 0
+          end
+        end
+      end
+    end
+
+    describe "Enumerable with no size" do
+      before :all do
+        @object = EnumerableSpecs::Numerous.new(1, 2, 3, 4)
+        @method = :each_slice
+        @method_args = [8]
+      end
+      it_should_behave_like :enumeratorized_with_unknown_size
+    end
+  end
 
 end

--- a/spec/ruby/core/enumerable/each_slice_spec.rb
+++ b/spec/ruby/core/enumerable/each_slice_spec.rb
@@ -18,6 +18,10 @@ describe "Enumerable#each_slice" do
     lambda{ @enum.each_slice(-2){}   }.should raise_error(ArgumentError)
     lambda{ @enum.each_slice{}       }.should raise_error(ArgumentError)
     lambda{ @enum.each_slice(2,2){}  }.should raise_error(ArgumentError)
+    lambda{ @enum.each_slice(0)      }.should raise_error(ArgumentError)
+    lambda{ @enum.each_slice(-2)     }.should raise_error(ArgumentError)
+    lambda{ @enum.each_slice         }.should raise_error(ArgumentError)
+    lambda{ @enum.each_slice(2,2)    }.should raise_error(ArgumentError)
   end
 
   it "tries to convert n to an Integer using #to_int" do

--- a/spec/ruby/core/enumerable/each_with_index_spec.rb
+++ b/spec/ruby/core/enumerable/each_with_index_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#each_with_index" do
 
@@ -48,8 +49,5 @@ describe "Enumerable#each_with_index" do
     count.arguments_passed.should == [:foo, :bar]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3)
-    enum.each_with_index.size.should == 3
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :each_with_index
 end

--- a/spec/ruby/core/enumerable/each_with_object_spec.rb
+++ b/spec/ruby/core/enumerable/each_with_object_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#each_with_object" do
   before :each do
@@ -36,8 +37,8 @@ describe "Enumerable#each_with_object" do
     array.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-    enum.each_with_object([]).size.should == 10
+  before :all do
+    @method_args = [[]]
   end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :each_with_object
 end

--- a/spec/ruby/core/enumerable/find_index_spec.rb
+++ b/spec/ruby/core/enumerable/find_index_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#find_index" do
   before :each do
@@ -51,11 +52,6 @@ describe "Enumerable#find_index" do
     it "gathers whole arrays as elements when each yields multiple" do
       @yieldsmixed.find_index([0, 1, 2]).should == 3
     end
-
-    it "returns nil as size" do
-      enum = EnumerableSpecs::NumerousWithSize.new(*@elements)
-      enum.find_index.size.should == nil
-    end
   end
 
   describe "with block" do
@@ -81,4 +77,6 @@ describe "Enumerable#find_index" do
       end
     end
   end
+
+  it_behaves_like :enumerable_enumeratorized_with_unknown_size, :find_index
 end

--- a/spec/ruby/core/enumerable/fixtures/classes.rb
+++ b/spec/ruby/core/enumerable/fixtures/classes.rb
@@ -41,6 +41,15 @@ module EnumerableSpecs
     end
   end
 
+  class EmptyWithSize
+    include Enumerable
+    def each
+    end
+    def size
+      0
+    end
+  end
+
   class ThrowingEach
     include Enumerable
     def each

--- a/spec/ruby/core/enumerable/group_by_spec.rb
+++ b/spec/ruby/core/enumerable/group_by_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#group_by" do
   it "returns a hash with values grouped according to the block" do
@@ -40,8 +41,5 @@ describe "Enumerable#group_by" do
     EnumerableSpecs::Empty.new.untrust.group_by {}.untrusted?.should be_true
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.group_by.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :group_by
 end

--- a/spec/ruby/core/enumerable/max_by_spec.rb
+++ b/spec/ruby/core/enumerable/max_by_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#max_by" do
   it "returns an enumerator if no block" do
@@ -38,8 +39,5 @@ describe "Enumerable#max_by" do
     multi.max_by {|e| e.size}.should == [6, 7, 8, 9]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.max_by.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :max_by
 end

--- a/spec/ruby/core/enumerable/min_by_spec.rb
+++ b/spec/ruby/core/enumerable/min_by_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#min_by" do
   it "returns an enumerator if no block" do
@@ -39,8 +40,5 @@ describe "Enumerable#min_by" do
     multi.min_by {|e| e.size}.should == [1, 2]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.min_by.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :min_by
 end

--- a/spec/ruby/core/enumerable/minmax_by_spec.rb
+++ b/spec/ruby/core/enumerable/minmax_by_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#minmax_by" do
   it "returns an enumerator if no block" do
@@ -39,8 +40,5 @@ describe "Enumerable#minmax_by" do
     multi.minmax_by {|e| e.size}.should == [[1, 2], [6, 7, 8, 9]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.minmax_by.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :minmax_by
 end

--- a/spec/ruby/core/enumerable/partition_spec.rb
+++ b/spec/ruby/core/enumerable/partition_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#partition" do
   it "returns two arrays, the first containing elements for which the block is true, the second containing the rest" do
@@ -15,8 +16,5 @@ describe "Enumerable#partition" do
     multi.partition {|e| e == [3, 4, 5] }.should == [[[3, 4, 5]], [[1, 2], [6, 7, 8, 9]]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.partition.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :partition
 end

--- a/spec/ruby/core/enumerable/reject_spec.rb
+++ b/spec/ruby/core/enumerable/reject_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#reject" do
   it "returns an array of the elements for which block is false" do
@@ -20,8 +21,5 @@ describe "Enumerable#reject" do
     multi.reject {|e| e == [3, 4, 5] }.should == [[1, 2], [6, 7, 8, 9]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.reject.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :reject
 end

--- a/spec/ruby/core/enumerable/reverse_each_spec.rb
+++ b/spec/ruby/core/enumerable/reverse_each_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#reverse_each" do
   it "traverses enum in reverse order and pass each element to block" do
@@ -20,4 +21,6 @@ describe "Enumerable#reverse_each" do
     multi.reverse_each {|e| yielded << e }
     yielded.should == [[6, 7, 8, 9], [3, 4, 5], [1, 2]]
   end
+
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :reverse_each
 end

--- a/spec/ruby/core/enumerable/shared/collect.rb
+++ b/spec/ruby/core/enumerable/shared/collect.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../enumerable_enumeratorized', __FILE__)
+
 describe :enumerable_collect, :shared => true do
   before :each do
     ScratchPad.record []
@@ -26,8 +28,5 @@ describe :enumerable_collect, :shared => true do
     enum.each { |i| -i }.should == [-2, -5, -3, -6, -1, -4]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4)
-    enum.send(@method).size.should == 4
-  end
+  it_should_behave_like :enumerable_enumeratorized_with_origin_size
 end

--- a/spec/ruby/core/enumerable/shared/collect_concat.rb
+++ b/spec/ruby/core/enumerable/shared/collect_concat.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../enumerable_enumeratorized', __FILE__)
+
 describe :enumerable_collect_concat, :shared => true do
   it "yields elements to the block and flattens one level" do
     numerous = EnumerableSpecs::Numerous.new(1, [2, 3], [4, [5, 6]], {:foo => :bar})
@@ -48,8 +50,5 @@ describe :enumerable_collect_concat, :shared => true do
     enum.each{ |i| [i] * i }.should == [1, 2, 2]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new([1, 2], [3, 4], [5, 6])
-    enum.send(@method).size.should == 3
-  end
+  it_should_behave_like :enumerable_enumeratorized_with_origin_size
 end

--- a/spec/ruby/core/enumerable/shared/enumerable_enumeratorized.rb
+++ b/spec/ruby/core/enumerable/shared/enumerable_enumeratorized.rb
@@ -1,0 +1,33 @@
+require File.expand_path('../enumeratorized', __FILE__)
+
+describe :enumerable_enumeratorized_with_unknown_size, :shared => true do
+  describe "Enumerable with size" do
+    before :all do
+      @object = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4)
+    end
+    it_should_behave_like :enumeratorized_with_unknown_size
+  end
+
+  describe "Enumerable with no size" do
+    before :all do
+      @object = EnumerableSpecs::Numerous.new(1, 2, 3, 4)
+    end
+    it_should_behave_like :enumeratorized_with_unknown_size
+  end
+end
+
+describe :enumerable_enumeratorized_with_origin_size, :shared => true do
+  describe "Enumerable with size" do
+    before :all do
+      @object = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4)
+    end
+    it_should_behave_like :enumeratorized_with_origin_size
+  end
+
+  describe "Enumerable with no size" do
+    before :all do
+      @object = EnumerableSpecs::Numerous.new(1, 2, 3, 4)
+    end
+    it_should_behave_like :enumeratorized_with_unknown_size
+  end
+end

--- a/spec/ruby/core/enumerable/shared/enumeratorized.rb
+++ b/spec/ruby/core/enumerable/shared/enumeratorized.rb
@@ -1,0 +1,42 @@
+describe :enumeratorized_with_unknown_size, :shared => true do
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      it "size returns nil" do
+        @object.send(@method,*@method_args).size.should == nil
+      end
+    end
+  end
+end
+
+describe :enumeratorized_with_origin_size, :shared => true do
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      it "size returns the enumerable size" do
+        @object.send(@method,*@method_args).size.should == @object.size
+      end
+    end
+  end
+end
+
+describe :enumeratorized_with_cycle_size, :shared => true do
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should be the result of multiplying the enumerable size by the argument passed" do
+          @object.cycle(2).size.should == @object.size * 2
+          @object.cycle(7).size.should == @object.size * 7
+          @object.cycle(0).size.should == 0
+          @empty_object.cycle(2).size.should == 0
+        end
+
+        it "should be zero when the argument passed is 0 or less" do
+          @object.cycle(-1).size.should == 0
+        end
+
+        it "should be Float::INFINITY when no argument is passed" do
+          @object.cycle.size.should == Float::INFINITY
+        end
+      end
+    end
+  end
+end

--- a/spec/ruby/core/enumerable/shared/find.rb
+++ b/spec/ruby/core/enumerable/shared/find.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../enumerable_enumeratorized', __FILE__)
+
 describe :enumerable_find, :shared => true do
   # #detect and #find are aliases, so we only need one function
   before :each do
@@ -67,8 +69,5 @@ describe :enumerable_find, :shared => true do
     multi.send(@method) {|e| e == [1, 2] }.should == [1, 2]
   end
 
-  it "returns the nil as size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(*@elements)
-    enum.send(@method).size.should == nil
-  end
+  it_should_behave_like :enumerable_enumeratorized_with_unknown_size
 end

--- a/spec/ruby/core/enumerable/shared/find_all.rb
+++ b/spec/ruby/core/enumerable/shared/find_all.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../enumerable_enumeratorized', __FILE__)
+
 describe :enumerable_find_all, :shared => true do
   before :each do
     ScratchPad.record []
@@ -25,8 +27,5 @@ describe :enumerable_find_all, :shared => true do
     multi.send(@method) {|e| e == [3, 4, 5] }.should == [[3, 4, 5]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(*@elements)
-    enum.send(@method).size.should == 10
-  end
+  it_should_behave_like :enumerable_enumeratorized_with_origin_size
 end

--- a/spec/ruby/core/enumerable/slice_before_spec.rb
+++ b/spec/ruby/core/enumerable/slice_before_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#slice_before" do
   before :each do
@@ -27,11 +28,6 @@ describe "Enumerable#slice_before" do
       arg.should_receive(:===).and_return(false, :foo, nil, false, false, 42, false)
       e = @enum.slice_before(arg)
       e.to_a.should == [[7], [6, 5, 4, 3], [2, 1]]
-    end
-
-    it "returns nil as size" do
-      enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-      enum.slice_before(3).size.should == nil
     end
   end
 
@@ -79,4 +75,9 @@ describe "Enumerable#slice_before" do
     lambda { @enum.slice_before("one", "two") }.should raise_error(ArgumentError)
     lambda { @enum.slice_before }.should raise_error(ArgumentError)
   end
+
+  before :all do
+    @method_args = [3]
+  end
+  it_behaves_like :enumerable_enumeratorized_with_unknown_size, :slice_before
 end

--- a/spec/ruby/core/enumerable/sort_by_spec.rb
+++ b/spec/ruby/core/enumerable/sort_by_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#sort_by" do
   it "returns an array of elements ordered by the result of block" do
@@ -26,8 +27,5 @@ describe "Enumerable#sort_by" do
     multi.sort_by {|e| e.size}.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
   end
 
-  it "returns the correct size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.sort_by.size.should == 6
-  end
+  it_behaves_like :enumerable_enumeratorized_with_origin_size, :sort_by
 end

--- a/spec/ruby/core/enumerable/take_while_spec.rb
+++ b/spec/ruby/core/enumerable/take_while_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require File.expand_path('../shared/enumerable_enumeratorized', __FILE__)
 
 describe "Enumerable#take_while" do
   before :each do
@@ -46,8 +47,5 @@ describe "Enumerable#take_while" do
     yields.should == [1, [2], 3, 5, [8, 9], nil, []]
   end
 
-  it "returns nil as size when no block is given" do
-    enum = EnumerableSpecs::NumerousWithSize.new(1, 2, 3, 4, 5, 6)
-    enum.take_while.size.should == nil
-  end
+  it_behaves_like :enumerable_enumeratorized_with_unknown_size, :take_while
 end

--- a/spec/ruby/core/enumerator/each_with_index_spec.rb
+++ b/spec/ruby/core/enumerator/each_with_index_spec.rb
@@ -1,8 +1,17 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../../../shared/enumerator/with_index', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Enumerator#each_with_index" do
   it_behaves_like(:enum_with_index, :each_with_index)
+  it_behaves_like(:enumeratorized_with_origin_size, :each_with_index, [1,2,3].select)
+
+  it "returns a new Enumerator when no block is given" do
+    enum1 = [1,2,3].select
+    enum2 = enum1.each_with_index
+    enum2.should be_an_instance_of(enumerator_class)
+    enum1.should_not === enum2
+  end
 
   it "raises an ArgumentError if passed extra arguments" do
     lambda do

--- a/spec/ruby/core/enumerator/with_index_spec.rb
+++ b/spec/ruby/core/enumerator/with_index_spec.rb
@@ -1,8 +1,17 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../../../shared/enumerator/with_index', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Enumerator#with_index" do
   it_behaves_like(:enum_with_index, :with_index)
+  it_behaves_like(:enumeratorized_with_origin_size, :with_index, [1,2,3].select)
+
+  it "returns a new Enumerator when no block is given" do
+    enum1 = [1,2,3].select
+    enum2 = enum1.with_index
+    enum2.should be_an_instance_of(enumerator_class)
+    enum1.should_not === enum2
+  end
 
   it "accepts an optional argument when given a block" do
     lambda do

--- a/spec/ruby/core/env/delete_if_spec.rb
+++ b/spec/ruby/core/env/delete_if_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "ENV.delete_if" do
   it "deletes pairs if the block returns true" do
@@ -21,4 +22,6 @@ describe "ENV.delete_if" do
     enum.each { |k, v| k == "foo" }
     ENV["foo"].should == nil
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :delete_if, ENV
 end

--- a/spec/ruby/core/env/each_key_spec.rb
+++ b/spec/ruby/core/env/each_key_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "ENV.each_key" do
 
@@ -26,4 +27,6 @@ describe "ENV.each_key" do
       key.encoding.should == Encoding.find('locale')
     end
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :each_key, ENV
 end

--- a/spec/ruby/core/env/each_value_spec.rb
+++ b/spec/ruby/core/env/each_value_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "ENV.each_value" do
 
@@ -26,4 +27,6 @@ describe "ENV.each_value" do
       value.encoding.should == Encoding.find('locale')
     end
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :each_value, ENV
 end

--- a/spec/ruby/core/env/keep_if_spec.rb
+++ b/spec/ruby/core/env/keep_if_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "ENV.keep_if" do
   it "deletes pairs if the block returns false" do
@@ -21,4 +22,6 @@ describe "ENV.keep_if" do
     enum.each { |k, v| k != "foo" }
     ENV["foo"].should == nil
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :keep_if, ENV
 end

--- a/spec/ruby/core/env/reject_spec.rb
+++ b/spec/ruby/core/env/reject_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "ENV.reject!" do
   it "rejects entries based on key" do
@@ -33,6 +34,8 @@ describe "ENV.reject!" do
       ENV.replace orig
     end
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :reject!, ENV
 end
 
 describe "ENV.reject" do
@@ -69,4 +72,6 @@ describe "ENV.reject" do
       ENV.replace orig
     end
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :reject, ENV
 end

--- a/spec/ruby/core/env/select_spec.rb
+++ b/spec/ruby/core/env/select_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "ENV.select!" do
   it "removes environment variables for which the block returns true" do
@@ -19,6 +20,8 @@ describe "ENV.select!" do
   it "returns an Enumerator if called without a block" do
     ENV.select!.should be_an_instance_of(enumerator_class)
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :select!, ENV
 end
 
 describe "ENV.select" do
@@ -31,4 +34,6 @@ describe "ENV.select" do
   it "returns an Enumerator when no block is given" do
     ENV.select.should be_an_instance_of(enumerator_class)
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :select, ENV
 end

--- a/spec/ruby/core/env/shared/each.rb
+++ b/spec/ruby/core/env/shared/each.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../../../enumerable/shared/enumeratorized', __FILE__)
+
 describe :env_each, :shared => true do
   it "returns each pair" do
     orig = ENV.to_hash
@@ -17,6 +19,11 @@ describe :env_each, :shared => true do
   it "returns an Enumerator if called without a block" do
     ENV.send(@method).should be_an_instance_of(enumerator_class)
   end
+
+  before :all do
+    @object = ENV
+  end
+  it_should_behave_like :enumeratorized_with_origin_size
 
   with_feature :encoding do
     describe "with encoding" do

--- a/spec/ruby/core/hash/delete_if_spec.rb
+++ b/spec/ruby/core/hash/delete_if_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#delete_if" do
   it "yields two arguments: key and value" do
@@ -33,4 +34,5 @@ describe "Hash#delete_if" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :delete_if)
+  it_behaves_like(:enumeratorized_with_origin_size, :delete_if, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/each_key_spec.rb
+++ b/spec/ruby/core/hash/each_key_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#each_key" do
   it "calls block once for each key, passing key" do
@@ -18,4 +19,5 @@ describe "Hash#each_key" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :each_key)
+  it_behaves_like(:enumeratorized_with_origin_size, :each_key, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/each_pair_spec.rb
+++ b/spec/ruby/core/hash/each_pair_spec.rb
@@ -2,8 +2,10 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
 require File.expand_path('../shared/each', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#each_pair" do
   it_behaves_like(:hash_each, :each_pair)
   it_behaves_like(:hash_iteration_no_block, :each_pair)
+  it_behaves_like(:enumeratorized_with_origin_size, :each_pair, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/each_spec.rb
+++ b/spec/ruby/core/hash/each_spec.rb
@@ -2,8 +2,10 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
 require File.expand_path('../shared/each', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#each" do
   it_behaves_like(:hash_each, :each)
   it_behaves_like(:hash_iteration_no_block, :each)
+  it_behaves_like(:enumeratorized_with_origin_size, :each, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/each_value_spec.rb
+++ b/spec/ruby/core/hash/each_value_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#each_value" do
   it "calls block once for each key, passing value" do
@@ -18,4 +19,5 @@ describe "Hash#each_value" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :each_value)
+  it_behaves_like(:enumeratorized_with_origin_size, :each_value, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/keep_if_spec.rb
+++ b/spec/ruby/core/hash/keep_if_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#keep_if" do
   it "yields two arguments: key and value" do
@@ -26,4 +27,5 @@ describe "Hash#keep_if" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :keep_if)
+  it_behaves_like(:enumeratorized_with_origin_size, :keep_if, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/reject_spec.rb
+++ b/spec/ruby/core/hash/reject_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#reject" do
   it "returns a new hash removing keys for which the block yields true" do
@@ -47,6 +48,7 @@ describe "Hash#reject" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :reject)
+  it_behaves_like(:enumeratorized_with_origin_size, :reject, new_hash(1 => 2, 3 => 4, 5 => 6))
 end
 
 describe "Hash#reject!" do
@@ -86,4 +88,5 @@ describe "Hash#reject!" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :reject!)
+  it_behaves_like(:enumeratorized_with_origin_size, :reject!, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/hash/select_spec.rb
+++ b/spec/ruby/core/hash/select_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/iteration', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Hash#select" do
   before(:each) do
@@ -40,6 +41,7 @@ describe "Hash#select" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :select)
+  it_behaves_like(:enumeratorized_with_origin_size, :select, new_hash(1 => 2, 3 => 4, 5 => 6))
 end
 
 describe "Hash#select!" do
@@ -71,4 +73,5 @@ describe "Hash#select!" do
   end
 
   it_behaves_like(:hash_iteration_no_block, :select!)
+  it_behaves_like(:enumeratorized_with_origin_size, :select!, new_hash(1 => 2, 3 => 4, 5 => 6))
 end

--- a/spec/ruby/core/integer/downto_spec.rb
+++ b/spec/ruby/core/integer/downto_spec.rb
@@ -31,12 +31,39 @@ describe "Integer#downto [stop] when self and stop are Fixnums" do
     lambda {1.downto(nil) {|x| p x } }.should raise_error(ArgumentError)
   end
 
-  it "returns an Enumerator" do
-    result = []
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      result = []
 
-    enum = 5.downto(2)
-    enum.each { |i| result << i }
+      enum = 5.downto(2)
+      enum.each { |i| result << i }
 
-    result.should == [5, 4, 3, 2]
+      result.should == [5, 4, 3, 2]
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "raises an ArgumentError for invalid endpoints" do
+          enum = 1.downto("A")
+          lambda { enum.size }.should raise_error(ArgumentError)
+          enum = 1.downto(nil)
+          lambda { enum.size }.should raise_error(ArgumentError)
+        end
+
+        it "returns self - stop + 1" do
+          10.downto(5).size.should == 6
+          10.downto(1).size.should == 10
+          10.downto(0).size.should == 11
+          0.downto(0).size.should == 1
+          -3.downto(-5).size.should == 3
+        end
+
+        it "returns 0 when stop > self" do
+          4.downto(5).size.should == 0
+          -5.downto(0).size.should == 0
+          -5.downto(-3).size.should == 0
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/integer/times_spec.rb
+++ b/spec/ruby/core/integer/times_spec.rb
@@ -64,4 +64,16 @@ describe "Integer#times" do
 
     result.should == [0, 1, 2]
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "returns self" do
+          5.times.size.should == 5
+          10.times.size.should == 10
+          0.times.size.should == 0
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/integer/upto_spec.rb
+++ b/spec/ruby/core/integer/upto_spec.rb
@@ -31,12 +31,39 @@ describe "Integer#upto [stop] when self and stop are Fixnums" do
     lambda { 1.upto(nil) {|x| p x} }.should raise_error(ArgumentError)
   end
 
-  it "returns an Enumerator" do
-    result = []
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      result = []
 
-    enum = 2.upto(5)
-    enum.each { |i| result << i }
+      enum = 2.upto(5)
+      enum.each { |i| result << i }
 
-    result.should == [2, 3, 4, 5]
+      result.should == [2, 3, 4, 5]
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "raises an ArgumentError for non-numeric endpoints" do
+          enum = 1.upto("A")
+          lambda { enum.size }.should raise_error(ArgumentError)
+          enum = 1.upto(nil)
+          lambda { enum.size }.should raise_error(ArgumentError)
+        end
+
+        it "returns stop - self + 1" do
+          5.upto(10).size.should == 6
+          1.upto(10).size.should == 10
+          0.upto(10).size.should == 11
+          0.upto(0).size.should == 1
+          -5.upto(-3).size.should == 3
+        end
+
+        it "returns 0 when stop < self" do
+          5.upto(4).size.should == 0
+          0.upto(-5).size.should == 0
+          -3.upto(-5).size.should == 0
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/io/each_byte_spec.rb
+++ b/spec/ruby/core/io/each_byte_spec.rb
@@ -28,10 +28,20 @@ describe "IO#each_byte" do
     ScratchPad.recorded.should == [86, 111, 105, 99, 105]
   end
 
-  it "returns an Enumerator when passed no block" do
-    enum = @io.each_byte
-    enum.should be_an_instance_of(enumerator_class)
-    enum.first(5).should == [86, 111, 105, 99, 105]
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      enum = @io.each_byte
+      enum.should be_an_instance_of(enumerator_class)
+      enum.first(5).should == [86, 111, 105, 99, 105]
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          @io.each_byte.size.should == nil
+        end
+      end
+    end
   end
 end
 

--- a/spec/ruby/core/io/foreach_spec.rb
+++ b/spec/ruby/core/io/foreach_spec.rb
@@ -55,9 +55,19 @@ describe "IO.foreach" do
     $_.should be_nil
   end
 
-  it "returns an Enumerator when called without a block" do
-    IO.foreach(@name).should be_an_instance_of(enumerator_class)
-    IO.foreach(@name).to_a.should == IOSpecs.lines
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      IO.foreach(@name).should be_an_instance_of(enumerator_class)
+      IO.foreach(@name).to_a.should == IOSpecs.lines
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          IO.foreach(@name).size.should == nil
+        end
+      end
+    end
   end
 
   it_behaves_like :io_readlines, :foreach, IOSpecs.collector

--- a/spec/ruby/core/io/lines_spec.rb
+++ b/spec/ruby/core/io/lines_spec.rb
@@ -15,6 +15,20 @@ describe "IO#lines" do
     @io.lines.should be_an_instance_of(enumerator_class)
   end
 
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      @io.lines.should be_an_instance_of(enumerator_class)
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          @io.lines.size.should == nil
+        end
+      end
+    end
+  end
+
   it "returns a line when accessed" do
     enum = @io.lines
     enum.first.should == IOSpecs.lines[0]

--- a/spec/ruby/core/io/shared/chars.rb
+++ b/spec/ruby/core/io/shared/chars.rb
@@ -23,10 +23,20 @@ describe :io_chars, :shared => true do
     ScratchPad.recorded.should == ["Q", "u", "i", " ", "è"]
   end
 
-  it "returns an Enumerator when passed no block" do
-    enum = @io.send(@method)
-    enum.should be_an_instance_of(enumerator_class)
-    enum.first(5).should == ["V", "o", "i", "c", "i"]
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      enum = @io.send(@method)
+      enum.should be_an_instance_of(enumerator_class)
+      enum.first(5).should == ["V", "o", "i", "c", "i"]
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          @io.send(@method).size.should == nil
+        end
+      end
+    end
   end
 
   it "returns itself" do

--- a/spec/ruby/core/io/shared/codepoints.rb
+++ b/spec/ruby/core/io/shared/codepoints.rb
@@ -11,8 +11,18 @@ describe :io_codepoints, :shared => true do
     @io.close
   end
 
-  it "returns an Enumerator when passed no block" do
-    @enum.should be_an_instance_of(enumerator_class)
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      @enum.should be_an_instance_of(enumerator_class)
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          @enum.size.should == nil
+        end
+      end
+    end
   end
 
   it "yields each codepoint" do

--- a/spec/ruby/core/io/shared/each.rb
+++ b/spec/ruby/core/io/shared/each.rb
@@ -54,12 +54,22 @@ describe :io_each, :shared => true do
       ScratchPad.recorded.should == [ 1,2,3,4,5,6,7,8,9 ]
     end
 
-    it "returns an Enumerator when passed no block" do
-      enum = @io.send(@method)
-      enum.should be_an_instance_of(enumerator_class)
+    describe "when no block is given" do
+      it "returns an Enumerator" do
+        enum = @io.send(@method)
+        enum.should be_an_instance_of(enumerator_class)
 
-      enum.each { |l| ScratchPad << l }
-      ScratchPad.recorded.should == IOSpecs.lines
+        enum.each { |l| ScratchPad << l }
+        ScratchPad.recorded.should == IOSpecs.lines
+      end
+
+      describe "returned Enumerator" do
+        describe "size" do
+          it "should return nil" do
+            @io.send(@method).size.should == nil
+          end
+        end
+      end
     end
   end
 

--- a/spec/ruby/core/kernel/loop_spec.rb
+++ b/spec/ruby/core/kernel/loop_spec.rb
@@ -59,4 +59,14 @@ describe "Kernel.loop" do
   it "does not rescue other errors" do
     lambda{ loop do raise StandardError end }.should raise_error( StandardError )
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "returns Float::INFINITY" do
+          loop.size.should == Float::INFINITY
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/numeric/step_spec.rb
+++ b/spec/ruby/core/numeric/step_spec.rb
@@ -312,4 +312,103 @@ describe "Numeric#step" do
   it "does not rescue TypeError exceptions" do
     lambda { 1.step(2) { raise TypeError, "" } }.should raise_error(TypeError)
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "raises an ArgumentError when step is 0" do
+          enum = 1.step(5, 0)
+          lambda { enum.size }.should raise_error(ArgumentError)
+        end
+
+        it "raises an ArgumentError when step is 0.0" do
+          enum = 1.step(2, 0.0)
+          lambda { enum.size }.should raise_error(ArgumentError)
+        end
+
+        describe "when self, stop and step are Fixnums and step is positive" do
+          it "returns the difference between self and stop divided by the number of steps" do
+            5.step(10, 11).size.should == 1
+            5.step(10, 6).size.should == 1
+            5.step(10, 5).size.should == 2
+            5.step(10, 4).size.should == 2
+            5.step(10, 2).size.should == 3
+            5.step(10, 1).size.should == 6
+            5.step(10).size.should == 6
+            10.step(10, 1).size.should == 1
+          end
+
+          it "returns 0 if value > limit" do
+            11.step(10, 1).size.should == 0
+          end
+        end
+
+        describe "when self, stop and step are Fixnums and step is negative" do
+          it "returns the difference between self and stop divided by the number of steps" do
+            10.step(5, -11).size.should == 1
+            10.step(5, -6).size.should == 1
+            10.step(5, -5).size.should == 2
+            10.step(5, -4).size.should == 2
+            10.step(5, -2).size.should == 3
+            10.step(5, -1).size.should == 6
+            10.step(10, -1).size.should == 1
+          end
+
+          it "returns 0 if value < limit" do
+            10.step(11, -1).size.should == 0
+          end
+        end
+
+        describe "when self, stop or step is a Float" do
+          describe "and step is positive" do
+            it "returns the difference between self and stop divided by the number of steps" do
+              5.step(10, 11.0).size.should == 1
+              5.step(10, 6.0).size.should == 1
+              5.step(10, 5.0).size.should == 2
+              5.step(10, 4.0).size.should == 2
+              5.step(10, 2.0).size.should == 3
+              5.step(10, 0.5).size.should == 11
+              5.step(10, 1.0).size.should == 6
+              5.step(10.5).size.should == 6
+              10.step(10, 1.0).size.should == 1
+            end
+
+            it "returns 0 if value > limit" do
+              10.step(5.5).size.should == 0
+              11.step(10, 1.0).size.should == 0
+              11.step(10, 1.5).size.should == 0
+              10.step(5, Float::INFINITY).size.should == 0
+            end
+
+            it "returns 1 if step is Float::INFINITY" do
+              5.step(10, Float::INFINITY).size.should == 1
+            end
+          end
+
+          describe "and step is negative" do
+            it "returns the difference between self and stop divided by the number of steps" do
+              10.step(5, -11.0).size.should == 1
+              10.step(5, -6.0).size.should == 1
+              10.step(5, -5.0).size.should == 2
+              10.step(5, -4.0).size.should == 2
+              10.step(5, -2.0).size.should == 3
+              10.step(5, -0.5).size.should == 11
+              10.step(5, -1.0).size.should == 6
+              10.step(10, -1.0).size.should == 1
+            end
+
+            it "returns 0 if value < limit" do
+              10.step(11, -1.0).size.should == 0
+              10.step(11, -1.5).size.should == 0
+              5.step(10, -Float::INFINITY).size.should == 0
+            end
+
+            it "returns 1 if step is Float::INFINITY" do
+              10.step(5, -Float::INFINITY).size.should == 1
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/numeric/step_spec.rb
+++ b/spec/ruby/core/numeric/step_spec.rb
@@ -94,11 +94,11 @@ describe "Numeric#step" do
       1.1.step(5.1, "foo").should be_an_instance_of(enumerator_class)
     end
 
-    it "raises a TypeError if given a block" do
-      lambda { 1.1.step(5.1, "1") {} }.should raise_error(TypeError)
-      lambda { 1.1.step(5.1, "0.1") {} }.should raise_error(TypeError)
-      lambda { 1.1.step(5.1, "1/3") {} }.should raise_error(TypeError)
-      lambda { 1.1.step(5.1, "foo") {} }.should raise_error(TypeError)
+    it "raises a ArgumentError if given a block" do
+      lambda { 1.1.step(5.1, "1") {} }.should raise_error(ArgumentError)
+      lambda { 1.1.step(5.1, "0.1") {} }.should raise_error(ArgumentError)
+      lambda { 1.1.step(5.1, "1/3") {} }.should raise_error(ArgumentError)
+      lambda { 1.1.step(5.1, "foo") {} }.should raise_error(ArgumentError)
     end
   end
 

--- a/spec/ruby/core/range/bsearch_spec.rb
+++ b/spec/ruby/core/range/bsearch_spec.rb
@@ -1,9 +1,12 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Range#bsearch" do
   it "returns an Enumerator when not passed a block" do
     (0..1).bsearch.should be_an_instance_of(enumerator_class)
   end
+
+  it_behaves_like :enumeratorized_with_unknown_size, :bsearch, (1..3)
 
   it "raises a TypeError if the block returns an Object" do
     lambda { (0..1).bsearch { Object.new } }.should raise_error(TypeError)

--- a/spec/ruby/core/range/each_spec.rb
+++ b/spec/ruby/core/range/each_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Range#each" do
   it "passes each element to the given block by using #succ" do
@@ -60,4 +61,6 @@ describe "Range#each" do
     (:aa..:ac).each.to_a.should == [:aa, :ab, :ac]
     (:aa...:ac).each.to_a.should == [:aa, :ab]
   end
+
+  it_behaves_like :enumeratorized_with_origin_size, :each, (1..3)
 end

--- a/spec/ruby/core/range/step_spec.rb
+++ b/spec/ruby/core/range/step_spec.rb
@@ -265,4 +265,87 @@ describe "Range#step" do
       end
     end
   end
+
+  describe "when no block is given" do
+    describe "returned Enumerator" do
+      describe "size" do
+        it "raises a TypeError if step does not respond to #to_int" do
+          obj = mock("Range#step non-integer")
+          enum = (1..2).step(obj)
+          lambda { enum.size }.should raise_error(TypeError)
+        end
+
+        it "raises a TypeError if #to_int does not return an Integer" do
+          obj = mock("Range#step non-integer")
+          obj.should_receive(:to_int).and_return("1")
+          enum = (1..2).step(obj)
+
+          lambda { enum.size }.should raise_error(TypeError)
+        end
+
+        it "raises an ArgumentError if step is 0" do
+          enum = (-1..1).step(0)
+          lambda { enum.size }.should raise_error(ArgumentError)
+        end
+
+        it "raises an ArgumentError if step is 0.0" do
+          enum = (-1..1).step(0.0)
+          lambda { enum.size }.should raise_error(ArgumentError)
+        end
+
+        it "raises an ArgumentError if step is negative" do
+          enum = (-1..1).step(-2)
+          lambda {  enum.size }.should raise_error(ArgumentError)
+        end
+
+        it "returns the ceil of range size divided by the number of steps" do
+          (1..10).step(4).size.should == 3
+          (1..10).step(3).size.should == 4
+          (1..10).step(2).size.should == 5
+          (1..10).step(1).size.should == 10
+          (-5..5).step(2).size.should == 6
+          (1...10).step(4).size.should == 3
+          (1...10).step(3).size.should == 3
+          (1...10).step(2).size.should == 5
+          (1...10).step(1).size.should == 9
+          (-5...5).step(2).size.should == 5
+        end
+
+        it "returns the correct number of steps when one of the arguments is a float" do
+          (-1..1.0).step(0.5).size.should == 5
+          (-1.0...1.0).step(0.5).size.should == 4
+        end
+
+        it "returns the range size when there's no step_size" do
+          (-2..2).step.size.should == 5
+          (-2.0..2.0).step.size.should == 5
+          (-2..2.0).step.size.should == 5
+          (-2.0..2).step.size.should == 5
+          (1.0..6.4).step(1.8).size.should == 4
+          (1.0..12.7).step(1.3).size.should == 10
+          (-2...2).step.size.should == 4
+          (-2.0...2.0).step.size.should == 4
+          (-2...2.0).step.size.should == 4
+          (-2.0...2).step.size.should == 4
+          (1.0...6.4).step(1.8).size.should == 3
+          (1.0...55.6).step(18.2).size.should == 3
+        end
+
+        it "returns nil with begin and end are String" do
+          ("A".."E").step(2).size.should == nil
+          ("A"..."E").step(2).size.should == nil
+          ("A".."E").step.size.should == nil
+          ("A"..."E").step.size.should == nil
+        end
+
+        it "return nil and not raises a TypeError if the first element does not respond to #succ" do
+          obj = mock("Range#step non-comparable")
+          obj.should_receive(:<=>).with(obj).and_return(1)
+          enum = (obj..obj).step
+          lambda { enum.size }.should_not raise_error
+          enum.size.should == nil
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/string/each_byte_spec.rb
+++ b/spec/ruby/core/string/each_byte_spec.rb
@@ -38,9 +38,27 @@ describe "String#each_byte" do
     (s.each_byte {}).should equal(s)
   end
 
-  it "returns an enumerator when no block given" do
-    enum = "hello".each_byte
-    enum.should be_an_instance_of(enumerator_class)
-    enum.to_a.should == [104, 101, 108, 108, 111]
+  describe "when no block is given" do
+    it "returns an enumerator" do
+      enum = "hello".each_byte
+      enum.should be_an_instance_of(enumerator_class)
+      enum.to_a.should == [104, 101, 108, 108, 111]
+    end
+
+    describe "returned enumerator" do
+      describe "size" do
+        it "should return the bytesize of the string" do
+          str = "hello"
+          str.each_byte.size.should == str.bytesize
+          str = "ola"
+          str.each_byte.size.should == str.bytesize
+          before = $KCODE
+          $KCODE = "UTF-8"
+          str = "\303\207\342\210\202\303\251\306\222g"
+          str.each_byte.size.should == str.bytesize
+          $KCODE = before
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/string/gsub_spec.rb
+++ b/spec/ruby/core/string/gsub_spec.rb
@@ -558,6 +558,22 @@ describe "String#gsub with pattern and block" do
   end
 end
 
+describe "String#gsub with pattern and without replacement and block" do
+  it "returns an enumerator" do
+    enum = "abca".gsub(/a/)
+    enum.should be_an_instance_of(enumerator_class)
+    enum.to_a.should == ["a", "a"]
+  end
+
+  describe "returned Enumerator" do
+    describe "size" do
+      it "should return nil" do
+        "abca".gsub(/a/).size.should == nil
+      end
+    end
+  end
+end
+
 describe "String#gsub! with pattern and replacement" do
   it "modifies self in place and returns self" do
     a = "hello"
@@ -655,5 +671,21 @@ describe "String#gsub! with pattern and block" do
 
   it "raises an ArgumentError if encoding is not valid" do
     lambda { "a\x92b".gsub!(/[^\x00-\x7f]/u, '') }.should raise_error(ArgumentError)
+  end
+end
+
+describe "String#gsub! with pattern and without replacement and block" do
+  it "returns an enumerator" do
+    enum = "abca".gsub!(/a/)
+    enum.should be_an_instance_of(enumerator_class)
+    enum.to_a.should == ["a", "a"]
+  end
+
+  describe "returned Enumerator" do
+    describe "size" do
+      it "should return nil" do
+        "abca".gsub!(/a/).size.should == nil
+      end
+    end
   end
 end

--- a/spec/ruby/core/string/shared/each_char_without_block.rb
+++ b/spec/ruby/core/string/shared/each_char_without_block.rb
@@ -3,9 +3,27 @@ require File.expand_path('../../../../spec_helper', __FILE__)
 require File.expand_path('../../fixtures/classes', __FILE__)
 
 describe :string_each_char_without_block, :shared => true do
-  it "returns an enumerator when no block given" do
-    enum = "hello".send(@method)
-    enum.should be_an_instance_of(enumerator_class)
-    enum.to_a.should == ['h', 'e', 'l', 'l', 'o']
+  describe "when no block is given" do
+    it "returns an enumerator" do
+      enum = "hello".send(@method)
+      enum.should be_an_instance_of(enumerator_class)
+      enum.to_a.should == ['h', 'e', 'l', 'l', 'o']
+    end
+
+    describe "returned enumerator" do
+      describe "size" do
+        it "should return the size of the string" do
+          str = "hello"
+          str.send(@method).size.should == str.size
+          str = "ola"
+          str.send(@method).size.should == str.size
+          before = $KCODE
+          $KCODE = "UTF-8"
+          str = "\303\207\342\210\202\303\251\306\222g"
+          str.send(@method).size.should == str.size
+          $KCODE = before
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/string/shared/each_codepoint_without_block.rb
+++ b/spec/ruby/core/string/shared/each_codepoint_without_block.rb
@@ -1,12 +1,36 @@
 
 describe :string_each_codepoint_without_block, :shared => true do
-  it "returns an Enumerator when no block is given" do
-    "".send(@method).should be_an_instance_of(enumerator_class)
-  end
+  describe "when no block is given" do
+    it "returns an Enumerator" do
+      "".send(@method).should be_an_instance_of(enumerator_class)
+    end
 
-  it "returns an Enumerator when no block is given even when self has an invalid encoding" do
-    s = "\xDF".force_encoding(Encoding::UTF_8)
-    s.valid_encoding?.should be_false
-    s.send(@method).should be_an_instance_of(enumerator_class)
+    it "returns an Enumerator even when self has an invalid encoding" do
+      s = "\xDF".force_encoding(Encoding::UTF_8)
+      s.valid_encoding?.should be_false
+      s.send(@method).should be_an_instance_of(enumerator_class)
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return the size of the string" do
+          str = "hello"
+          str.send(@method).size.should == str.size
+          str = "ola"
+          str.send(@method).size.should == str.size
+          before = $KCODE
+          $KCODE = "UTF-8"
+          str = "\303\207\342\210\202\303\251\306\222g"
+          str.send(@method).size.should == str.size
+          $KCODE = before
+        end
+
+        it "should return the size of the string even when the string has an invalid encoding" do
+          s = "\xDF".force_encoding(Encoding::UTF_8)
+          s.valid_encoding?.should be_false
+          s.send(@method).size.should == 1
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/string/shared/each_line_without_block.rb
+++ b/spec/ruby/core/string/shared/each_line_without_block.rb
@@ -1,7 +1,17 @@
 describe :string_each_line_without_block, :shared => true do
-  it "returns an enumerator when no block given" do
-    enum = "hello world".send(@method, ' ')
-    enum.should be_an_instance_of(enumerator_class)
-    enum.to_a.should == ["hello ", "world"]
+  describe "when no block is given" do
+    it "returns an enumerator" do
+      enum = "hello world".send(@method, ' ')
+      enum.should be_an_instance_of(enumerator_class)
+      enum.to_a.should == ["hello ", "world"]
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          "hello world".send(@method, ' ').size.should == nil
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/string/sub_spec.rb
+++ b/spec/ruby/core/string/sub_spec.rb
@@ -551,3 +551,15 @@ describe "String#sub! with pattern and Hash" do
     str.sub!(/a$/, 'a' => 'di'.taint).tainted?.should be_true
   end
 end
+
+describe "String#sub with pattern and without replacement and block" do
+  it "raises a ArgumentError" do
+    lambda { "abca".sub(/a/) }.should raise_error(ArgumentError)
+  end
+end
+
+describe "String#sub! with pattern and without replacement and block" do
+  it "raises a ArgumentError" do
+    lambda { "abca".sub!(/a/) }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/ruby/core/string/upto_spec.rb
+++ b/spec/ruby/core/string/upto_spec.rb
@@ -62,12 +62,6 @@ describe "String#upto" do
     lambda { "a".upto(:c).to_a }.should raise_error(TypeError)
   end
 
-  it "returns an enumerator when no block given" do
-    enum = "aaa".upto("baa", true)
-    enum.should be_an_instance_of(enumerator_class)
-    enum.count.should == 26**2
-  end
-
   it "returns non-alphabetic characters in the ASCII range for single letters" do
     "9".upto("A").to_a.should == ["9", ":", ";", "<", "=", ">", "?", "@", "A"]
     "Z".upto("a").to_a.should == ["Z", "[", "\\", "]", "^", "_", "`", "a"]
@@ -83,6 +77,22 @@ describe "String#upto" do
   describe "on sequence of numbers" do
     it "calls the block as Integer#upto"  do
       "8".upto("11").to_a.should == 8.upto(11).map(&:to_s)
+    end
+  end
+
+  describe "when no block is given" do
+    it "returns an enumerator" do
+      enum = "aaa".upto("baa", true)
+      enum.should be_an_instance_of(enumerator_class)
+      enum.count.should == 26**2
+    end
+
+    describe "returned Enumerator" do
+      describe "size" do
+        it "should return nil" do
+          "a".upto("b").size.should == nil
+        end
+      end
     end
   end
 end

--- a/spec/ruby/core/struct/each_pair_spec.rb
+++ b/spec/ruby/core/struct/each_pair_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/accessor', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Struct#each_pair" do
   it "passes each key value pair to the given block" do
@@ -21,4 +22,5 @@ describe "Struct#each_pair" do
   end
 
   it_behaves_like :struct_accessor, :each_pair
+  it_behaves_like :enumeratorized_with_origin_size, :each_pair, StructClasses::Car.new('Ford', 'Ranger')
 end

--- a/spec/ruby/core/struct/each_spec.rb
+++ b/spec/ruby/core/struct/each_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/accessor', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Struct#each" do
   it "passes each value to the given block" do
@@ -22,4 +23,5 @@ describe "Struct#each" do
   end
 
   it_behaves_like :struct_accessor, :each
+  it_behaves_like :enumeratorized_with_origin_size, :each, StructClasses::Car.new('Ford', 'Ranger')
 end

--- a/spec/ruby/core/struct/select_spec.rb
+++ b/spec/ruby/core/struct/select_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 require File.expand_path('../shared/accessor', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
 
 describe "Struct#select" do
   it "raises an ArgumentError if given any non-block arguments" do
@@ -25,4 +26,5 @@ describe "Struct#select" do
   end
 
   it_behaves_like :struct_accessor, :select
+  it_behaves_like :enumeratorized_with_origin_size, :select, Struct.new(:foo).new
 end

--- a/spec/tags/ruby/core/array/cycle_tags.txt
+++ b/spec/tags/ruby/core/array/cycle_tags.txt
@@ -1,2 +1,0 @@
-fails:Array#cycle returns Float::INFINITY as size when passed no argument and no block is given
-fails:Array#cycle returns the correct size when passed a number n as argument and no block is given

--- a/spec/tags/ruby/core/array/delete_if_tags.txt
+++ b/spec/tags/ruby/core/array/delete_if_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#delete_if returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/each_index_tags.txt
+++ b/spec/tags/ruby/core/array/each_index_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#each_index returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/each_tags.txt
+++ b/spec/tags/ruby/core/array/each_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#each returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/keep_if_tags.txt
+++ b/spec/tags/ruby/core/array/keep_if_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#keep_if returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/reject_tags.txt
+++ b/spec/tags/ruby/core/array/reject_tags.txt
@@ -1,2 +1,0 @@
-fails:Array#reject returns the correct size when no block is given
-fails:Array#reject! returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/reverse_each_tags.txt
+++ b/spec/tags/ruby/core/array/reverse_each_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#reverse_each returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/select_tags.txt
+++ b/spec/tags/ruby/core/array/select_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#select! returns the correct size when no block is given

--- a/spec/tags/ruby/core/array/sort_by_tags.txt
+++ b/spec/tags/ruby/core/array/sort_by_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#sort_by! returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/collect_concat_tags.txt
+++ b/spec/tags/ruby/core/enumerable/collect_concat_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#collect_concat returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/collect_tags.txt
+++ b/spec/tags/ruby/core/enumerable/collect_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#collect returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/detect_tags.txt
+++ b/spec/tags/ruby/core/enumerable/detect_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#detect returns the nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/drop_while_tags.txt
+++ b/spec/tags/ruby/core/enumerable/drop_while_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#drop_while returns nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/each_cons_tags.txt
+++ b/spec/tags/ruby/core/enumerable/each_cons_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#each_cons returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/each_with_index_tags.txt
+++ b/spec/tags/ruby/core/enumerable/each_with_index_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#each_with_index returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/each_with_object_tags.txt
+++ b/spec/tags/ruby/core/enumerable/each_with_object_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#each_with_object returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/find_all_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_all_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#find_all returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/find_index_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_index_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#find_index without block returns nil as size

--- a/spec/tags/ruby/core/enumerable/find_tags.txt
+++ b/spec/tags/ruby/core/enumerable/find_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#find returns the nil as size when no block is given

--- a/spec/tags/ruby/core/enumerable/flat_map_tags.txt
+++ b/spec/tags/ruby/core/enumerable/flat_map_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#flat_map returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/group_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/group_by_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#group_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/map_tags.txt
+++ b/spec/tags/ruby/core/enumerable/map_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#map returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/max_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/max_by_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#max_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/min_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/min_by_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#min_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/minmax_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/minmax_by_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#minmax_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/partition_tags.txt
+++ b/spec/tags/ruby/core/enumerable/partition_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#partition returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/reject_tags.txt
+++ b/spec/tags/ruby/core/enumerable/reject_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#reject returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/select_tags.txt
+++ b/spec/tags/ruby/core/enumerable/select_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#select returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/sort_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/sort_by_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#sort_by returns the correct size when no block is given

--- a/spec/tags/ruby/core/enumerable/take_while_tags.txt
+++ b/spec/tags/ruby/core/enumerable/take_while_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerable#take_while returns nil as size when no block is given


### PR DESCRIPTION
Hi,

This is an attempt to fix the Enumerator#size method issues identified previously [here](https://github.com/rubinius/rubinius/issues/3306) and [here](https://github.com/rubinius/rubinius/pull/3318). It's still a work in progress but I opened this pull request to check with you guys if I'm on the right track and also get some guidance.

I took a look at the JRuby implementation and what they do is pass the a 'calculated' size to the enumerator. Usually the size is enough (each, reverse_each, etc...), but there are some methods that need some math, like the cycle, each_cons and each_slice.

To start I've implemented a to_enum_with_size private method on the Enumerable module to use on these methods to create the an enum with the size calculation. Doing it here allow it to be used on Array and other classes that mix in the Enumerable module. Nevertheless, my question here is if it's the right place to do it.

Another thing I would like to point out is the each_cons and each_slice size spec. The size calculation is a little bit more complex that the cycle. The spec is only testing some value combinations, but I think it could be better. Do you guys have a better way to implement it?

When I was at it, I saw that both each_cons and each_slice raise an exception when called without a block. I added the calls to the spec that tests that the exception is raised and fixed it.

Like I said, this is still a work in progress. Enumerable seems to be fixed with these changes, but Array and other aren't. I already started with Array. With time, and if you are all ok with these changes, I'll continue to add them to this pull request.

Thank you