### PR TITLE
Include zlib linker flag if not building with the vendored one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ notifications:
     on_start: always
 
 env:
-  - RVM=2.0.0 LANG="en_US.UTF-8"
+  - RVM=2.2.0 LANG="en_US.UTF-8"
 
 os:
   - linux

--- a/rakelib/blueprint.rb
+++ b/rakelib/blueprint.rb
@@ -179,6 +179,8 @@ Daedalus.blueprint do |i|
     end
     gcc.add_library zlib
     files << zlib
+  else
+    gcc.ldflags << "-lz"
   end
 
   if Rubinius::BUILD_CONFIG[:vendor_libsodium]


### PR DESCRIPTION
Apparently building with LLVM enabled includes this flag, probably because of using `--system-libs`, so  building without LLVM fails because it can't link against zlib.