### PR TITLE
String#split should trim tail empty strings when the limit is zero

### DIFF
--- a/kernel/common/splitter.rb
+++ b/kernel/common/splitter.rb
@@ -32,7 +32,9 @@ module Rubinius
           return [string.dup] if limit == 1
           limited = true
         else
-          tail_empty = true
+          if limit < 0
+            tail_empty = true
+          end
           limited = false
         end
       end

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -103,6 +103,12 @@ describe "String#split with String" do
     "a\x00a b".split(' ').should == ["a\x00a", "b"]
   end
 
+  describe "when limit is zero" do
+    it "ignores leading and continuous whitespace when string is a single space" do
+      " now's  the time  ".split(' ', 0).should == ["now's", "the", "time"]
+    end
+  end
+
   it "splits between characters when its argument is an empty string" do
     "hi!".split("").should == ["h", "i", "!"]
     "hi!".split("", -1).should == ["h", "i", "!", ""]


### PR DESCRIPTION
Fix #3474