### PR TITLE
Add local var methods to Binding

### DIFF
--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -56,14 +56,14 @@ class Binding
   end
 
   def local_variable_defined?(symbol)
-    eval("defined?(#{symbol}) == 'local-variable'")
+    variables.local_defined?(symbol)
   end
 
   def local_variable_get(symbol)
-    eval("#{symbol}")
+    variables.get_eval_local(symbol)
   end
 
   def local_variable_set(symbol, obj)
-    eval("#{symbol} = #{obj}")
+    variables.set_eval_local(symbol, obj)
   end
 end

--- a/kernel/common/binding.rb
+++ b/kernel/common/binding.rb
@@ -54,4 +54,16 @@ class Binding
 
     Kernel.eval(expr, self, filename, lineno)
   end
+
+  def local_variable_defined?(symbol)
+    eval("defined?(#{symbol}) == 'local-variable'")
+  end
+
+  def local_variable_get(symbol)
+    eval("#{symbol}")
+  end
+
+  def local_variable_set(symbol, obj)
+    eval("#{symbol} = #{obj}")
+  end
 end


### PR DESCRIPTION
These are defined in MRI as of 2.1.

I basically just copied these from the [RubyDocs](http://ruby-doc.org/core-2.1.0/Binding.html#method-i-local_variable_defined-3F).

My implementation of `Binding#local_variable_set` assumes obj responds to #to_s, which may cause issues.