### PR TITLE
Rename `Float#negative?` to `Float#signbit?`

### DIFF
--- a/kernel/common/complex.rb
+++ b/kernel/common/complex.rb
@@ -277,7 +277,7 @@ class Complex < Numeric
   def to_s
     result = real.to_s
 
-    if imag.kind_of?(Float) ? !imag.nan? && imag.negative? : imag < 0
+    if imag.kind_of?(Float) ? !imag.nan? && imag.signbit? : imag < 0
       result << "-"
     else
       result << "+"

--- a/kernel/common/float.rb
+++ b/kernel/common/float.rb
@@ -57,7 +57,7 @@ class Float < Numeric
   def arg
     if nan?
       self
-    elsif negative?
+    elsif signbit?
       Math::PI
     else
       0
@@ -118,9 +118,9 @@ class Float < Numeric
 
   alias_method :magnitude, :abs
 
-  def negative?
-    Rubinius.primitive :float_negative
-    raise PrimitiveFailure, "Float#negative primitive failed"
+  def signbit?
+    Rubinius.primitive :float_signbit_p
+    raise PrimitiveFailure, "Float#signbit? primitive failed"
   end
 
   def +(other)

--- a/vm/builtin/float.cpp
+++ b/vm/builtin/float.cpp
@@ -457,7 +457,7 @@ namespace rubinius {
     return String::create(state, str, sz);
   }
 
-  Object* Float::negative(STATE) {
+  Object* Float::signbit_p(STATE) {
     return signbit(this->val) ? cTrue : cFalse;
   }
 

--- a/vm/builtin/float.hpp
+++ b/vm/builtin/float.hpp
@@ -129,8 +129,8 @@ namespace rubinius {
     // Rubinius.primitive :float_to_packed
     String* to_packed(STATE, Object* want_double);
 
-    // Rubinius.primitive :float_negative
-    Object* negative(STATE);
+    // Rubinius.primitive :float_signbit_p
+    Object* signbit_p(STATE);
 
     static int radix()      { return FLT_RADIX; }
     static int rounds()     { return FLT_ROUNDS; }


### PR DESCRIPTION
Hello,

Ruby 2.3 ships with a new `Numeric#negative?` method. Rubinius implements this method since b92c84f7, for internal usage though ; it delegates to the `signbit` C++ function.

However, `signbit`'s behavior can't match MRI `Float#negative?`'s one since the former operates on the sign while the latter operates on the value (see [here](http://git.io/vm1fg)).

This makes [a test](https://github.com/rails/rails/blob/0daf1619a0631f7a5022645aca3a39b6d1ab7d07/activesupport/test/core_ext/numeric_ext_test.rb#L444) to fail on the Rails test suite (the [same example](http://en.cppreference.com/w/cpp/numeric/math/signbit#Examples) is present in the `signbit`'s documentation and -0.0 is considered negative this time).

Moreover, if people rely on feature detection rather than version checking, they may wrongly assume that the current running Ruby is 2.3+ checking if a float respond to `#negative?`.

Have a nice day!