### PR TITLE
Removed Socketable/io_accept primitive

### DIFF
--- a/kernel/bootstrap/io.rb
+++ b/kernel/bootstrap/io.rb
@@ -145,13 +145,6 @@ class IO
     raise PrimitiveFailure, "io_socket_read failed"
   end
 
-  module Socketable
-    def accept
-      Rubinius.primitive :io_accept
-      raise PrimitiveFailure, "io_accept failed"
-    end
-  end
-
   module TransferIO
     def send_io
       Rubinius.primitive :io_send_io

--- a/vm/builtin/io.cpp
+++ b/vm/builtin/io.cpp
@@ -1230,40 +1230,6 @@ failed: /* try next '*' position */
 
 
   /** Socket methods */
-  Object* IO::accept(STATE, CallFrame* calling_environment) {
-    int fd = descriptor()->to_native();
-    int new_fd = -1;
-
-    struct sockaddr_storage socka;
-    socklen_t sock_len = sizeof(socka);
-
-  retry:
-    state->vm()->interrupt_with_signal();
-    state->vm()->thread->sleep(state, cTrue);
-
-    {
-      GCIndependent guard(state, calling_environment);
-      new_fd = ::accept(fd, (struct sockaddr*)&socka, &sock_len);
-    }
-
-    state->vm()->thread->sleep(state, cFalse);
-    state->vm()->clear_waiter();
-
-    if(new_fd == -1) {
-      if(errno == EAGAIN || errno == EINTR) {
-        if(!state->check_async(calling_environment)) return NULL;
-        ensure_open(state);
-        goto retry;
-      } else {
-        Exception::errno_error(state, "accept(2) failed");
-      }
-
-      return NULL;
-    }
-
-    return Fixnum::from(new_fd);
-  }
-
   static const int cmsg_space = CMSG_SPACE(sizeof(int));
 
   Object* IO::send_io(STATE, IO* io) {

--- a/vm/builtin/io.hpp
+++ b/vm/builtin/io.hpp
@@ -121,9 +121,6 @@ namespace rubinius {
     // Rubinius.primitive :io_close
     Object* close(STATE);
 
-    // Rubinius.primitive :io_accept
-    Object* accept(STATE, CallFrame* calling_environment);
-
     // Rubinius.primitive :io_send_io
     Object* send_io(STATE, IO* io);
 


### PR DESCRIPTION
This is no longer in use by rubysl-socket and serves no further purpose as far as I can find. This should not be merged until rubysl-socket has been released as otherwise local installations will break (due to current rubysl-socket still using this code).