### PR TITLE
Specify `superclass` in respect to `prepend`

### DIFF
--- a/spec/ruby/core/module/prepend_spec.rb
+++ b/spec/ruby/core/module/prepend_spec.rb
@@ -6,6 +6,10 @@ describe "Module#prepend" do
     Module.should have_public_instance_method(:prepend, true)
   end
 
+  it "does not affect the superclass" do
+    Class.new { prepend Module.new }.superclass.should == Object
+  end
+
   it "calls #prepend_features(self) in reversed order on each module" do
     ScratchPad.record []
 


### PR DESCRIPTION
This was unspecified/recently merged to ruby/rubyspec. Rubinius does
the Right Thing :tm: