### PR TITLE
Add Method#curry specs

### DIFF
--- a/spec/ruby/core/method/curry_spec.rb
+++ b/spec/ruby/core/method/curry_spec.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+describe "Method#curry" do
+
+  it "returns a curried proc" do
+    x = Object.new
+    def x.foo(a,b,c); [a,b,c]; end
+
+    c = x.method(:foo).curry
+    c.should be_kind_of(Proc)
+    c.(1).(2, 3).should == [1,2,3]
+  end
+
+  describe "with optional arity argument" do
+    before(:each) do
+      @obj = MethodSpecs::Methods.new
+    end
+
+    it "returns a curried proc when given correct arity" do
+      @obj.method(:one_req).curry(1).should be_kind_of(Proc)
+      @obj.method(:zero_with_splat).curry(100).should be_kind_of(Proc)
+      @obj.method(:two_req_with_splat).curry(2).should be_kind_of(Proc)
+    end
+
+    it "raises ArgumentError when the method requires less arguments than the given arity" do
+      lambda { @obj.method(:zero).curry(1) }.should raise_error(ArgumentError)
+      lambda { @obj.method(:one_req_one_opt).curry(3) }.should raise_error(ArgumentError)
+      lambda { @obj.method(:two_req_one_opt_with_block).curry(4) }.should raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError when the method requires more arguments than the given arity" do
+      lambda { @obj.method(:two_req_with_splat).curry(1) }.should raise_error(ArgumentError)
+      lambda { @obj.method(:one_req).curry(0) }.should raise_error(ArgumentError)
+    end
+  end
+
+end

--- a/spec/tags/ruby/core/method/curry_tags.txt
+++ b/spec/tags/ruby/core/method/curry_tags.txt
@@ -1,0 +1,4 @@
+fails:Method#curry returns a curried proc
+fails:Method#curry with optional arity argument returns a curried proc when given correct arity
+fails:Method#curry with optional arity argument raises ArgumentError when the method requires less arguments than the given arity
+fails:Method#curry with optional arity argument raises ArgumentError when the method requires more arguments than the given arity


### PR DESCRIPTION
This PR adds specs for Method#curry released in Ruby 2.2.

If there's anything wrong with the PR please let me know.