### PR TITLE
Clean bundler environment before running Homebrew during configuration

### DIFF
--- a/configure
+++ b/configure
@@ -576,7 +576,7 @@ class Configure
         if macports?
           config = macports_llvm_config
         else
-          out = `brew list llvm | grep '/llvm-config$'`
+          out = Bundler.with_clean_env { `brew list llvm | grep '/llvm-config$'` }
           config = out.chomp if $?.success?
         end
       end


### PR DESCRIPTION
Bundler leaks RUBYOPT='-rbundler/setup' to Homebrew which may cause it to crash when system Ruby doesn't have bundler installed. This causes RVM to crash during `rvm install rbx`, see rvm/rvm#3386