### PR TITLE
Implement Binding#local_variables and Binding#receiver

### DIFF
--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -3,8 +3,16 @@ class Binding
   attr_accessor :compiled_code
   attr_accessor :constant_scope
   attr_accessor :proc_environment
-  attr_accessor :self
   attr_accessor :location
+  attr_reader   :receiver
+
+  def self=(obj)
+    @receiver = obj
+  end
+
+  def self
+    @receiver
+  end
 
   def from_proc?
     @proc_environment
@@ -53,5 +61,9 @@ class Binding
     lineno ||= filename ? 1 : line_number
 
     Kernel.eval(expr, self, filename, lineno)
+  end
+
+  def local_variables
+    variables.local_variables
   end
 end

--- a/kernel/common/eval.rb
+++ b/kernel/common/eval.rb
@@ -107,28 +107,8 @@ module Kernel
   # Names of local variables at point of call (including evaled)
   #
   def local_variables
-    locals = []
-
     scope = Rubinius::VariableScope.of_sender
-
-    # Ascend up through all applicable blocks to get all vars.
-    while scope
-      if scope.method.local_names
-        scope.method.local_names.each do |name|
-          locals << name
-        end
-      end
-
-      if dyn = scope.dynamic_locals
-        dyn.keys.each do |name|
-          locals << name unless locals.include?(name)
-        end
-      end
-
-      scope = scope.parent
-    end
-
-    locals
+    scope.local_variables
   end
   module_function :local_variables
 

--- a/kernel/common/variable_scope.rb
+++ b/kernel/common/variable_scope.rb
@@ -101,6 +101,32 @@ module Rubinius
       out
     end
 
+    # Returns the names of local variables available in this scope
+    #
+    def local_variables
+      locals = []
+      scope = self
+
+      # Ascend up through all applicable blocks to get all vars.
+      while scope
+        if scope.method.local_names
+          scope.method.local_names.each do |name|
+            locals << name
+          end
+        end
+
+        if dyn = scope.dynamic_locals
+          dyn.keys.each do |name|
+            locals << name unless locals.include?(name)
+          end
+        end
+
+        scope = scope.parent
+      end
+
+      locals
+    end
+
     def exitted?
       @exitted
     end

--- a/spec/tags/ruby/core/binding/local_variables_tags.txt
+++ b/spec/tags/ruby/core/binding/local_variables_tags.txt
@@ -1,5 +1,0 @@
-fails:Binding#local_variables returns an Array
-fails:Binding#local_variables includes local variables in the current scope
-fails:Binding#local_variables includes local variables defined after calling binding.local_variables
-fails:Binding#local_variables includes local variables of inherited scopes and eval'ed context
-fails:Binding#local_variables includes shadowed local variables only once

--- a/spec/tags/ruby/core/binding/receiver_tags.txt
+++ b/spec/tags/ruby/core/binding/receiver_tags.txt
@@ -1,1 +1,0 @@
-fails:Binding#receiver returns the object to which binding is bound


### PR DESCRIPTION
This is a follow-up of #3352.

In summary:
* ```Binding#receiver```: I took @jemc's advice and renamed the ```@self``` ivar to ```@receiver```. To avoid breaking other code, ```self```is kept as a virtual attribute.
* ```Binding#local_variables```: Created the ```local_variables```method in ```Rubinius::VariableScope```, which is used both in ```Kernel.local_variables``` and ```Binding#local_variables```.

Comments and feedback welcome. Thanks for your time :smile: