### PR TITLE
Fix OSX build to use llvm35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,3 @@ env:
 os:
   - linux
   - osx
-
-osx_image: beta-xcode6.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - echo $LANG
   - echo $LC_ALL
   - if [ $TRAVIS_OS_NAME == linux ]; then sudo apt-get update && sudo apt-get install -y llvm-3.4 llvm-3.4-dev; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install llvm && brew link --force llvm; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew update && brew install llvm35 && brew link --force llvm35; fi
   - rvm use $RVM --install --binary --fuzzy
   - gem update --system
   - gem --version
@@ -16,7 +16,7 @@ before_install:
 before_script:
   - travis_retry bundle
   - if [ $TRAVIS_OS_NAME == linux ]; then travis_retry ./configure --llvm-config llvm-config-3.4; fi
-  - if [ $TRAVIS_OS_NAME == osx ]; then travis_retry ./configure --llvm-config /usr/local/opt/llvm/bin/llvm-config; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then travis_retry ./configure; fi
 
 script: rake ci
 
@@ -49,6 +49,6 @@ env:
 
 os:
   - linux
-  # - osx
+  - osx
 
-osx_image: xcode61
+osx_image: beta-xcode6.3

--- a/configure
+++ b/configure
@@ -577,8 +577,8 @@ class Configure
         if macports?
           config = macports_llvm_config
         else
-          out = Bundler.with_clean_env { `brew list llvm | grep '/llvm-config$'` }
-          config = out.chomp if $?.success?
+          out = Bundler.with_clean_env { `brew --prefix llvm35` }.chomp
+          config = "#{out}/bin/llvm-config-3.5" if $?.success?
         end
       end
     end


### PR DESCRIPTION
Until RBX supports LLVM 3.6, compiling with homebrew/versions' llvm35 should work painlessly. Also, CI should compile with llvm-3.5 on Linux.