### PR TITLE
Compile fails on arm because of unknown opcode.

### DIFF
--- a/vendor/libffi/src/arm/sysv.S
+++ b/vendor/libffi/src/arm/sysv.S
@@ -396,7 +396,7 @@ LSYM(Lbase_args):
 	beq	LSYM(Lepilogue_vfp)
 
 	cmp	r3, #FFI_TYPE_SINT64
-	stmeqia	r2, {r0, r1}
+	stmiaeq r2, {r0, r1}
 	beq	LSYM(Lepilogue_vfp)
 
 	cmp	r3, #FFI_TYPE_FLOAT


### PR DESCRIPTION
"stmeqia" is an mistyped and unknown opcode.
Replaced with "stmiaeq".
Compiling ffi on ARM now possible.
Maybe an update do a newer version of libffi is also possible.

Compiling of rubinius failed later with "no memory barrier implementation" in atomic.hpp
:(