### PR TITLE
Fix true/false frozen specs to operate on the proper values

### DIFF
--- a/spec/ruby/core/kernel/frozen_spec.rb
+++ b/spec/ruby/core/kernel/frozen_spec.rb
@@ -50,13 +50,13 @@ describe "Kernel#frozen?" do
 
   describe "on true" do
     it "returns true" do
-      nil.frozen?.should be_true
+      true.frozen?.should be_true
     end
   end
 
   describe "on false" do
     it "returns true" do
-      nil.frozen?.should be_true
+      false.frozen?.should be_true
     end
   end
 end


### PR DESCRIPTION
The 2.2 frozen specs for nil, true, and false were all operating on nil. This will fix the test cases, though they will still fail.