### PR TITLE
Fix Mirror.subject= assignments.

### DIFF
--- a/kernel/bootstrap/array_mirror.rb
+++ b/kernel/bootstrap/array_mirror.rb
@@ -1,7 +1,7 @@
 module Rubinius
   class Mirror
     class Array < Mirror
-      subject = ::Array
+      self.subject = ::Array
 
       def self.reflect(object)
         m = super(object)

--- a/kernel/bootstrap/mirror.rb
+++ b/kernel/bootstrap/mirror.rb
@@ -20,7 +20,7 @@ module Rubinius
     end
 
     class Object < Mirror
-      subject = ::Object
+      self.subject = ::Object
     end
 
     def inspect

--- a/kernel/common/string_mirror.rb
+++ b/kernel/common/string_mirror.rb
@@ -1,7 +1,7 @@
 module Rubinius
   class Mirror
     class String < Mirror
-      subject = ::String
+      self.subject = ::String
 
       def character_to_byte_index(idx, start=0)
         Rubinius.invoke_primitive :string_character_byte_index, @object, idx, start


### PR DESCRIPTION
This fixes a common Ruby gotcha.

Besides `Mirror.subject` is not used anywhere, should we remove it?

PS: additionally, would a patch like this get accepted?
```diff
--- a/kernel/bootstrap/mirror.rb
+++ b/kernel/bootstrap/mirror.rb
@@ -1,11 +1,7 @@
 module Rubinius
   class Mirror
-    def self.subject=(klass)
-      @subject = klass
-    end
-
-    def self.subject
-      @subject
+    class << self
+      attr_accessor :subject
     end
 
     def self.reflect(obj)
```