### PR TITLE
Fix edge case in the argument handling of Proc#curry for 0-ary lambdas

### DIFF
--- a/kernel/common/proc.rb
+++ b/kernel/common/proc.rb
@@ -77,7 +77,7 @@ class Proc
 
   def curry(curried_arity = nil)
     if lambda? && curried_arity
-      if arity > 0 && curried_arity != arity
+      if arity >= 0 && curried_arity != arity
         raise ArgumentError, "Wrong number of arguments (%i for %i)" % [
           curried_arity,
           arity

--- a/spec/ruby/core/proc/curry_spec.rb
+++ b/spec/ruby/core/proc/curry_spec.rb
@@ -113,6 +113,7 @@ describe "Proc#curry with arity argument" do
 
   it "raises an ArgumentError if called on a lambda that requires fewer than _arity_ arguments" do
     lambda { @lambda_add.curry(4) }.should raise_error(ArgumentError)
+    lambda { lambda { true }.curry(1) }.should raise_error(ArgumentError)
   end
 
   it "calls the curried proc with the arguments if _arity_ arguments have been given" do


### PR DESCRIPTION
Hi everyone, this PR fixes an edge case in the `curried_arity` argument check in Proc#curry for 0-ary lambdas.