### PR TITLE
Protect self and CompiledCode from GC before handling arguments

### DIFF
--- a/vm/stack_variables.hpp
+++ b/vm/stack_variables.hpp
@@ -46,6 +46,10 @@ namespace rubinius {
       block_ = block;
     }
 
+    void set_self(Object* self) {
+      self_ = self;
+    }
+
     Object* self() const {
       return self_;
     }


### PR DESCRIPTION
When arguments are keywords, `GenericArguments::call` will call `Rubinius::Runtime.keyword_object?`, which results in allocating some objects. When the young zone is full, garbage collection is run, which could lead to forwarding the self and/or the CompiledCode objects without updating their references, resulting in a faulty behavior or crashes like in #3540.

However, I'm not sure about the solution, so a feedback would be appreciated :smiley: .