### PR TITLE
File#utime: Don't check for usec resolution on Darwin

### DIFF
--- a/spec/ruby/core/file/utime_spec.rb
+++ b/spec/ruby/core/file/utime_spec.rb
@@ -22,28 +22,30 @@ describe "File.utime" do
     File.mtime(@file2).to_i.should be_close(@mtime.to_i, 2)
   end
 
-  it "sets and gets microseconds from Time arguments" do
-    File.utime(@atime, @mtime, @file1, @file2)
-    File.atime(@file1).usec.should equal(10)
-    File.mtime(@file1).usec.should equal(10)
-    File.atime(@file2).usec.should equal(10)
-    File.mtime(@file2).usec.should equal(10)
-  end
+  platform_is_not :darwin do
+    it "sets and gets microseconds from Time arguments" do
+      File.utime(@atime, @mtime, @file1, @file2)
+      File.atime(@file1).usec.should equal(10)
+      File.mtime(@file1).usec.should equal(10)
+      File.atime(@file2).usec.should equal(10)
+      File.mtime(@file2).usec.should equal(10)
+    end
 
-  it "sets and gets microseconds from Float arguments" do
-    File.utime(0.0001, 0.0001, @file1, @file2)
-    File.atime(@file1).usec.should equal(100)
-    File.mtime(@file1).usec.should equal(100)
-    File.atime(@file2).usec.should equal(100)
-    File.mtime(@file2).usec.should equal(100)
-  end
+    it "sets and gets microseconds from Float arguments" do
+      File.utime(0.0001, 0.0001, @file1, @file2)
+      File.atime(@file1).usec.should equal(100)
+      File.mtime(@file1).usec.should equal(100)
+      File.atime(@file2).usec.should equal(100)
+      File.mtime(@file2).usec.should equal(100)
+    end
 
-  it "sets and gets microseconds from Rational arguments" do
-    File.utime(Rational(1, 1000), Rational(1, 1000), @file1, @file2)
-    File.atime(@file1).usec.should equal(1000)
-    File.mtime(@file1).usec.should equal(1000)
-    File.atime(@file2).usec.should equal(1000)
-    File.mtime(@file2).usec.should equal(1000)
+    it "sets and gets microseconds from Rational arguments" do
+      File.utime(Rational(1, 1000), Rational(1, 1000), @file1, @file2)
+      File.atime(@file1).usec.should equal(1000)
+      File.mtime(@file1).usec.should equal(1000)
+      File.atime(@file2).usec.should equal(1000)
+      File.mtime(@file2).usec.should equal(1000)
+    end
   end
 
   it "uses the current times if two nil values are passed" do


### PR DESCRIPTION
Fixes failing specs discussed in #3502 

```bash
andre@MacPro:~/rubinius$ bin/mspec -tr spec/ruby/core/file/utime_spec.rb
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin14]
...

Finished in 0.001898 seconds

1 file, 3 examples, 10 expectations, 0 failures, 0 errors
andre@MacPro:~/rubinius$ bin/mspec -tx spec/ruby/core/file/utime_spec.rb
rubinius 2.5.8.c106 (2.1.0 4de8eb50 2015-10-16 3.5.1 JI) [x86_64-darwin14.5.0]
...

Finished in 0.005834 seconds

1 file, 3 examples, 10 expectations, 0 failures, 0 errors
```