### PR TITLE
add failing spec for String.new with optional encoding argument

### DIFF
--- a/spec/ruby/core/string/new_spec.rb
+++ b/spec/ruby/core/string/new_spec.rb
@@ -7,6 +7,12 @@ describe "String.new" do
     str.should be_an_instance_of(String)
   end
 
+  it "accepts an encoding argument" do
+    str = String.new("\xA4\xA2", encoding: 'euc-jp')
+
+    str.encoding.should == Encoding::EUC_JP
+  end
+
   it "returns a fully-formed String" do
     str = String.new
     str.size.should == 0

--- a/spec/tags/ruby/core/string/new_tags.txt
+++ b/spec/tags/ruby/core/string/new_tags.txt
@@ -1,0 +1,1 @@
+fails:String.new accepts an encoding argument


### PR DESCRIPTION
Related to #3559 