### PR TITLE
Fix Stat::stat_birthtime.

### DIFF
--- a/vm/builtin/stat.cpp
+++ b/vm/builtin/stat.cpp
@@ -79,7 +79,8 @@ namespace rubinius {
 
   Object* Stat::stat_birthtime(STATE) {
     #ifdef HAVE_ST_BIRTHTIME
-      return Time::at(state, st_.st_birthtimespec);
+      struct timespec ts = st_.st_birthtimespec;
+      return Time::at(state, ts.tv_sec, ts.tv_nsec);
     #else
       return Primitives::failure();
     #endif


### PR DESCRIPTION
This commit fixes a build error due to a signature mismatch of the Time::at
method and the way it was being used in Stat::stat_birthtime.

The build error was:
```
vm/builtin/stat.cpp:82:30: error: no viable conversion from 'struct timespec' to 'time64_t' (aka 'long long')
      return Time::at(state, st_.st_birthtimespec);
                             ^~~~~~~~~~~~~~~~~~~~
/Users/ruiserra/code/ruby/ruipserra/rubinius/vm/builtin/time.hpp:40:37: note: passing argument to parameter 'seconds' here
    static Time* at(STATE, time64_t seconds, long nanoseconds = 0);
                                    ^
```