### PR TITLE
Break up old/new license & clarify what we use

### DIFF
--- a/BSD_LICENSE
+++ b/BSD_LICENSE
@@ -1,0 +1,27 @@
+BSD 3-clause License
+
+Copyright (c) 2007-2015, Evan Phoenix and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Rubinius nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -362,31 +362,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
-
-BSD 3-clause License
-
-Copyright (c) 2007-2015, Evan Phoenix and contributors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of Rubinius nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README
+++ b/README
@@ -35,8 +35,9 @@ The following Ruby features are not supported on Rubinius:
 
 3. License
 
-Rubinius uses the MPL-2.0 license. See LICENSE for details.
-
+Rubinius uses the MPL-2.0 license. See LICENSE for details. Contributions made
+prior to January 3rd, 2016 are licensed under the old BSD 3-clause license. A
+copy of this license can be found in the file "BSD_LICENSE".
 
 4. Installing Rubinius from Source
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ The following Ruby features are not supported on Rubinius:
 
 ### License
 
-Rubinius uses the MPL-2.0 license. See LICENSE for details.
-
+Rubinius uses the MPL-2.0 license. See LICENSE for details. Contributions made
+prior to January 3rd, 2016 are licensed under the old BSD 3-clause license. A
+copy of this license can be found in the file "BSD_LICENSE".
 
 ### Installing Rubinius from Source
 


### PR DESCRIPTION
I decided to move the BSD license to a separate file as I feel uncomfortable adding any extra clauses to the MPL 2.0 license. I also feel it would be too easy to miss the BSD license at the bottom of the already long MPL 2.0 license. As far as I'm aware the BSD license does not disallow renaming license files, thus I believe we should be fine.

cc @brixen @hintjens