### PR TITLE
Fix Method equalitiy

### DIFF
--- a/kernel/common/block_environment.rb
+++ b/kernel/common/block_environment.rb
@@ -105,6 +105,7 @@ module Rubinius
         # when given a Proc.
         #
         # The methods are equal if the BEs are equal.
+        return false unless other.kind_of? AsMethod
 
         @block_env == other.block_env
       end

--- a/spec/ruby/core/method/shared/eql.rb
+++ b/spec/ruby/core/method/shared/eql.rb
@@ -54,6 +54,16 @@ describe :method_equal, :shared => true do
     @m_foo.send(@method, m2).should be_true
   end
 
+  it "returns false if comparing a method defined via define_method and def" do
+    MethodSpecs::Methods.send :define_method, :defined_foo, lambda {}
+
+    defn = @m.method(:foo)
+    defined = @m.method(:defined_foo)
+
+    defn.send(@method, defined).should be_false
+    defined.send(@method, defn).should be_false
+  end
+
   describe 'missing methods' do
     it "returns true for the same method missing" do
       miss1 = @m.method(:handled_via_method_missing)

--- a/spec/ruby/core/method/shared/eql.rb
+++ b/spec/ruby/core/method/shared/eql.rb
@@ -55,10 +55,8 @@ describe :method_equal, :shared => true do
   end
 
   it "returns false if comparing a method defined via define_method and def" do
-    MethodSpecs::Methods.send :define_method, :defined_foo, lambda {}
-
-    defn = @m.method(:foo)
-    defined = @m.method(:defined_foo)
+    defn = @m.method(:zero)
+    defined = @m.method(:zero_defined_method)
 
     defn.send(@method, defined).should be_false
     defined.send(@method, defn).should be_false


### PR DESCRIPTION
A Method defined via def has an executable attribute of class Rubinius::CompiledCode. On the other site a method defined via define_method has an executable attribute of class Rubinius::BlockEnvironment::AsMethod.

Comparing method equality includes the comparison of executable equality.

For comparing an executable of type Rubinius::BlockEnvironment::AsMethod against an executable of Rubinius::CompiledCode results in an error because it tries to access the block_env attribute on an Rubinius::CompiledCode object, which doesn't exist.

This PR adds an early return like in Rubinius::CompiledCode#==

This closes #3118 