### PR TITLE
Add 2.2 language specs

### DIFF
--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -54,12 +54,4 @@ class Binding
 
     Kernel.eval(expr, self, filename, lineno)
   end
-
-  def local_variables
-    eval('local_variables')
-  end
-
-  def receiver
-    @self
-  end
 end

--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -54,4 +54,12 @@ class Binding
 
     Kernel.eval(expr, self, filename, lineno)
   end
+
+  def local_variables
+    eval('local_variables')
+  end
+
+  def receiver
+    @self
+  end
 end

--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -3,8 +3,16 @@ class Binding
   attr_accessor :compiled_code
   attr_accessor :constant_scope
   attr_accessor :proc_environment
-  attr_accessor :self
   attr_accessor :location
+  attr_reader   :receiver
+
+  def self=(obj)
+    @receiver = obj
+  end
+
+  def self
+    @receiver
+  end
 
   def from_proc?
     @proc_environment
@@ -53,5 +61,9 @@ class Binding
     lineno ||= filename ? 1 : line_number
 
     Kernel.eval(expr, self, filename, lineno)
+  end
+
+  def local_variables
+    variables.local_variables
   end
 end

--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -4,15 +4,7 @@ class Binding
   attr_accessor :constant_scope
   attr_accessor :proc_environment
   attr_accessor :location
-  attr_reader   :receiver
-
-  def self=(obj)
-    @receiver = obj
-  end
-
-  def self
-    @receiver
-  end
+  attr_accessor :receiver
 
   def from_proc?
     @proc_environment
@@ -37,7 +29,7 @@ class Binding
   def self.setup(variables, code, constant_scope, recv=nil, location=nil)
     bind = allocate()
 
-    bind.self = self_context(recv, variables)
+    bind.receiver = self_context(recv, variables)
     bind.variables = variables
     bind.compiled_code = code
     bind.constant_scope = constant_scope

--- a/kernel/common/enumerable.rb
+++ b/kernel/common/enumerable.rb
@@ -160,6 +160,31 @@ module Enumerable
     end
   end
 
+  def slice_after(pattern = undefined, &block)
+    pattern_given = !undefined.equal?(pattern)
+
+    raise ArgumentError, "cannot pass both pattern and block" if pattern_given && block_given?
+    raise ArgumentError, "wrong number of arguments (0 for 1)" if !pattern_given && !block_given?
+
+    block = Proc.new { |elem| pattern === elem } if pattern_given
+
+    Enumerator.new do |yielder|
+      accumulator = nil
+      each do |elem|
+        end_chunk = block.yield(elem)
+        accumulator ||= []
+        if end_chunk
+          accumulator << elem
+          yielder.yield accumulator
+          accumulator = nil
+        else
+          accumulator << elem
+        end
+      end
+      yielder.yield accumulator if accumulator
+    end
+  end
+
   def to_a(*arg)
     ary = []
     each(*arg) do

--- a/kernel/common/eval.rb
+++ b/kernel/common/eval.rb
@@ -107,28 +107,8 @@ module Kernel
   # Names of local variables at point of call (including evaled)
   #
   def local_variables
-    locals = []
-
     scope = Rubinius::VariableScope.of_sender
-
-    # Ascend up through all applicable blocks to get all vars.
-    while scope
-      if scope.method.local_names
-        scope.method.local_names.each do |name|
-          locals << name
-        end
-      end
-
-      if dyn = scope.dynamic_locals
-        dyn.keys.each do |name|
-          locals << name unless locals.include?(name)
-        end
-      end
-
-      scope = scope.parent
-    end
-
-    locals
+    scope.local_variables
   end
   module_function :local_variables
 

--- a/kernel/common/eval.rb
+++ b/kernel/common/eval.rb
@@ -153,7 +153,7 @@ module Kernel
     c = Rubinius::ToolSets::Runtime::Compiler
     be = c.construct_block string, binding, filename, lineno
 
-    result = be.call_on_instance(binding.self)
+    result = be.call_on_instance(binding.receiver)
     binding.constant_scope = existing_scope
     result
   end

--- a/kernel/common/variable_scope.rb
+++ b/kernel/common/variable_scope.rb
@@ -101,6 +101,32 @@ module Rubinius
       out
     end
 
+    # Returns the names of local variables available in this scope
+    #
+    def local_variables
+      locals = []
+      scope = self
+
+      # Ascend up through all applicable blocks to get all vars.
+      while scope
+        if scope.method.local_names
+          scope.method.local_names.each do |name|
+            locals << name
+          end
+        end
+
+        if dyn = scope.dynamic_locals
+          dyn.keys.each do |name|
+            locals << name unless locals.include?(name)
+          end
+        end
+
+        scope = scope.parent
+      end
+
+      locals
+    end
+
     def exitted?
       @exitted
     end

--- a/spec/ruby/core/binding/local_variables_spec.rb
+++ b/spec/ruby/core/binding/local_variables_spec.rb
@@ -1,0 +1,29 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "Binding#local_variables" do
+  it "returns an Array" do
+    binding.local_variables.should be_kind_of(Array)
+  end
+
+  it "includes local variables in the current scope" do
+    a = 1
+    b = nil
+    binding.local_variables.should == [:a, :b]
+  end
+
+  it "includes local variables defined after calling binding.local_variables" do
+    binding.local_variables.should == [:a, :b]
+    a = 1
+    b = 2
+  end
+
+  it "includes local variables of inherited scopes and eval'ed context" do
+    p = proc { |a| b = 1; eval("c = 2; binding.local_variables") }
+    p.call.should == [:c, :a, :b, :p]
+  end
+
+  it "includes shadowed local variables only once" do
+    a = 1
+    proc { a = 2; binding.local_variables }.call.should == [:a]
+  end
+end

--- a/spec/ruby/core/binding/receiver_spec.rb
+++ b/spec/ruby/core/binding/receiver_spec.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+describe "Binding#receiver" do
+  it "returns the object to which binding is bound" do
+    obj = BindingSpecs::Demo.new(1)
+    obj.get_binding.receiver.should == obj
+
+    binding.receiver.should == self
+  end
+end

--- a/spec/ruby/core/enumerable/each_cons_spec.rb
+++ b/spec/ruby/core/enumerable/each_cons_spec.rb
@@ -14,7 +14,7 @@ describe "Enumerable#each_cons" do
     acc.should == @in_threes
   end
 
-  it "raises an Argument Error if there is not a single parameter > 0" do
+  it "raises an ArgumentError if there is not a single parameter > 0" do
     lambda{ @enum.each_cons(0){}    }.should raise_error(ArgumentError)
     lambda{ @enum.each_cons(-2){}   }.should raise_error(ArgumentError)
     lambda{ @enum.each_cons{}       }.should raise_error(ArgumentError)

--- a/spec/ruby/core/enumerable/each_entry_spec.rb
+++ b/spec/ruby/core/enumerable/each_entry_spec.rb
@@ -26,7 +26,7 @@ describe "Enumerable#each_entry" do
     ScratchPad.recorded.should == [[:a, 0], [:b, 1]]
   end
 
-  it "raises an Argument error when extra arguments" do
+  it "raises an ArgumentError when extra arguments" do
     lambda { @enum.each_entry("one").to_a   }.should raise_error(ArgumentError)
     lambda { @enum.each_entry("one"){}.to_a }.should raise_error(ArgumentError)
   end

--- a/spec/ruby/core/enumerable/each_slice_spec.rb
+++ b/spec/ruby/core/enumerable/each_slice_spec.rb
@@ -14,7 +14,7 @@ describe "Enumerable#each_slice" do
     acc.should == @sliced
   end
 
-  it "raises an Argument Error if there is not a single parameter > 0" do
+  it "raises an ArgumentError if there is not a single parameter > 0" do
     lambda{ @enum.each_slice(0){}    }.should raise_error(ArgumentError)
     lambda{ @enum.each_slice(-2){}   }.should raise_error(ArgumentError)
     lambda{ @enum.each_slice{}       }.should raise_error(ArgumentError)

--- a/spec/ruby/core/enumerable/max_by_spec.rb
+++ b/spec/ruby/core/enumerable/max_by_spec.rb
@@ -40,4 +40,36 @@ describe "Enumerable#max_by" do
   end
 
   it_behaves_like :enumerable_enumeratorized_with_origin_size, :max_by
+
+  context "when called with an argument n" do
+    before :each do
+      @enum = EnumerableSpecs::Numerous.new(101, 55, 1, 20, 33, 500, 60)
+    end
+
+    context "without a block" do
+      it "returns an enumerator" do
+        @enum.max_by(2).should be_an_instance_of(enumerator_class)
+      end
+    end
+
+    context "with a block" do
+      it "returns an array containing the maximum n elements based on the block's value" do
+        result = @enum.max_by(3) { |i| i.to_s }
+        result.should == [60, 55, 500]
+      end
+
+      context "on a enumerable of length x where x < n" do
+        it "returns an array containing the maximum n elements of length n" do
+          result = @enum.max_by(500) { |i| i.to_s }
+          result.length.should == 7
+        end
+      end
+
+      context "when n is negative" do
+        it "raises an ArgumentError" do
+          lambda { @enum.max_by(-1) { |i| i.to_s } }.should raise_error(ArgumentError)
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/enumerable/max_spec.rb
+++ b/spec/ruby/core/enumerable/max_spec.rb
@@ -68,7 +68,7 @@ describe "Enumerable#max" do
     end
   end
 
-  it "returns the minimum for enumerables that contain nils" do
+  it "returns the maximum for enumerables that contain nils" do
     arr = EnumerableSpecs::Numerous.new(nil, nil, true)
     arr.max { |a, b|
       x = a.nil? ? 1 : a ? 0 : -1

--- a/spec/ruby/core/enumerable/max_spec.rb
+++ b/spec/ruby/core/enumerable/max_spec.rb
@@ -3,8 +3,6 @@ require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Enumerable#max" do
   before :each do
-    @a = EnumerableSpecs::EachDefiner.new( 2, 4, 6, 8, 10 )
-
     @e_strs = EnumerableSpecs::EachDefiner.new("333", "22", "666666", "1", "55555", "1010101010")
     @e_ints = EnumerableSpecs::EachDefiner.new( 333,   22,   666666,   55555, 1010101010)
   end

--- a/spec/ruby/core/enumerable/max_spec.rb
+++ b/spec/ruby/core/enumerable/max_spec.rb
@@ -82,4 +82,32 @@ describe "Enumerable#max" do
     multi.max.should == [6, 7, 8, 9]
   end
 
+  context "when called with an argument n" do
+    context "without a block" do
+      it "returns an array containing the maximum n elements" do
+        result = @e_ints.max(2)
+        result.should == [1010101010, 666666]
+      end
+    end
+
+    context "with a block" do
+      it "returns an array containing the maximum n elements" do
+        result = @e_ints.max(2) { |a, b| a * 2 <=> b * 2 }
+        result.should == [1010101010, 666666]
+      end
+    end
+
+    context "on a enumerable of length x where x < n" do
+      it "returns an array containing the maximum n elements of length x" do
+        result = @e_ints.max(500)
+        result.length.should == 5
+      end
+    end
+
+    context "that is negative" do
+      it "raises an Argument error" do
+        lambda { @e_ints.max(-1) }.should raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/spec/ruby/core/enumerable/max_spec.rb
+++ b/spec/ruby/core/enumerable/max_spec.rb
@@ -7,7 +7,7 @@ describe "Enumerable#max" do
     @e_ints = EnumerableSpecs::EachDefiner.new( 333,   22,   666666,   55555, 1010101010)
   end
 
-  it "max should return the maximum element" do
+  it "returns the maximum element" do
     EnumerableSpecs::Numerous.new.max.should == 6
   end
 

--- a/spec/ruby/core/enumerable/max_spec.rb
+++ b/spec/ruby/core/enumerable/max_spec.rb
@@ -105,7 +105,7 @@ describe "Enumerable#max" do
     end
 
     context "that is negative" do
-      it "raises an Argument error" do
+      it "raises an ArgumentError" do
         lambda { @e_ints.max(-1) }.should raise_error(ArgumentError)
       end
     end

--- a/spec/ruby/core/enumerable/max_spec.rb
+++ b/spec/ruby/core/enumerable/max_spec.rb
@@ -52,21 +52,22 @@ describe "Enumerable#max" do
     end.should raise_error(ArgumentError)
   end
 
-  it "returns the maximum element (with block" do
-    # with a block
-    EnumerableSpecs::EachDefiner.new("2","33","4","11").max {|a,b| a <=> b }.should == "4"
-    EnumerableSpecs::EachDefiner.new( 2 , 33 , 4 , 11 ).max {|a,b| a <=> b }.should == 33
+  context "when passed a block" do
+    it "returns the maximum element" do
+      EnumerableSpecs::EachDefiner.new("2","33","4","11").max {|a,b| a <=> b }.should == "4"
+      EnumerableSpecs::EachDefiner.new( 2 , 33 , 4 , 11 ).max {|a,b| a <=> b }.should == 33
 
-    EnumerableSpecs::EachDefiner.new("2","33","4","11").max {|a,b| b <=> a }.should == "11"
-    EnumerableSpecs::EachDefiner.new( 2 , 33 , 4 , 11 ).max {|a,b| b <=> a }.should == 2
+      EnumerableSpecs::EachDefiner.new("2","33","4","11").max {|a,b| b <=> a }.should == "11"
+      EnumerableSpecs::EachDefiner.new( 2 , 33 , 4 , 11 ).max {|a,b| b <=> a }.should == 2
 
-    @e_strs.max {|a,b| a.length <=> b.length }.should == "1010101010"
+      @e_strs.max {|a,b| a.length <=> b.length }.should == "1010101010"
 
-    @e_strs.max {|a,b| a <=> b }.should == "666666"
-    @e_strs.max {|a,b| a.to_i <=> b.to_i }.should == "1010101010"
+      @e_strs.max {|a,b| a <=> b }.should == "666666"
+      @e_strs.max {|a,b| a.to_i <=> b.to_i }.should == "1010101010"
 
-    @e_ints.max {|a,b| a <=> b }.should == 1010101010
-    @e_ints.max {|a,b| a.to_s <=> b.to_s }.should == 666666
+      @e_ints.max {|a,b| a <=> b }.should == 1010101010
+      @e_ints.max {|a,b| a.to_s <=> b.to_s }.should == 666666
+    end
   end
 
   it "returns the minimum for enumerables that contain nils" do

--- a/spec/ruby/core/enumerable/min_by_spec.rb
+++ b/spec/ruby/core/enumerable/min_by_spec.rb
@@ -40,4 +40,36 @@ describe "Enumerable#min_by" do
   end
 
   it_behaves_like :enumerable_enumeratorized_with_origin_size, :min_by
+
+  context "when called with an argument n" do
+    before :each do
+      @enum = EnumerableSpecs::Numerous.new(101, 55, 1, 20, 33, 500, 60)
+    end
+
+    context "without a block" do
+      it "returns an enumerator" do
+        @enum.min_by(2).should be_an_instance_of(enumerator_class)
+      end
+    end
+
+    context "with a block" do
+      it "returns an array containing the minimum n elements based on the block's value" do
+        result = @enum.min_by(3) { |i| i.to_s }
+        result.should == [1, 101, 20]
+      end
+
+      context "on a enumerable of length x where x < n" do
+        it "returns an array containing the minimum n elements of length n" do
+          result = @enum.min_by(500) { |i| i.to_s }
+          result.length.should == 7
+        end
+      end
+
+      context "when n is negative" do
+        it "raises an Argument error" do
+          lambda { @enum.min_by(-1) { |i| i.to_s } }.should raise_error(ArgumentError)
+        end
+      end
+    end
+  end
 end

--- a/spec/ruby/core/enumerable/min_by_spec.rb
+++ b/spec/ruby/core/enumerable/min_by_spec.rb
@@ -11,8 +11,7 @@ describe "Enumerable#min_by" do
     EnumerableSpecs::Empty.new.min_by {|o| o.nonesuch }.should == nil
   end
 
-
-  it "returns the object for whom the value returned by block is the largest" do
+  it "returns the object for whom the value returned by block is the smallest" do
     EnumerableSpecs::Numerous.new(*%w[3 2 1]).min_by {|obj| obj.to_i }.should == '1'
     EnumerableSpecs::Numerous.new(*%w[five three]).min_by {|obj| obj.length }.should == 'five'
   end
@@ -29,7 +28,7 @@ describe "Enumerable#min_by" do
     EnumerableSpecs::Numerous.new(a, b, c).min_by {|obj| obj }.should == c
   end
 
-  it "is able to return the maximum for enums that contain nils" do
+  it "is able to return the minimum for enums that contain nils" do
     enum = EnumerableSpecs::Numerous.new(nil, nil, true)
     enum.min_by {|o| o.nil? ? 0 : 1 }.should == nil
     enum.min_by {|o| o.nil? ? 1 : 0 }.should == true

--- a/spec/ruby/core/enumerable/min_by_spec.rb
+++ b/spec/ruby/core/enumerable/min_by_spec.rb
@@ -66,7 +66,7 @@ describe "Enumerable#min_by" do
       end
 
       context "when n is negative" do
-        it "raises an Argument error" do
+        it "raises an ArgumentError" do
           lambda { @enum.min_by(-1) { |i| i.to_s } }.should raise_error(ArgumentError)
         end
       end

--- a/spec/ruby/core/enumerable/min_spec.rb
+++ b/spec/ruby/core/enumerable/min_spec.rb
@@ -88,4 +88,19 @@ describe "Enumerable#min" do
     multi.min.should == [1, 2]
   end
 
+  context "when called with an argument n" do
+    context "without a block" do
+      it "returns an array containing the minimum n elements" do
+        result = @e_ints.min(2)
+        result.should == [22, 333]
+      end
+    end
+
+    context "with a block" do
+      it "returns an array containing the minimum n elements" do
+        result = @e_ints.min(2) { |a, b| a * 2 <=> b * 2 }
+        result.should == [22, 333]
+      end
+    end
+  end
 end

--- a/spec/ruby/core/enumerable/min_spec.rb
+++ b/spec/ruby/core/enumerable/min_spec.rb
@@ -3,8 +3,6 @@ require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Enumerable#min" do
   before :each do
-    @a = EnumerableSpecs::EachDefiner.new( 2, 4, 6, 8, 10 )
-
     @e_strs = EnumerableSpecs::EachDefiner.new("333", "22", "666666", "1", "55555", "1010101010")
     @e_ints = EnumerableSpecs::EachDefiner.new( 333,   22,   666666,   55555, 1010101010)
   end

--- a/spec/ruby/core/enumerable/min_spec.rb
+++ b/spec/ruby/core/enumerable/min_spec.rb
@@ -109,7 +109,7 @@ describe "Enumerable#min" do
     end
 
     context "that is negative" do
-      it "raises an Argument error" do
+      it "raises an ArgumentError" do
         lambda { @e_ints.min(-1) }.should raise_error(ArgumentError)
       end
     end

--- a/spec/ruby/core/enumerable/min_spec.rb
+++ b/spec/ruby/core/enumerable/min_spec.rb
@@ -100,5 +100,18 @@ describe "Enumerable#min" do
         result.should == [22, 333]
       end
     end
+
+    context "on a enumerable of length x where x < n" do
+      it "returns an array containing the minimum n elements of length x" do
+        result = @e_ints.min(500)
+        result.length.should == 5
+      end
+    end
+
+    context "that is negative" do
+      it "raises an Argument error" do
+        lambda { @e_ints.min(-1) }.should raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/ruby/core/enumerable/slice_after_spec.rb
+++ b/spec/ruby/core/enumerable/slice_after_spec.rb
@@ -1,0 +1,53 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+describe "Enumerable#slice_after" do
+  before :each do
+    @enum = EnumerableSpecs::Numerous.new(7, 6, 5, 4, 3, 2, 1)
+  end
+
+  describe "when given an argument and no block" do
+    it "calls === on the argument to determine when to yield" do
+      arg = mock "filter"
+      arg.should_receive(:===).and_return(false, true, false, false, false, true, false)
+      e = @enum.slice_after(arg)
+      e.should be_an_instance_of(enumerator_class)
+      e.to_a.should == [[7, 6], [5, 4, 3, 2], [1]]
+    end
+
+    it "doesn't yield an empty array if the filter matches the first entry or the last entry" do
+      arg = mock "filter"
+      arg.should_receive(:===).and_return(true).exactly(7)
+      e = @enum.slice_after(arg)
+      e.to_a.should == [[7], [6], [5], [4], [3], [2], [1]]
+    end
+
+    it "uses standard boolean as a test" do
+      arg = mock "filter"
+      arg.should_receive(:===).and_return(false, :foo, nil, false, false, 42, false)
+      e = @enum.slice_after(arg)
+      e.to_a.should == [[7, 6], [5, 4, 3, 2], [1]]
+    end
+  end
+
+  describe "when given a block" do
+    describe "and no argument" do
+      it "calls the block to determine when to yield" do
+        e = @enum.slice_after{ |i| i == 6 || i == 2 }
+        e.should be_an_instance_of(enumerator_class)
+        e.to_a.should == [[7, 6], [5, 4, 3, 2], [1]]
+      end
+    end
+
+    describe "and an argument" do
+      it "raises an Argument error" do
+        lambda { @enum.slice_after(42) { |i| i == 6 } }.should raise_error(ArgumentError)
+      end
+    end
+  end
+
+  it "raises an Argument error when given an incorrect number of arguments" do
+    lambda { @enum.slice_after("one", "two") }.should raise_error(ArgumentError)
+    lambda { @enum.slice_after }.should raise_error(ArgumentError)
+  end
+end

--- a/spec/ruby/core/enumerable/slice_after_spec.rb
+++ b/spec/ruby/core/enumerable/slice_after_spec.rb
@@ -40,13 +40,13 @@ describe "Enumerable#slice_after" do
     end
 
     describe "and an argument" do
-      it "raises an Argument error" do
+      it "raises an ArgumentError" do
         lambda { @enum.slice_after(42) { |i| i == 6 } }.should raise_error(ArgumentError)
       end
     end
   end
 
-  it "raises an Argument error when given an incorrect number of arguments" do
+  it "raises an ArgumentError when given an incorrect number of arguments" do
     lambda { @enum.slice_after("one", "two") }.should raise_error(ArgumentError)
     lambda { @enum.slice_after }.should raise_error(ArgumentError)
   end

--- a/spec/ruby/core/enumerable/slice_before_spec.rb
+++ b/spec/ruby/core/enumerable/slice_before_spec.rb
@@ -71,7 +71,7 @@ describe "Enumerable#slice_before" do
     end
   end
 
-  it "raises an Argument error when given an incorrect number of arguments" do
+  it "raises an ArgumentError when given an incorrect number of arguments" do
     lambda { @enum.slice_before("one", "two") }.should raise_error(ArgumentError)
     lambda { @enum.slice_before }.should raise_error(ArgumentError)
   end

--- a/spec/ruby/core/enumerable/slice_when_spec.rb
+++ b/spec/ruby/core/enumerable/slice_when_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+describe "Enumerable#slice_when" do
+  before :each do
+    ary = [10, 9, 7, 6, 4, 3, 2, 1]
+    @enum = EnumerableSpecs::Numerous.new *ary
+    @result = @enum.slice_when { |i, j| i - 1 != j }
+    @enum_length = ary.length
+  end
+
+  context "when given a block" do
+    it "returns an enumerator" do
+      @result.should be_an_instance_of(enumerator_class)
+    end
+
+    it "splits chunks between adjacent elements i and j where the block returns true" do
+      @result.to_a.should == [[10, 9], [7, 6], [4, 3, 2, 1]]
+    end
+
+    it "calls the block for length of the receiver enumerable minus one times" do
+      times_called = 0
+      @enum.slice_when do |i, j|
+        times_called += 1
+        i - 1 != j
+      end.to_a
+      times_called.should == (@enum_length - 1)
+    end
+  end
+
+  context "when not given a block" do
+    it "raises an ArgumentError" do
+      lambda { @enum.slice_when }.should raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/ruby/core/file/birthtime_spec.rb
+++ b/spec/ruby/core/file/birthtime_spec.rb
@@ -1,0 +1,40 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "File.birthtime" do
+  before :each do
+    @file = __FILE__
+  end
+
+  after :each do
+    @file = nil
+  end
+
+  it "returns the birth time for the named file as a Time object" do
+    File.birthtime(@file)
+    File.birthtime(@file).should be_kind_of(Time)
+  end
+
+  it "accepts an object that has a #to_path method" do
+    File.birthtime(mock_to_path(@file))
+  end
+
+  it "raises an Errno::ENOENT exception if the file is not found" do
+    lambda { File.birthtime('bogus') }.should raise_error(Errno::ENOENT)
+  end
+end
+
+describe "File#birthtime" do
+  before :each do
+    @file = File.open(__FILE__)
+  end
+
+  after :each do
+    @file.close
+    @file = nil
+  end
+
+  it "returns the birth time for self" do
+    @file.birthtime
+    @file.birthtime.should be_kind_of(Time)
+  end
+end

--- a/spec/ruby/core/file/ctime_spec.rb
+++ b/spec/ruby/core/file/ctime_spec.rb
@@ -28,7 +28,7 @@ describe "File#ctime" do
     @file = File.open(__FILE__)
   end
 
-  after:each do
+  after :each do
     @file.close
     @file = nil
   end

--- a/spec/ruby/core/file/stat/birthtime_spec.rb
+++ b/spec/ruby/core/file/stat/birthtime_spec.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+
+describe "File::Stat#birthtime" do
+  before :each do
+    @file = tmp('i_exist')
+    touch(@file) { |f| f.write "rubinius" }
+  end
+
+  after :each do
+    rm_r @file
+  end
+
+  it "returns the birthtime of a File::Stat object" do
+    st = File.stat(@file)
+    st.birthtime.should be_kind_of(Time)
+    st.birthtime.should <= Time.now
+  end
+end

--- a/spec/ruby/core/kernel/frozen_spec.rb
+++ b/spec/ruby/core/kernel/frozen_spec.rb
@@ -41,4 +41,22 @@ describe "Kernel#frozen?" do
       @symbol.frozen?.should be_true
     end
   end
+
+  describe "on nil" do
+    it "returns true" do
+      nil.frozen?.should be_true
+    end
+  end
+
+  describe "on true" do
+    it "returns true" do
+      nil.frozen?.should be_true
+    end
+  end
+
+  describe "on false" do
+    it "returns true" do
+      nil.frozen?.should be_true
+    end
+  end
 end

--- a/spec/ruby/core/method/curry_spec.rb
+++ b/spec/ruby/core/method/curry_spec.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+describe "Method#curry" do
+
+  it "returns a curried proc" do
+    x = Object.new
+    def x.foo(a,b,c); [a,b,c]; end
+
+    c = x.method(:foo).curry
+    c.should be_kind_of(Proc)
+    c.(1).(2, 3).should == [1,2,3]
+  end
+
+  describe "with optional arity argument" do
+    before(:each) do
+      @obj = MethodSpecs::Methods.new
+    end
+
+    it "returns a curried proc when given correct arity" do
+      @obj.method(:one_req).curry(1).should be_kind_of(Proc)
+      @obj.method(:zero_with_splat).curry(100).should be_kind_of(Proc)
+      @obj.method(:two_req_with_splat).curry(2).should be_kind_of(Proc)
+    end
+
+    it "raises ArgumentError when the method requires less arguments than the given arity" do
+      lambda { @obj.method(:zero).curry(1) }.should raise_error(ArgumentError)
+      lambda { @obj.method(:one_req_one_opt).curry(3) }.should raise_error(ArgumentError)
+      lambda { @obj.method(:two_req_one_opt_with_block).curry(4) }.should raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError when the method requires more arguments than the given arity" do
+      lambda { @obj.method(:two_req_with_splat).curry(1) }.should raise_error(ArgumentError)
+      lambda { @obj.method(:one_req).curry(0) }.should raise_error(ArgumentError)
+    end
+  end
+
+end

--- a/spec/ruby/language/block_spec.rb
+++ b/spec/ruby/language/block_spec.rb
@@ -789,6 +789,23 @@ describe "Post-args" do
         [a, b, c, d]
       end.call(2, 3).should == [2, 6, [], 3]
     end
+
+    describe "with a circular argument reference" do
+      it "shadows an existing local with the same name as the argument" do
+        a = 1
+        proc { |a=a| a }.call.should == nil
+      end
+
+      it "shadows an existing method with the same name as the argument" do
+        def a; 1; end
+        proc { |a=a| a }.call.should == nil
+      end
+
+      it "calls an existing method with the same name as the argument if explicitly using ()" do
+        def a; 1; end
+        proc { |a=a()| a }.call.should == 1
+      end
+    end
   end
 
   describe "with pattern matching" do

--- a/spec/ruby/language/def_spec.rb
+++ b/spec/ruby/language/def_spec.rb
@@ -154,11 +154,22 @@ describe "An instance method with a default argument" do
     foo(2,3,3).should == [2,3,[3]]
   end
 
-  it "calls a method with the same name as the local" do
+  it "shadows an existing method with the same name as the local" do
     def bar
       1
     end
     def foo(bar = bar)
+      bar
+    end
+    foo.should == nil
+    foo(2).should == 2
+  end
+
+  it "calls a method with the same name as the local when explicitly using ()" do
+    def bar
+      1
+    end
+    def foo(bar = bar())
       bar
     end
     foo.should == 1

--- a/spec/ruby/language/hash_spec.rb
+++ b/spec/ruby/language/hash_spec.rb
@@ -93,7 +93,7 @@ describe "Hash literal" do
     obj = mock("hash splat")
     obj.should_receive(:to_hash).and_return({a: 2, b: 3})
 
-    {a: 1, **obj, c: 3}.should == {a:1, b: 3, c: 3}
+    {a: 1, **obj, c: 3}.should == {a: 2, b: 3, c: 3}
   end
 
   it "raises a TypeError if #to_hash does not return a Hash" do
@@ -103,12 +103,12 @@ describe "Hash literal" do
     lambda { {**obj} }.should raise_error(TypeError)
   end
 
-  it "merges the containing Hash into the **obj before importing obj's items" do
-    {a: 1, **{a: 2, b: 3, c: 4}, c: 3}.should == {a: 1, b: 3, c: 3}
+  it "expands an '**obj' element into the containing Hash and keeps the latter keys if there are duplicates" do
+    {a: 1, **{a: 2, b: 3, c: 4}, c: 3}.should == {a: 2, b: 3, c: 3}
   end
 
   it "merges multiple nested '**obj' in Hash literals" do
     h = {a: 1, **{a: 2, **{b: 3, **{c: 4}}, **{d: 5}, }, **{d: 6}}
-    h.should == {a: 1, b: 3, c: 4, d: 5}
+    h.should == {a: 2, b: 3, c: 4, d: 6}
   end
 end

--- a/spec/ruby/language/hash_spec.rb
+++ b/spec/ruby/language/hash_spec.rb
@@ -73,9 +73,9 @@ describe "Hash literal" do
     {rbx: :cool, specs: 'fail_sometimes',}.should == h
   end
 
-  it "accepts mixed 'key: value' and 'key => value' syntax" do
-    h = {:a => 1, :b => 2, "c" => 3}
-    {a: 1, :b => 2, "c" => 3}.should == h
+  it "accepts mixed 'key: value', 'key => value' and '\"key\"': value' syntax" do
+    h = {:a => 1, :b => 2, "c" => 3, :d => 4}
+    eval('{a: 1, :b => 2, "c" => 3, "d": 4}').should == h
   end
 
   it "expands an '**{}' element into the containing Hash literal initialization" do

--- a/spec/ruby/language/lambda_spec.rb
+++ b/spec/ruby/language/lambda_spec.rb
@@ -268,6 +268,23 @@ describe "A lambda literal -> () { }" do
       result = @a.(1, 2, e: 3, g: 4, h: 5, i: 6, &(l = ->{}))
       result.should == [1, 1, [], 2, 3, 2, 4, { h: 5, i: 6 }, l]
     end
+
+    describe "with circular optional argument reference" do
+      it "shadows an existing local with the same name as the argument" do
+        a = 1
+        -> (a=a) { a }.call.should == nil
+      end
+
+      it "shadows an existing method with the same name as the argument" do
+        def a; 1; end
+        -> (a=a) { a }.call.should == nil
+      end
+
+      it "calls an existing method with the same name as the argument if explicitly using ()" do
+        def a; 1; end
+        -> (a=a()) { a }.call.should == 1
+      end
+    end
   end
 end
 

--- a/spec/ruby/language/regexp/character_classes_spec.rb
+++ b/spec/ruby/language/regexp/character_classes_spec.rb
@@ -142,7 +142,6 @@ describe "Regexp with character classes" do
   end
 
   it "matches Unicode space characters with [[:blank:]]" do
-    "\u{180E}".match(/[[:blank:]]/).to_a.should == ["\u{180E}"]
     "\u{1680}".match(/[[:blank:]]/).to_a.should == ["\u{1680}"]
   end
 

--- a/spec/tags/ruby/core/binding/local_variables_tags.txt
+++ b/spec/tags/ruby/core/binding/local_variables_tags.txt
@@ -1,0 +1,5 @@
+fails:Binding#local_variables returns an Array
+fails:Binding#local_variables includes local variables in the current scope
+fails:Binding#local_variables includes local variables defined after calling binding.local_variables
+fails:Binding#local_variables includes local variables of inherited scopes and eval'ed context
+fails:Binding#local_variables includes shadowed local variables only once

--- a/spec/tags/ruby/core/binding/local_variables_tags.txt
+++ b/spec/tags/ruby/core/binding/local_variables_tags.txt
@@ -1,5 +1,0 @@
-fails:Binding#local_variables returns an Array
-fails:Binding#local_variables includes local variables in the current scope
-fails:Binding#local_variables includes local variables defined after calling binding.local_variables
-fails:Binding#local_variables includes local variables of inherited scopes and eval'ed context
-fails:Binding#local_variables includes shadowed local variables only once

--- a/spec/tags/ruby/core/binding/receiver_tags.txt
+++ b/spec/tags/ruby/core/binding/receiver_tags.txt
@@ -1,0 +1,1 @@
+fails:Binding#receiver returns the object to which binding is bound

--- a/spec/tags/ruby/core/binding/receiver_tags.txt
+++ b/spec/tags/ruby/core/binding/receiver_tags.txt
@@ -1,1 +1,0 @@
-fails:Binding#receiver returns the object to which binding is bound

--- a/spec/tags/ruby/core/enumerable/max_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/max_by_tags.txt
@@ -1,0 +1,3 @@
+fails:Enumerable#max_by when called with an argument n without a block returns an enumerator
+fails:Enumerable#max_by when called with an argument n with a block returns an array containing the maximum n elements based on the block's value
+fails:Enumerable#max_by when called with an argument n with a block on a enumerable of length x where x < n returns an array containing the maximum n elements of length n

--- a/spec/tags/ruby/core/enumerable/max_tags.txt
+++ b/spec/tags/ruby/core/enumerable/max_tags.txt
@@ -1,0 +1,3 @@
+fails:Enumerable#max when called with an argument n without a block returns an array containing the maximum n elements
+fails:Enumerable#max when called with an argument n with a block returns an array containing the maximum n elements
+fails:Enumerable#max when called with an argument n on a enumerable of length x where x < n returns an array containing the maximum n elements of length x

--- a/spec/tags/ruby/core/enumerable/min_by_tags.txt
+++ b/spec/tags/ruby/core/enumerable/min_by_tags.txt
@@ -1,0 +1,3 @@
+fails:Enumerable#min_by when called with an argument n without a block returns an enumerator
+fails:Enumerable#min_by when called with an argument n with a block returns an array containing the minimum n elements based on the block's value
+fails:Enumerable#min_by when called with an argument n with a block on a enumerable of length x where x < n returns an array containing the minimum n elements of length n

--- a/spec/tags/ruby/core/enumerable/min_tags.txt
+++ b/spec/tags/ruby/core/enumerable/min_tags.txt
@@ -1,0 +1,2 @@
+fails:Enumerable#min when called with an argument n without a block returns an array containing the minimum n elements
+fails:Enumerable#min when called with an argument n with a block returns an array containing the minimum n elements

--- a/spec/tags/ruby/core/enumerable/min_tags.txt
+++ b/spec/tags/ruby/core/enumerable/min_tags.txt
@@ -1,2 +1,3 @@
 fails:Enumerable#min when called with an argument n without a block returns an array containing the minimum n elements
 fails:Enumerable#min when called with an argument n with a block returns an array containing the minimum n elements
+fails:Enumerable#min when called with an argument n on a enumerable of length x where x < n returns an array containing the minimum n elements of length x

--- a/spec/tags/ruby/core/enumerable/slice_after_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_after_tags.txt
@@ -2,5 +2,5 @@ fails:Enumerable#slice_after when given an argument and no block calls === on th
 fails:Enumerable#slice_after when given an argument and no block doesn't yield an empty array if the filter matches the first entry or the last entry
 fails:Enumerable#slice_after when given an argument and no block uses standard boolean as a test
 fails:Enumerable#slice_after when given a block and no argument calls the block to determine when to yield
-fails:Enumerable#slice_after when given a block and an argument raises an Argument error
-fails:Enumerable#slice_after raises an Argument error when given an incorrect number of arguments
+fails:Enumerable#slice_after raises an ArgumentError when given an incorrect number of arguments
+fails:Enumerable#slice_after when given a block and an argument raises an ArgumentError

--- a/spec/tags/ruby/core/enumerable/slice_after_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_after_tags.txt
@@ -1,0 +1,6 @@
+fails:Enumerable#slice_after when given an argument and no block calls === on the argument to determine when to yield
+fails:Enumerable#slice_after when given an argument and no block doesn't yield an empty array if the filter matches the first entry or the last entry
+fails:Enumerable#slice_after when given an argument and no block uses standard boolean as a test
+fails:Enumerable#slice_after when given a block and no argument calls the block to determine when to yield
+fails:Enumerable#slice_after when given a block and an argument raises an Argument error
+fails:Enumerable#slice_after raises an Argument error when given an incorrect number of arguments

--- a/spec/tags/ruby/core/enumerable/slice_when_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_when_tags.txt
@@ -1,4 +1,4 @@
 fails:Enumerable#slice_when when given a block returns an enumerator
 fails:Enumerable#slice_when when given a block splits chunks between adjacent elements i and j where the block returns true
-fails:Enumerable#slice_when when given a block calls the block the length of the receiver enumerable minus one times
 fails:Enumerable#slice_when when not given a block raises an Argument error
+fails:Enumerable#slice_when when given a block calls the block for length of the receiver enumerable minus one times

--- a/spec/tags/ruby/core/enumerable/slice_when_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_when_tags.txt
@@ -1,4 +1,4 @@
 fails:Enumerable#slice_when when given a block returns an enumerator
 fails:Enumerable#slice_when when given a block splits chunks between adjacent elements i and j where the block returns true
-fails:Enumerable#slice_when when not given a block raises an Argument error
 fails:Enumerable#slice_when when given a block calls the block for length of the receiver enumerable minus one times
+fails:Enumerable#slice_when when not given a block raises an ArgumentError

--- a/spec/tags/ruby/core/enumerable/slice_when_tags.txt
+++ b/spec/tags/ruby/core/enumerable/slice_when_tags.txt
@@ -1,0 +1,4 @@
+fails:Enumerable#slice_when when given a block returns an enumerator
+fails:Enumerable#slice_when when given a block splits chunks between adjacent elements i and j where the block returns true
+fails:Enumerable#slice_when when given a block calls the block the length of the receiver enumerable minus one times
+fails:Enumerable#slice_when when not given a block raises an Argument error

--- a/spec/tags/ruby/core/file/birthtime_tags.txt
+++ b/spec/tags/ruby/core/file/birthtime_tags.txt
@@ -1,0 +1,4 @@
+fails:File.birthtime returns the birth time for the named file as a Time object
+fails:File.birthtime accepts an object that has a #to_path method
+fails:File.birthtime raises an Errno::ENOENT exception if the file is not found
+fails:File#birthtime returns the birth time for self

--- a/spec/tags/ruby/core/file/stat/birthtime_tags.txt
+++ b/spec/tags/ruby/core/file/stat/birthtime_tags.txt
@@ -1,0 +1,1 @@
+fails:File::Stat#birthtime returns the birthtime of a File::Stat object

--- a/spec/tags/ruby/core/kernel/frozen_tags.txt
+++ b/spec/tags/ruby/core/kernel/frozen_tags.txt
@@ -1,0 +1,3 @@
+fails:Kernel#frozen? on nil returns true
+fails:Kernel#frozen? on true returns true
+fails:Kernel#frozen? on false returns true

--- a/spec/tags/ruby/core/method/curry_tags.txt
+++ b/spec/tags/ruby/core/method/curry_tags.txt
@@ -1,0 +1,4 @@
+fails:Method#curry returns a curried proc
+fails:Method#curry with optional arity argument returns a curried proc when given correct arity
+fails:Method#curry with optional arity argument raises ArgumentError when the method requires less arguments than the given arity
+fails:Method#curry with optional arity argument raises ArgumentError when the method requires more arguments than the given arity

--- a/spec/tags/ruby/language/block_tags.txt
+++ b/spec/tags/ruby/language/block_tags.txt
@@ -1,0 +1,2 @@
+fails:Post-args with optional args with a circular argument reference shadows an existing local with the same name as the argument
+fails:Post-args with optional args with a circular argument reference shadows an existing method with the same name as the argument

--- a/spec/tags/ruby/language/def_tags.txt
+++ b/spec/tags/ruby/language/def_tags.txt
@@ -1,2 +1,3 @@
+fails:An instance method with a default argument shadows an existing method with the same name as the local
 fails:A singleton method definition raises RuntimeError if frozen
 fails:A method definition inside a metaclass scope raises RuntimeError if frozen

--- a/spec/tags/ruby/language/hash_tags.txt
+++ b/spec/tags/ruby/language/hash_tags.txt
@@ -1,1 +1,4 @@
 fails:Hash literal accepts mixed 'key: value', 'key => value' and '"key"': value' syntax
+fails:Hash literal calls #to_hash to convert an '**obj' element
+fails:Hash literal expands an '**obj' element into the containing Hash and keeps the latter keys if there are duplicates
+fails:Hash literal merges multiple nested '**obj' in Hash literals

--- a/spec/tags/ruby/language/hash_tags.txt
+++ b/spec/tags/ruby/language/hash_tags.txt
@@ -1,0 +1,1 @@
+fails:Hash literal accepts mixed 'key: value', 'key => value' and '"key"': value' syntax

--- a/spec/tags/ruby/language/lambda_tags.txt
+++ b/spec/tags/ruby/language/lambda_tags.txt
@@ -1,0 +1,2 @@
+fails:A lambda literal -> () { } assigns variables from parameters with circular optional argument reference shadows an existing local with the same name as the argument
+fails:A lambda literal -> () { } assigns variables from parameters with circular optional argument reference shadows an existing method with the same name as the argument


### PR DESCRIPTION
This PR adds specs for the the following language changes in ruby 2.2 ([see NEWS file](http://github.com/ruby/ruby/blob/v2_2_0/NEWS)):

* nil/true/false objects are frozen. [Feature #8923]
* Hash literal: Symbol key followed by a colon can be quoted. [Feature #4276]
* fixed a very longstanding bug that an optional argument was not
  accessible in its default value expression.  [Bug #9593]

I'll go over some points about the commits:

* I wasn't sure where to put the nil/true/false specs. I considered creating `nil_spec.rb`, `true_spec.rb` and `false_spec.rb` in `spec/ruby/language` with a single example for `frozen?`, but for the sake of consistency with the existing specs I ended up putting them in `kernel/frozen_spec.rb`. Was this the best choice?
* The expectation for the new quoted symbol syntax uses an  `eval` because otherwise it would break the whole file (the parser would throw a syntax error and no examples would be run).

Thank you for your time. 