### PR TITLE
Implemented File birthtime

### DIFF
--- a/configure
+++ b/configure
@@ -1231,7 +1231,7 @@ int main() { return tgetnum(""); }
     end
 
     if has_function("birthtime", ["sys/stat.h"])
-       @defines << "HAVE_ST_BIRTHTIME"
+      @defines << "HAVE_ST_BIRTHTIME"
     end
 
     # glibc has useless lchmod() so we don't try to use lchmod() on linux

--- a/configure
+++ b/configure
@@ -1230,7 +1230,7 @@ int main() { return tgetnum(""); }
       @defines << "HAVE_GETTID"
     end
 
-    if has_function("birthtime", ["sys/stat.h"])
+    if has_struct_member("stat", "st_birthtimespec", ["sys/stat.h"])
       @defines << "HAVE_ST_BIRTHTIME"
     end
 

--- a/configure
+++ b/configure
@@ -1230,6 +1230,10 @@ int main() { return tgetnum(""); }
       @defines << "HAVE_GETTID"
     end
 
+    if has_function("birthtime", ["sys/stat.h"])
+       @defines << "HAVE_ST_BIRTHTIME"
+    end
+
     # glibc has useless lchmod() so we don't try to use lchmod() on linux
     if !@linux and has_function("lchmod", ["sys/stat.h", "unistd.h"])
       @have_lchmod = true

--- a/kernel/bootstrap/stat.rb
+++ b/kernel/bootstrap/stat.rb
@@ -87,6 +87,11 @@ module Rubinius
       raise PrimitiveFailure, "Rubinius::Stat#ctime primitive failed"
     end
 
+    def birthtime
+      Rubinius.primitive :stat_birthtime
+      raise NotImplementedError, "birthtime() function is unimplemented on this machine"
+    end
+
     def inspect
       "#<#{self.class.name} dev=0x#{self.dev.to_s(16)}, ino=#{self.ino}, " \
       "mode=#{sprintf("%07d", self.mode.to_s(8).to_i)}, nlink=#{self.nlink}, " \

--- a/kernel/common/file.rb
+++ b/kernel/common/file.rb
@@ -104,6 +104,28 @@ class File < IO
   end
 
   ##
+  # Returns the change time for the named file (the
+  # time at which directory information about the
+  # file was changed, not the file itself).
+  #
+  #  File.ctime("testfile")   #=> Wed Apr 09 08:53:13 CDT 2003
+  def self.ctime(path)
+    Stat.new(path).ctime
+  end
+
+  def self.birthtime(path)
+    Stat.new(path).birthtime
+  end
+
+  ##
+  # Returns the modification time for the named file as a Time object.
+  #
+  #  File.mtime("testfile")   #=> Tue Apr 08 12:58:04 CDT 2003
+  def self.mtime(path)
+    Stat.new(path).mtime
+  end
+
+  ##
   # Returns the last component of the filename given
   # in file_name, which must be formed using forward
   # slashes (``/’’) regardless of the separator used
@@ -302,16 +324,6 @@ class File < IO
     end
 
     paths.size
-  end
-
-  ##
-  # Returns the change time for the named file (the
-  # time at which directory information about the
-  # file was changed, not the file itself).
-  #
-  #  File.ctime("testfile")   #=> Wed Apr 09 08:53:13 CDT 2003
-  def self.ctime(path)
-    Stat.new(path).ctime
   end
 
   ##
@@ -816,14 +828,6 @@ class File < IO
     Stat.lstat path
   end
 
-  ##
-  # Returns the modification time for the named file as a Time object.
-  #
-  #  File.mtime("testfile")   #=> Tue Apr 08 12:58:04 CDT 2003
-  def self.mtime(path)
-    Stat.new(path).mtime
-  end
-
   def self.path(obj)
     return obj.to_path if obj.respond_to? :to_path
 
@@ -1226,16 +1230,24 @@ class File < IO
     Stat.new(@path).atime
   end
 
+  def ctime
+    Stat.new(@path).ctime
+  end
+
+  def birthtime
+    Stat.new(@path).birthtime
+  end
+
+  def mtime
+    Stat.new(@path).mtime
+  end
+
   def reopen(other, mode = 'r+')
     rewind unless closed?
     unless other.kind_of? IO
       other = Rubinius::Type.coerce_to_path(other)
     end
     super(other, mode)
-  end
-
-  def ctime
-    Stat.new(@path).ctime
   end
 
   def flock(const)
@@ -1249,10 +1261,6 @@ class File < IO
 
   def lstat
     Stat.lstat @path
-  end
-
-  def mtime
-    Stat.new(@path).mtime
   end
 
   def stat

--- a/spec/ruby/core/file/birthtime_spec.rb
+++ b/spec/ruby/core/file/birthtime_spec.rb
@@ -9,7 +9,7 @@ describe "File.birthtime" do
     @file = nil
   end
 
-  platform_is :darwin, :freebsd, :netbsd do
+  platform_is :darwin do
     it "returns the birth time for the named file as a Time object" do
       File.birthtime(@file)
       File.birthtime(@file).should be_kind_of(Time)
@@ -24,7 +24,7 @@ describe "File.birthtime" do
     end
   end
 
-  platform_is :windows, :linux do
+  platform_is :windows, :linux, :openbsd, :freebsd, :netbsd do
     it "raises an NotImplementedError" do
       lambda { File.birthtime(@file) }.should raise_error(NotImplementedError)
     end
@@ -41,14 +41,14 @@ describe "File#birthtime" do
     @file = nil
   end
 
-  platform_is :darwin, :freebsd, :netbsd, :openbsd do
+  platform_is :darwin do
     it "returns the birth time for self" do
       @file.birthtime
       @file.birthtime.should be_kind_of(Time)
     end
   end
 
-  platform_is :windows, :linux do
+  platform_is :windows, :linux, :openbsd, :freebsd, :netbsd do
     it "raises an NotImplementedError" do
       lambda { @file.birthtime }.should raise_error(NotImplementedError)
     end

--- a/spec/ruby/core/file/birthtime_spec.rb
+++ b/spec/ruby/core/file/birthtime_spec.rb
@@ -9,17 +9,25 @@ describe "File.birthtime" do
     @file = nil
   end
 
-  it "returns the birth time for the named file as a Time object" do
-    File.birthtime(@file)
-    File.birthtime(@file).should be_kind_of(Time)
+  platform_is :darwin, :freebsd, :netbsd do
+    it "returns the birth time for the named file as a Time object" do
+      File.birthtime(@file)
+      File.birthtime(@file).should be_kind_of(Time)
+    end
+
+    it "accepts an object that has a #to_path method" do
+      File.birthtime(mock_to_path(@file))
+    end
+
+    it "raises an Errno::ENOENT exception if the file is not found" do
+      lambda { File.birthtime('bogus') }.should raise_error(Errno::ENOENT)
+    end
   end
 
-  it "accepts an object that has a #to_path method" do
-    File.birthtime(mock_to_path(@file))
-  end
-
-  it "raises an Errno::ENOENT exception if the file is not found" do
-    lambda { File.birthtime('bogus') }.should raise_error(Errno::ENOENT)
+  platform_is :windows, :linux do
+    it "raises an NotImplementedError" do
+      lambda { File.birthtime(@file) }.should raise_error(NotImplementedError)
+    end
   end
 end
 
@@ -33,8 +41,16 @@ describe "File#birthtime" do
     @file = nil
   end
 
-  it "returns the birth time for self" do
-    @file.birthtime
-    @file.birthtime.should be_kind_of(Time)
+  platform_is :darwin, :freebsd, :netbsd, :openbsd do
+    it "returns the birth time for self" do
+      @file.birthtime
+      @file.birthtime.should be_kind_of(Time)
+    end
+  end
+
+  platform_is :windows, :linux do
+    it "raises an NotImplementedError" do
+      lambda { @file.birthtime }.should raise_error(NotImplementedError)
+    end
   end
 end

--- a/spec/ruby/core/nil/frozen_spec.rb
+++ b/spec/ruby/core/nil/frozen_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-
-describe "NilClass#frozen?" do
-  it "returns true" do
-    nil.frozen?.should == true
-  end
-end

--- a/spec/ruby/core/nil/frozen_spec.rb
+++ b/spec/ruby/core/nil/frozen_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "NilClass#frozen?" do
+  it "returns true" do
+    nil.frozen?.should == true
+  end
+end

--- a/spec/tags/ruby/core/file/birthtime_tags.txt
+++ b/spec/tags/ruby/core/file/birthtime_tags.txt
@@ -1,4 +1,0 @@
-fails:File.birthtime returns the birth time for the named file as a Time object
-fails:File.birthtime accepts an object that has a #to_path method
-fails:File.birthtime raises an Errno::ENOENT exception if the file is not found
-fails:File#birthtime returns the birth time for self

--- a/vm/builtin/stat.cpp
+++ b/vm/builtin/stat.cpp
@@ -79,7 +79,7 @@ namespace rubinius {
 
   Object* Stat::stat_birthtime(STATE) {
     #ifdef HAVE_ST_BIRTHTIME
-      return Time::at(state, st_.st_birthtime);
+      return Time::at(state, st_.st_birthtimespec);
     #else
       return Primitives::failure();
     #endif

--- a/vm/builtin/stat.cpp
+++ b/vm/builtin/stat.cpp
@@ -77,5 +77,13 @@ namespace rubinius {
     return Time::at(state, st_.st_ctime);
   }
 
+  Object* Stat::stat_birthtime(STATE) {
+    #ifdef HAVE_ST_BIRTHTIME
+      return Time::at(state, st_.st_birthtime);
+    #else
+      return Primitives::failure();
+    #endif
+  }
+
 }
 

--- a/vm/builtin/stat.hpp
+++ b/vm/builtin/stat.hpp
@@ -73,6 +73,9 @@ namespace rubinius {
     // Rubinius.primitive+ :stat_ctime
     Time* stat_ctime(STATE);
 
+    // Rubinius.primitive+ :stat_birthtime
+    Object* stat_birthtime(STATE);
+
     class Info : public TypeInfo {
     public:
       BASIC_TYPEINFO(TypeInfo)


### PR DESCRIPTION
Opening this pr because I'm not sure if I did it the "right" way.

The configure script checks if on your system in `stat.h` the function `birthtime()` is defined.
If it is a `HAVE_ST_BIRTHTIME` macro is set which can be used in c++ to check whether to return `st_.st_birthtime` as Time Object or return a `Primitives::failure()`.

In the ruby Stat#birthtime method a `NotImplementedError` is raised if the primitive fails.
Also updated the specs for the specific platforms, the problem here I'm not sure which platform supports `birthtime()` and which don't.

Belongs to #3264 