### PR TITLE
Use BasicObject#equal? for Symbol#==.

### DIFF
--- a/kernel/common/symbol.rb
+++ b/kernel/common/symbol.rb
@@ -7,6 +7,9 @@ class Symbol
     to_s <=> other.to_s
   end
 
+  # Use equal? for == (and not Comparable version)
+  alias_method :==, :equal?
+
   def capitalize
     to_s.capitalize.to_sym
   end


### PR DESCRIPTION
Significantly faster for the case of different symbols:

```ruby
require 'benchmark/ips'
Benchmark.ips do |b|
  b.report("Symbol#==") do
    :a == :b
  end
end
```

Before:
Symbol#==      2.712M (± 3.4%) i/s -     13.589M
After
Symbol#==      6.862M (± 2.6%) i/s -     34.413M