### PR TITLE
Implement {Method,UnboundMethod}#super_method

### DIFF
--- a/kernel/common/method.rb
+++ b/kernel/common/method.rb
@@ -158,6 +158,20 @@ class Method
     UnboundMethod.new(@defined_in, @executable, @receiver.class, @name)
   end
 
+  def super_method
+    superclass = @defined_in.direct_superclass
+
+    if superclass
+      mod, entry = superclass.lookup_method(@name)
+
+      if entry && entry.visibility != :undef
+        return Method.new(@receiver, superclass, entry.method, @name)
+      end
+    end
+
+    return nil
+  end
+
 end
 
 ##
@@ -287,5 +301,19 @@ class UnboundMethod
     else
       @defined_in
     end
+  end
+
+  def super_method
+    superclass = @defined_in.direct_superclass
+
+    if superclass
+      mod, entry = superclass.lookup_method(@name)
+
+      if entry && entry.visibility != :undef
+        return UnboundMethod.new(superclass, entry.method, @defined_in, @name)
+      end
+    end
+
+    return nil
   end
 end

--- a/spec/ruby/core/method/super_method_spec.rb
+++ b/spec/ruby/core/method/super_method_spec.rb
@@ -22,4 +22,18 @@ describe "Method#super_method" do
     sss_meth.receiver.should == obj
     sss_meth.name.should == :overridden
   end
+
+  it "returns nil when there's no super method in the parent" do
+    method = Object.new.method(:method)
+    method.super_method.should == nil
+  end
+
+  it "returns nil when the parent's method is removed" do
+    object = MethodSpecs::B.new
+    method = object.method(:overridden)
+
+    MethodSpecs::A.class_eval { undef :overridden }
+
+    method.super_method.should == nil
+  end
 end

--- a/spec/ruby/core/unboundmethod/fixtures/classes.rb
+++ b/spec/ruby/core/unboundmethod/fixtures/classes.rb
@@ -73,7 +73,7 @@ module UnboundMethodSpecs
     def baz(a, b)
       return [__FILE__, self.class]
     end
-    def overriden; end
+    def overridden; end
   end
 
   class B < A

--- a/spec/ruby/core/unboundmethod/super_method_spec.rb
+++ b/spec/ruby/core/unboundmethod/super_method_spec.rb
@@ -9,4 +9,18 @@ describe "UnboundMethod#super_method" do
     meth = meth.super_method
     meth.should == UnboundMethodSpecs::A.instance_method(:overridden)
   end
+
+  it "returns nil when there's no super method in the parent" do
+    method = Object.instance_method(:method)
+    method.super_method.should == nil
+  end
+
+  it "returns nil when the parent's method is removed" do
+    object = UnboundMethodSpecs::B
+    method = object.instance_method(:overridden)
+
+    UnboundMethodSpecs::A.class_eval { undef :overridden }
+
+    method.super_method.should == nil
+  end
 end

--- a/spec/tags/ruby/core/method/super_method_tags.txt
+++ b/spec/tags/ruby/core/method/super_method_tags.txt
@@ -1,1 +1,0 @@
-fails: returns the method that would be called by super in the method

--- a/spec/tags/ruby/core/unboundmethod/super_method_tags.txt
+++ b/spec/tags/ruby/core/unboundmethod/super_method_tags.txt
@@ -1,1 +1,0 @@
-fails: returns the method that would be called by super in the method


### PR DESCRIPTION
Hello,

This is a tiny pull request that adds the `#super_method` method to the `Method` and `UnboundMethod` objects.

With this feature added, the method objects need to keep track of the ancestors chain. This is not a problem when the chain only contain parents of the class. This is, however, when a module is included inside it since we loose the previous ancestry chain.

The method is about [5 times slower](http://git.io/vmhpf) than the MRI implementation though. I don't know if it's acceptable.

Cross-refs #3264.

Have a nice day.