### PR TITLE
Updating the error message to be equal to the error in ruby variable.c

### DIFF
--- a/vm/capi/class.cpp
+++ b/vm/capi/class.cpp
@@ -105,7 +105,7 @@ extern "C" {
 
       if(reason != vFound) {
         free(pathd);
-        rb_raise(rb_eArgError, "undefined class or module %s", path);
+        rb_raise(rb_eArgError, "undefined class/module %s", path);
       }
 
       if(Autoload* autoload = try_as<Autoload>(val)) {


### PR DESCRIPTION
for compatibility

This causes one error in this build:
https://travis-ci.org/tenderlove/psych/jobs/50729645

Differs from:
https://github.com/ruby/ruby/blob/4194ca02fb2899ce00e6284953d1fd4ee8bdbf38/variable.c

Failing test:
https://github.com/ruby/ruby/blob/eeb05e8c119f8cab6434d90f21551b6bb2954778/test/psych/test_psych.rb