### PR TITLE
Compile in debug mode when in git submodule

### DIFF
--- a/configure
+++ b/configure
@@ -167,7 +167,7 @@ class Configure
     @ruby_libversion = @ruby_version.split(/\./)[0..1].join.to_i
 
     # Configure settings
-    @release_build = !git_directory
+    @release_build = !in_git?
   end
 
   # Set up system commands to run in cmd.exe on Windows. Either Windows

--- a/rakelib/release.rb
+++ b/rakelib/release.rb
@@ -3,6 +3,11 @@ def git_directory
   File.directory?(git_dir) && git_dir
 end
 
+def in_git?
+  git_dir = File.expand_path "../../.git", __FILE__
+  File.exist?(git_dir) && git_dir
+end
+
 def revision_file
   File.expand_path "../../.revision", __FILE__
 end


### PR DESCRIPTION
We currently compile in debug mode if there is a `.git` directory in the project
root.

This compiles Rubinius in debug mode even if `.git` is a file, so that
we compile in debug mode when rubinius is in a git submodule.