### PR TITLE
Allow passing strings to #public_constant and #private_constant

### DIFF
--- a/kernel/common/module.rb
+++ b/kernel/common/module.rb
@@ -130,6 +130,7 @@ class Module
   end
 
   def private_constant(*names)
+    names = names.map(&:to_sym)
     unknown_constants = names - @constant_table.keys
     if unknown_constants.size > 0
       raise NameError, "#{unknown_constants.size > 1 ? 'Constants' : 'Constant'} #{unknown_constants.map{|e| "#{name}::#{e}"}.join(', ')} undefined"
@@ -141,6 +142,7 @@ class Module
   end
 
   def public_constant(*names)
+    names = names.map(&:to_sym)
     unknown_constants = names - @constant_table.keys
     if unknown_constants.size > 0
       raise NameError, "#{unknown_constants.size > 1 ? 'Constants' : 'Constant'} #{unknown_constants.map{|e| "#{name}::#{e}"}.join(', ')} undefined"

--- a/spec/ruby/core/module/private_constant_spec.rb
+++ b/spec/ruby/core/module/private_constant_spec.rb
@@ -11,6 +11,14 @@ describe "Module#private_constant" do
     end.should raise_error(NameError)
   end
 
+  it "accepts strings as constant names" do
+    cls = Class.new
+    cls.const_set :Foo, true
+    cls.send :private_constant, "Foo"
+
+    lambda { cls::Foo }.should raise_error(NameError)
+  end
+
   ruby_bug "[ruby-list:48559]", "1.9.3" do
     it "accepts multiple names" do
       mod = Module.new

--- a/spec/ruby/core/module/public_constant_spec.rb
+++ b/spec/ruby/core/module/public_constant_spec.rb
@@ -11,6 +11,16 @@ describe "Module#public_constant" do
     end.should raise_error(NameError)
   end
 
+  it "accepts strings as constant names" do
+    cls = Class.new
+    cls.const_set :Foo, true
+
+    cls.send :private_constant, :Foo
+    cls.send :public_constant, "Foo"
+
+    cls::Foo.should == true
+  end
+
   # [ruby-list:48558]
   it "accepts multiple names" do
     mod = Module.new


### PR DESCRIPTION
Hello,

This is a tiny patch that makes `#private_constant` and `#public_constant` accept strings as arguments. The maintained constants table is dealing with symbols but these methods can take strings ; it's pretty common to pass `class.name` as an argument.

MRI is doing the [symbol conversion](https://github.com/ruby/ruby/blob/1782dd8cd753401578ae19ea8be285f9d41bcde5/variable.c#L2593) even though the documentation sets ["symbol" as the given argument](https://github.com/ruby/ruby/blob/1782dd8cd753401578ae19ea8be285f9d41bcde5/variable.c#L2618).

The Active Record test suite doesn't run at all on Rubinius since `has_and_belongs_to_many` relies on this.

Have a nice day.