### PR TITLE
Allow shared linking to LLVM 3.5

### DIFF
--- a/configure
+++ b/configure
@@ -563,15 +563,6 @@ class Configure
       return false
     end
 
-    if setup_config
-      check_llvm_flags
-      return true
-    end
-
-    failure "ABORT: unable to set up LLVM"
-  end
-
-  def setup_config
     @log.print "  Checking for 'llvm-config': "
 
     config = @llvm_configure
@@ -602,36 +593,38 @@ class Configure
         # Ruby 1.9 raises this error
         failed = true
       end
-      if failed
-        @log.write "Executing #{config_cmd.inspect} failed"
-        return false
-      end
 
-      parts = version.sub(/svn$/, "").split(".").map { |i| i.to_i }
-      api_version = ("%d%02d" % parts[0..1]).to_i
-      if api_version < 300 or api_version > 305
-        @log.write "only LLVM 3.0-3.5 is supported"
-      else
-        @log.write "found! (version #{version} - api: #{api_version})"
-        @llvm = :config
-        @llvm_configure = config_cmd
-        @llvm_version = version
-        @llvm_api_version = api_version
+      unless failed
+        parts = version.sub(/svn$/, "").split(".").map { |i| i.to_i }
+        api_version = ("%d%02d" % parts[0..1]).to_i
+        if api_version < 300 or api_version > 305
+          @log.write "only LLVM 3.0-3.5 is supported"
+        else
+          @log.write "found! (version #{version} - api: #{api_version})"
+          @llvm = :config
+          @llvm_configure = config_cmd
+          @llvm_version = version
+          @llvm_api_version = api_version
 
-        if @llvm_shared
-          setup_config_shared
+          check_llvm_flags
+
+          if @llvm_shared
+            setup_llvm_shared
+          end
+
+          return true
         end
-
-        return true
+      else
+        @log.write "executing #{config_cmd.inspect} failed"
       end
     else
       @log.write "not found"
     end
 
-    false
+    failure "ABORT: unable to set up LLVM"
   end
 
-  def setup_config_shared
+  def setup_llvm_shared
     @log.print "  Checking for LLVM shared libs: "
 
     src = <<-EOP
@@ -640,7 +633,7 @@ using namespace llvm;
 int main() { LLVMContext &Context = getGlobalContext(); }
     EOP
 
-    common_args = `#{@llvm_configure} --cppflags --ldflags`.strip.split(/\s+/)
+    common_args = "`#{@llvm_configure} --cppflags` #{@llvm_cxxflags} #{@llvm_ldflags}".strip.split(/\s+/)
     shared_configs = {
       "libLLVM-#{@llvm_version}"  => ["-lLLVM-#{@llvm_version}"],
       "#{@llvm_configure} --libs" => `#{@llvm_configure} --libs`.strip.split(/\s+/)


### PR DESCRIPTION
Run check_llvm_flags before checking for shared libs and use the
calculated flags there.