### PR TITLE
Clean up define method

### DIFF
--- a/core/block_environment.rb
+++ b/core/block_environment.rb
@@ -104,7 +104,7 @@ module Rubinius
       end
 
       def scope
-        nil
+        @block_env.scope
       end
     end
 

--- a/core/block_environment.rb
+++ b/core/block_environment.rb
@@ -103,10 +103,8 @@ module Rubinius
         @block_env.line
       end
 
-      def for_define_method(name, meth)
-        code  = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
-
-        [code, nil]
+      def scope
+        nil
       end
     end
 

--- a/core/block_environment.rb
+++ b/core/block_environment.rb
@@ -102,6 +102,12 @@ module Rubinius
       def defined_line
         @block_env.line
       end
+
+      def for_define_method(name, meth)
+        code  = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
+
+        [code, nil]
+      end
     end
 
     def from_proc?

--- a/core/compiled_code.rb
+++ b/core/compiled_code.rb
@@ -212,6 +212,12 @@ module Rubinius
       raise ArgumentError, "Unable to retrieve breakpoint status on #{inspect} at bytecode address #{ip}"
     end
 
+    def for_define_method(name, meth)
+      code  = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
+
+      [code, @scope]
+    end
+
     class Script
       attr_accessor :compiled_code
       attr_accessor :file_path

--- a/core/compiled_code.rb
+++ b/core/compiled_code.rb
@@ -212,12 +212,6 @@ module Rubinius
       raise ArgumentError, "Unable to retrieve breakpoint status on #{inspect} at bytecode address #{ip}"
     end
 
-    def for_define_method(name, meth)
-      code  = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
-
-      [code, @scope]
-    end
-
     class Script
       attr_accessor :compiled_code
       attr_accessor :file_path

--- a/core/delegated_method.rb
+++ b/core/delegated_method.rb
@@ -31,5 +31,9 @@ module Rubinius
     def source_location
       @receiver.source_location
     end
+
+    def for_define_method(name, meth)
+      [self, nil]
+    end
   end
 end

--- a/core/delegated_method.rb
+++ b/core/delegated_method.rb
@@ -32,8 +32,8 @@ module Rubinius
       @receiver.source_location
     end
 
-    def for_define_method(name, meth)
-      [self, nil]
+    def scope
+      nil
     end
   end
 end

--- a/core/method.rb
+++ b/core/method.rb
@@ -338,4 +338,22 @@ class UnboundMethod
 
     return nil
   end
+
+  def for_define_method(name, klass)
+    Rubinius::Type.bindable_method? self.defined_in, klass
+
+    if @executable.kind_of? Rubinius::DelegatedMethod
+      code = @executable
+      scope = nil
+    else
+      code = Rubinius::DelegatedMethod.new(name, :call_on_instance, self, true)
+      if @executable.kind_of? Rubinius::CompiledCode
+        scope = @executable.scope
+      else
+        scope = nil
+      end
+    end
+
+    [code, scope]
+  end
 end

--- a/core/method.rb
+++ b/core/method.rb
@@ -172,6 +172,28 @@ class Method
     return nil
   end
 
+  def for_define_method(name, klass)
+    Rubinius::Type.bindable_method? self.defined_in, klass
+
+    # We see through delegated methods because code creates these crazy calls
+    # to define_method over and over again and if we don't check, we create
+    # a huge delegated method chain. So instead, just see through them at one
+    # level always.
+    if @executable.kind_of? Rubinius::DelegatedMethod
+      code = @executable
+      scope = nil
+    else
+      code = Rubinius::DelegatedMethod.new(name, :call_on_instance, self.unbind, true)
+      if @executable.kind_of? Rubinius::CompiledCode
+        scope = @executable.scope
+      else
+        scope = nil
+      end
+    end
+
+    [code, scope]
+  end
+
 end
 
 ##

--- a/core/method.rb
+++ b/core/method.rb
@@ -175,25 +175,8 @@ class Method
   def for_define_method(name, klass)
     Rubinius::Type.bindable_method? self.defined_in, klass
 
-    # We see through delegated methods because code creates these crazy calls
-    # to define_method over and over again and if we don't check, we create
-    # a huge delegated method chain. So instead, just see through them at one
-    # level always.
-    if @executable.kind_of? Rubinius::DelegatedMethod
-      code = @executable
-      scope = nil
-    else
-      code = Rubinius::DelegatedMethod.new(name, :call_on_instance, self.unbind, true)
-      if @executable.kind_of? Rubinius::CompiledCode
-        scope = @executable.scope
-      else
-        scope = nil
-      end
-    end
-
-    [code, scope]
+    @executable.for_define_method(name, self.unbind)
   end
-
 end
 
 ##
@@ -342,18 +325,6 @@ class UnboundMethod
   def for_define_method(name, klass)
     Rubinius::Type.bindable_method? self.defined_in, klass
 
-    if @executable.kind_of? Rubinius::DelegatedMethod
-      code = @executable
-      scope = nil
-    else
-      code = Rubinius::DelegatedMethod.new(name, :call_on_instance, self, true)
-      if @executable.kind_of? Rubinius::CompiledCode
-        scope = @executable.scope
-      else
-        scope = nil
-      end
-    end
-
-    [code, scope]
+    @executable.for_define_method(name, self)
   end
 end

--- a/core/module.rb
+++ b/core/module.rb
@@ -444,21 +444,7 @@ class Module
 
     case meth
     when Proc
-      if meth.ruby_method
-        code = Rubinius::DelegatedMethod.new(name, :call, meth, false)
-        if meth.ruby_method.executable.kind_of? Rubinius::CompiledCode
-          scope = meth.ruby_method.executable.scope
-        else
-          scope = nil
-        end
-      else
-        be = meth.block.dup
-        be.change_name name
-        code = Rubinius::BlockEnvironment::AsMethod.new(be)
-        meth = meth.dup
-        meth.lambda_style!
-        scope = meth.block.scope
-      end
+      code, scope = meth.for_define_method(name)
     when Method
       Rubinius::Type.bindable_method? meth.defined_in, self.class
 

--- a/core/module.rb
+++ b/core/module.rb
@@ -442,7 +442,11 @@ class Module
 
     name = Rubinius::Type.coerce_to_symbol name
 
-    code, scope = meth.for_define_method(name, self.class)
+    if meth.respond_to?(:for_define_method)
+      code, scope = meth.for_define_method(name, self.class)
+    else
+      raise TypeError, "wrong argument type #{meth.class} (expected Proc/Method)"
+    end
 
     Rubinius.add_method name, code, self, scope, 0, :public
 

--- a/core/module.rb
+++ b/core/module.rb
@@ -442,30 +442,7 @@ class Module
 
     name = Rubinius::Type.coerce_to_symbol name
 
-    case meth
-    when Proc
-      code, scope = meth.for_define_method(name, nil)
-    when Method
-      code, scope = meth.for_define_method(name, self.class)
-    when UnboundMethod
-      Rubinius::Type.bindable_method? meth.defined_in, self.class
-
-      exec = meth.executable
-      # Same reasoning as above.
-      if exec.kind_of? Rubinius::DelegatedMethod
-        code = exec
-        scope = nil
-      else
-        code = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
-        if exec.kind_of? Rubinius::CompiledCode
-          scope = exec.scope
-        else
-          scope = nil
-        end
-      end
-    else
-      raise TypeError, "wrong argument type #{meth.class} (expected Proc/Method)"
-    end
+    code, scope = meth.for_define_method(name, self.class)
 
     Rubinius.add_method name, code, self, scope, 0, :public
 

--- a/core/module.rb
+++ b/core/module.rb
@@ -444,26 +444,9 @@ class Module
 
     case meth
     when Proc
-      code, scope = meth.for_define_method(name)
+      code, scope = meth.for_define_method(name, nil)
     when Method
-      Rubinius::Type.bindable_method? meth.defined_in, self.class
-
-      exec = meth.executable
-      # We see through delegated methods because code creates these crazy calls
-      # to define_method over and over again and if we don't check, we create
-      # a huge delegated method chain. So instead, just see through them at one
-      # level always.
-      if exec.kind_of? Rubinius::DelegatedMethod
-        code = exec
-        scope = nil
-      else
-        code = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth.unbind, true)
-        if exec.kind_of? Rubinius::CompiledCode
-          scope = exec.scope
-        else
-          scope = nil
-        end
-      end
+      code, scope = meth.for_define_method(name, self.class)
     when UnboundMethod
       Rubinius::Type.bindable_method? meth.defined_in, self.class
 

--- a/core/native_method.rb
+++ b/core/native_method.rb
@@ -79,10 +79,8 @@ module Rubinius
       @file
     end
 
-    def for_define_method(name, meth)
-      code  = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
-
-      [code, nil]
+    def scope
+      nil
     end
   end
 end

--- a/core/native_method.rb
+++ b/core/native_method.rb
@@ -78,5 +78,11 @@ module Rubinius
     def active_path
       @file
     end
+
+    def for_define_method(name, meth)
+      code  = Rubinius::DelegatedMethod.new(name, :call_on_instance, meth, true)
+
+      [code, nil]
+    end
   end
 end

--- a/core/proc.rb
+++ b/core/proc.rb
@@ -244,6 +244,26 @@ class Proc
     copy
   end
 
+  def for_define_method(name)
+    if @ruby_method
+      code = Rubinius::DelegatedMethod.new(name, :call, self, false)
+      if @ruby_method.executable.kind_of? Rubinius::CompiledCode
+        scope = @ruby_method.executable.scope
+      else
+        scope = nil
+      end
+    else
+      be = @block.dup
+      be.change_name name
+      code = Rubinius::BlockEnvironment::AsMethod.new(be)
+      meth = self.dup
+      meth.lambda_style!
+      scope = meth.block.scope
+    end
+
+    [code, scope]
+  end
+
   def self.from_method(meth)
     if meth.kind_of? Method
       return __from_method__(meth)

--- a/core/proc.rb
+++ b/core/proc.rb
@@ -251,10 +251,11 @@ class Proc
       be = @block.dup
       be.change_name name
 
-      executable = Rubinius::BlockEnvironment::AsMethod.new(be)
+      duped_proc = self.dup
+      duped_proc.lambda_style!
 
-      code  = executable
-      scope = executable.scope
+      code  = Rubinius::BlockEnvironment::AsMethod.new(be)
+      scope = duped_proc.block.scope
     end
 
     [code, scope]

--- a/core/proc.rb
+++ b/core/proc.rb
@@ -246,12 +246,7 @@ class Proc
 
   def for_define_method(name, klass)
     if @ruby_method
-      code = Rubinius::DelegatedMethod.new(name, :call, self, false)
-      if @ruby_method.executable.kind_of? Rubinius::CompiledCode
-        scope = @ruby_method.executable.scope
-      else
-        scope = nil
-      end
+      code, scope = @ruby_method.for_define_method(name, klass, self)
     else
       be = @block.dup
       be.change_name name

--- a/core/proc.rb
+++ b/core/proc.rb
@@ -244,7 +244,7 @@ class Proc
     copy
   end
 
-  def for_define_method(name)
+  def for_define_method(name, klass)
     if @ruby_method
       code = Rubinius::DelegatedMethod.new(name, :call, self, false)
       if @ruby_method.executable.kind_of? Rubinius::CompiledCode

--- a/core/proc.rb
+++ b/core/proc.rb
@@ -250,10 +250,9 @@ class Proc
     else
       be = @block.dup
       be.change_name name
-      code = Rubinius::BlockEnvironment::AsMethod.new(be)
-      meth = self.dup
-      meth.lambda_style!
-      scope = meth.block.scope
+
+      code  = Rubinius::BlockEnvironment::AsMethod.new(be)
+      scope = code.block_env.scope
     end
 
     [code, scope]

--- a/core/proc.rb
+++ b/core/proc.rb
@@ -251,8 +251,10 @@ class Proc
       be = @block.dup
       be.change_name name
 
-      code  = Rubinius::BlockEnvironment::AsMethod.new(be)
-      scope = code.block_env.scope
+      executable = Rubinius::BlockEnvironment::AsMethod.new(be)
+
+      code  = executable
+      scope = executable.scope
     end
 
     [code, scope]

--- a/spec/ruby/core/module/define_method_spec.rb
+++ b/spec/ruby/core/module/define_method_spec.rb
@@ -180,6 +180,26 @@ describe "Module#define_method" do
     lambda{o.other_inspect}.should raise_error(NoMethodError)
   end
 
+  it "accepts a proc from a method" do
+    class ProcFromMethod
+      attr_accessor :data
+      def cool_method
+        "data is #{@data}"
+      end
+    end
+
+    o = ProcFromMethod.new
+    o.data = :foo
+
+    p     = o.method(:cool_method).to_proc
+    klass = Class.new(ProcFromMethod)
+    klass.send(:define_method, :other_cool_method, p)
+
+    object = klass.new
+    object.data = :bar
+    object.other_cool_method.should == "data is foo"
+  end
+
   it "maintains the Proc's scope" do
     class DefineMethodByProcClass
       in_scope = true

--- a/spec/ruby/core/module/define_method_spec.rb
+++ b/spec/ruby/core/module/define_method_spec.rb
@@ -188,16 +188,16 @@ describe "Module#define_method" do
       end
     end
 
-    o = ProcFromMethod.new
-    o.data = :foo
+    object1 = ProcFromMethod.new
+    object1.data = :foo
 
-    p     = o.method(:cool_method).to_proc
+    method_proc = object1.method(:cool_method).to_proc
     klass = Class.new(ProcFromMethod)
-    klass.send(:define_method, :other_cool_method, p)
+    klass.send(:define_method, :other_cool_method, &method_proc)
 
-    object = klass.new
-    object.data = :bar
-    object.other_cool_method.should == "data is foo"
+    object2 = klass.new
+    object2.data = :bar
+    object2.other_cool_method.should == "data is foo"
   end
 
   it "maintains the Proc's scope" do


### PR DESCRIPTION
First I tried to ship most of the logic towards executables and use `Method#for_define_method` and `UnbindMethod#for_define_method` as thin wrapper around `Executable#for_define_method`.
The result can be seen here: https://github.com/rubinius/rubinius/commit/7cd43157d6efe0a4b4a534ef944df8563a062979

When the need to support Proc again came up it was clear that shipping most of the stuff into executables was not quite doable, or at least I was not able to do it properly.
Therefore I moved it up into `Method` and `UnboundMethod` where again we have nested conditionals (but at least no more nested conditionals in a big fat case statement)

As for `BlockEnvironment::AsMethod#scope` I'm not sure if this should return nil or the scope of `@block_env`. In the previous implementation `define_method` for a `BlockEnvironment::AsMethod` executable used nil as scope. Also when changing it to `@block_env.scope` all ci specs are still passing so probably this means there are missing specs for that.