### PR TITLE
Implement Enumerable#slice_after

### DIFF
--- a/kernel/common/enumerable.rb
+++ b/kernel/common/enumerable.rb
@@ -160,6 +160,31 @@ module Enumerable
     end
   end
 
+  def slice_after(pattern = undefined, &block)
+    pattern_given = !undefined.equal?(pattern)
+
+    raise ArgumentError, "cannot pass both pattern and block" if pattern_given && block_given?
+    raise ArgumentError, "wrong number of arguments (0 for 1)" if !pattern_given && !block_given?
+
+    block = Proc.new { |elem| pattern === elem } if pattern_given
+
+    Enumerator.new do |yielder|
+      accumulator = nil
+      each do |elem|
+        end_chunk = block.yield(elem)
+        accumulator ||= []
+        if end_chunk
+          accumulator << elem
+          yielder.yield accumulator
+          accumulator = nil
+        else
+          accumulator << elem
+        end
+      end
+      yielder.yield accumulator if accumulator
+    end
+  end
+
   def to_a(*arg)
     ary = []
     each(*arg) do


### PR DESCRIPTION
Now that we have the specs for Enumerable#slice_after, we can implement it!

I hope I didn't confuse anyone with the crazy case when usage. Correct me if I am wrong, but I think it's more readable than a bunch of `if`s and `nil?`s.