### PR TITLE
Fix Enumerable#sort_by when #map does not return an array

### DIFF
--- a/kernel/common/enumerable.rb
+++ b/kernel/common/enumerable.rb
@@ -355,7 +355,7 @@ module Enumerable
     sort_values = map do
       element = Rubinius.single_block_arg
       SortedElement.new(element, yield(element))
-    end
+    end.to_a
 
     # Now sort the tuple according to the sort by value
     sort_values.sort!

--- a/spec/ruby/core/enumerable/fixtures/classes.rb
+++ b/spec/ruby/core/enumerable/fixtures/classes.rb
@@ -300,4 +300,33 @@ module EnumerableSpecs
       super.freeze
     end
   end
+
+  class MapReturnsEnumerable
+    include Enumerable
+
+    class EnumerableMapping
+      include Enumerable
+
+      def initialize(items, block)
+        @items = items
+        @block = block
+      end
+
+      def each
+        @items.each do |i|
+          yield @block.call(i)
+        end
+      end
+    end
+
+    def each
+      yield 1
+      yield 2
+      yield 3
+    end
+
+    def map(&block)
+      EnumerableMapping.new(self, block)
+    end
+  end
 end # EnumerableSpecs utility classes

--- a/spec/ruby/core/enumerable/sort_by_spec.rb
+++ b/spec/ruby/core/enumerable/sort_by_spec.rb
@@ -27,5 +27,10 @@ describe "Enumerable#sort_by" do
     multi.sort_by {|e| e.size}.should == [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
   end
 
+  it "returns an array of elements when a block is supplied and #map returns an enumerable" do
+    b = EnumerableSpecs::MapReturnsEnumerable.new
+    b.sort_by{ |x| -x }.should == [3, 2, 1]
+  end
+
   it_behaves_like :enumerable_enumeratorized_with_origin_size, :sort_by
 end


### PR DESCRIPTION
See #3592 for a description of the issue fixed here.