### PR TITLE
Change Comparable#== to use a recursion guard

### DIFF
--- a/kernel/common/comparable.rb
+++ b/kernel/common/comparable.rb
@@ -2,14 +2,16 @@ module Comparable
   def ==(other)
     return true if equal?(other)
 
-    begin
-      unless comp = (self <=> other)
+    return false if Thread.detect_recursion(self, other) do
+      begin
+        unless comp = (self <=> other)
+          return false
+        end
+
+        return Comparable.compare_int(comp) == 0
+      rescue StandardError
         return false
       end
-
-      return Comparable.compare_int(comp) == 0
-    rescue StandardError, SystemStackError
-      return false
     end
   end
 

--- a/spec/ruby/core/comparable/equal_value_spec.rb
+++ b/spec/ruby/core/comparable/equal_value_spec.rb
@@ -65,4 +65,19 @@ describe "Comparable#==" do
       (@raise_sub_standard_error == @b).should be_false
     end
   end
+
+  context "when #<=> is not defined" do
+    before :each do
+      @a = ComparableSpecs::WithoutCompareDefined.new
+      @b = ComparableSpecs::WithoutCompareDefined.new
+    end
+
+    it "returns true for identical objects" do
+      @a.should == @a
+    end
+
+    it "returns false and does not recurse infinitely" do
+      @a.should_not == @b
+    end
+  end
 end

--- a/spec/ruby/core/comparable/equal_value_spec.rb
+++ b/spec/ruby/core/comparable/equal_value_spec.rb
@@ -80,4 +80,20 @@ describe "Comparable#==" do
       @a.should_not == @b
     end
   end
+
+  context "when #<=> calls super" do
+    before :each do
+      @a = ComparableSpecs::CompareCallingSuper.new
+      @b = ComparableSpecs::CompareCallingSuper.new
+    end
+
+    it "returns true for identical objects" do
+      @a.should == @a
+    end
+
+    it "calls the defined #<=> only once for different objects" do
+      @a.should_not == @b
+      @a.calls.should == 1
+    end
+  end
 end

--- a/spec/ruby/core/comparable/fixtures/classes.rb
+++ b/spec/ruby/core/comparable/fixtures/classes.rb
@@ -16,4 +16,19 @@ module ComparableSpecs
   class WithoutCompareDefined
     include Comparable
   end
+
+  class CompareCallingSuper
+    include Comparable
+
+    attr_reader :calls
+
+    def initialize
+      @calls = 0
+    end
+
+    def <=>(other)
+      @calls += 1
+      super(other)
+    end
+  end
 end

--- a/spec/ruby/core/comparable/fixtures/classes.rb
+++ b/spec/ruby/core/comparable/fixtures/classes.rb
@@ -12,4 +12,8 @@ module ComparableSpecs
       self.value <=> other.value
     end
   end
+
+  class WithoutCompareDefined
+    include Comparable
+  end
 end


### PR DESCRIPTION
Changes Comparable#== to use a recursion guard instead of rescuing a SystemStackError.

Stack overflows should generally not be caught and the user #<=> should be called only once (instead of 1214 in my environment).