### PR TITLE
Dig with no arguments should raise ArgumentError

### DIFF
--- a/kernel/common/array.rb
+++ b/kernel/common/array.rb
@@ -597,13 +597,13 @@ class Array
     self
   end
 
-  def dig(*sequence)
-    item = self[sequence.shift]
-    return item if sequence.empty? || item.nil?
+  def dig(index, *remaining_indeces)
+    item = self[index]
+    return item if remaining_indeces.empty? || item.nil?
 
     raise TypeError, "#{item.class} does not have #dig method" unless item.respond_to?(:dig)
 
-    item.dig(*sequence)
+    item.dig(*remaining_indeces)
   end
 
   def each_index

--- a/kernel/common/hash.rb
+++ b/kernel/common/hash.rb
@@ -322,13 +322,13 @@ class Hash
     return yield(key) if block_given?
   end
 
-  def dig(*sequence)
-    item = self[sequence.shift]
-    return item if sequence.empty? || item.nil?
+  def dig(key, *remaining_keys)
+    item = self[key]
+    return item if remaining_keys.empty? || item.nil?
 
     raise TypeError, "#{item.class} does not have #dig method" unless item.respond_to?(:dig)
 
-    item.dig(*sequence)
+    item.dig(*remaining_keys)
   end
 
   def each_item

--- a/kernel/common/struct.rb
+++ b/kernel/common/struct.rb
@@ -181,17 +181,17 @@ class Struct
     return instance_variable_set(:"@#{var}", obj)
   end
 
-  def dig(*sequence)
+  def dig(key, *remaining_keys)
     item = begin
-             self[sequence.shift]
-            rescue NameError
-              nil
-            end
-    return item if sequence.empty? || item.nil?
+             self[key]
+           rescue NameError
+             nil
+           end
+    return item if remaining_keys.empty? || item.nil?
 
     raise TypeError, "#{item.class} does not have #dig method" unless item.respond_to?(:dig)
 
-    item.dig(*sequence)
+    item.dig(*remaining_keys)
   end
 
   def eql?(other)

--- a/spec/ruby/core/array/dig_spec.rb
+++ b/spec/ruby/core/array/dig_spec.rb
@@ -19,6 +19,12 @@ describe "Array#dig" do
     lambda { a.dig(0, 1) }.should raise_error(TypeError)
   end
 
+  it "raises an ArgumentError if no arguments provided" do
+    a = []
+
+    lambda { a.dig }.should raise_error(ArgumentError)
+  end
+
   it "returns nil if any intermediate step is nil" do
     a = [[1, [2, 3]]]
 

--- a/spec/ruby/core/hash/dig_spec.rb
+++ b/spec/ruby/core/hash/dig_spec.rb
@@ -25,6 +25,12 @@ describe "Hash#dig" do
     lambda { h.dig(:foo, 3) }.should raise_error(TypeError)
   end
 
+  it "raises an ArgumentError if no arguments provided" do
+    h = {}
+
+    lambda { h.dig }.should raise_error(ArgumentError)
+  end
+
   it "calls #dig on any intermediate step with the rest of the sequence as arguments" do
     o = Object.new
     h = new_hash(foo: o)

--- a/spec/ruby/core/struct/dig_spec.rb
+++ b/spec/ruby/core/struct/dig_spec.rb
@@ -24,6 +24,10 @@ describe "Struct#dig" do
     lambda { instance.dig(:a, 3) }.should raise_error(TypeError)
   end
 
+  it "raises an ArgumentError if no arguments provided" do
+    lambda { @instance.dig }.should raise_error(ArgumentError)
+  end
+
   it "calls #dig on any intermediate step with the rest of the sequence as arguments" do
     obj = Object.new
     instance = @klass.new(obj)


### PR DESCRIPTION
Trying to call `#dig` methods using cruby 2.3.0 + gives you:
```ruby
ArgumentError: wrong number of arguments (given 0, expected 1+)
```

However, the current Rubinius implementation will instead try to use `nil` as a key. This is inconsistent and unintuitive:
```ruby
[].dig # => TypeError: Coercion error: nil.to_int => Fixnum failed
{}.dig # => nil
{nil => 42}.dig # => 42
```