### PR TITLE
Remove Ruby from the build system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ vendor/cache/*
 
 .build_ruby
 .build_signature
+
+rubinius-runtime-core.tar.bz2
+rubinius-runtime-core.tar.bz2.sha512

--- a/configure
+++ b/configure
@@ -166,6 +166,7 @@ class Configure
     @ruby_libversion = @ruby_version.split(/\./)[0..1].join.to_i
 
     @build_bin = "#{@sourcedir}/build/bin"
+    @scriptsdir = "#{@sourcedir}/scripts"
 
     # Configure settings
     @release_build = !in_git?
@@ -1779,6 +1780,24 @@ int main() { return tgetnum(""); }
     end
   end
 
+  def fetch_core
+    @log.write "\nFetching runtime core..."
+
+    unless File.directory? "#{@sourcedir}/runtime/core"
+      system("#{@scriptsdir}/build_support.sh fetch_core")
+
+      failure "Unable to fetch runtime core" unless $?.success?
+    end
+  end
+
+  def setup_core
+    @log.write "\nSetting up runtime core..."
+
+    system("#{@scriptsdir}/build_support.sh setup_core")
+
+    failure "Unable to setup runtime core from archive" unless $?.success?
+  end
+
   def fetch_gems
     @log.write "\nFetching gems..."
     failed = false
@@ -1884,8 +1903,10 @@ int main() { return tgetnum(""); }
       verify_gems
     else
       fetch_gems
+      fetch_core
     end
     setup_gems
+    setup_core
     write_configure_files
     write_build_signature
 

--- a/machine/environment.cpp
+++ b/machine/environment.cpp
@@ -656,7 +656,7 @@ namespace rubinius {
   bool Environment::load_signature(std::string runtime) {
     std::string path = runtime;
 
-    path += "/signature";
+    path += "/core/signature";
 
     std::ifstream signature(path.c_str());
     if(signature) {

--- a/rakelib/core.rake
+++ b/rakelib/core.rake
@@ -95,6 +95,8 @@ end
 # Generate a digest of the Rubinius runtime files
 signature_file = "core/signature.rb"
 
+runtime_signature_file = "runtime/core/signature"
+
 runtime_gems_dir = BUILD_CONFIG[:runtime_gems_dir]
 bootstrap_gems_dir = BUILD_CONFIG[:bootstrap_gems_dir]
 
@@ -176,7 +178,7 @@ bootstrap_gem_files.each do |name|
 end
 
 namespace :compiler do
-  task :load => ['compiler:generate'] do
+  task :load do
     require "rubinius/bridge"
     require "rubinius/code/toolset"
 
@@ -189,8 +191,6 @@ namespace :compiler do
 
     require File.expand_path("../../core/signature", __FILE__)
   end
-
-  task :generate => [signature_file]
 end
 
 directory "runtime/core"
@@ -287,11 +287,11 @@ file "runtime/core/initialize" => "runtime/core/data" do |t|
   end
 end
 
-file "runtime/core/signature" => signature_file do |t|
+file runtime_signature_file => signature_file do |t|
   puts "CodeDB: writing signature..."
 
   File.open t.name, "wb" do |f|
-    f.puts Rubinius::Signature
+    f.puts SIGNATURE_HASH
   end
 end
 
@@ -301,6 +301,12 @@ task :core => 'core:build'
 namespace :core do
   desc "Build all core library files"
   task :build => ['compiler:load'] + runtime_files + code_db_files
+
+  desc "Create runtime core signature"
+  task :signature => [signature_file, signature_header, runtime_signature_file]
+
+  desc "Create platform configuration"
+  task :platform => "runtime/platform.conf"
 
   desc "Delete all .rbc files"
   task :clean do

--- a/rakelib/vm.rake
+++ b/rakelib/vm.rake
@@ -153,11 +153,11 @@ namespace :build do
   # Issue the actual build commands. NEVER USE DIRECTLY.
   task :build => %W[
     #{VM_EXE}
-    compiler:generate
+    core:signature
+    core:platform
     stage:bin
     stage:extra_bins
     stage:capi_include
-    core:build
     stage:core
     stage:runtime
     stage:lib

--- a/scripts/build_support.sh
+++ b/scripts/build_support.sh
@@ -4,16 +4,19 @@ __dir__="$(cd "$(dirname "$0")" && pwd)"
 
 # shellcheck source=scripts/configuration.sh
 source "$__dir__/configuration.sh"
+# shellcheck source=scripts/digest.sh
+source "$__dir__/digest.sh"
 # shellcheck source=scripts/aws.sh
 source "$__dir__/aws.sh"
 # shellcheck source=scripts/io.sh
 source "$__dir__/io.sh"
 
 function rbx_archive_core {
-  local archive ext url bucket
+  local archive ext path bucket url
 
   archive="$(rbx_runtime_core_name)"
   ext=".sha512"
+  path="$(rbx_runtime_core_path)"
   bucket="$(rbx_binary_bucket)"
   url=$(rbx_url_prefix "$bucket")
 
@@ -29,6 +32,43 @@ function rbx_archive_core {
   rm -f "$archive" "$archive$ext"
 }
 
+function rbx_fetch_core {
+  local archive digest check path bucket url
+
+  archive="$(rbx_runtime_core_name)"
+  digest="$archive.sha512"
+  check="$digest.check"
+  path="$(rbx_runtime_core_path)"
+  bucket="$(rbx_binary_bucket)"
+  url=$(rbx_url_prefix "$bucket")
+
+  rbx_s3_download "$url" "$archive" "$path"
+  rbx_s3_download "$url" "$digest" "$path"
+
+  mv "$digest" "$check"
+
+  rbx_digest_file "$archive"
+
+  diff "$digest" "$check"
+  if [ $? -ne 0 ]; then
+    fail "runtime core achive digest does not match"
+  fi
+
+  rm -f "$digest" "$check"
+}
+
+function rbx_setup_core {
+  local runtime
+
+  runtime="./runtime"
+
+  rm -rf "$runtime/core"
+
+  if [ ! -d "$runtime" ]; then mkdir "$runtime"; fi
+
+  bzip2 -dc "$(rbx_runtime_core_name)" | tar -x -f -
+}
+
 function rbx_build_support_usage {
   cat >&2 <<-EOM
 Usage: ${0##*/} archive_core
@@ -40,6 +80,12 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   case "$1" in
     "archive_core")
       rbx_archive_core
+      ;;
+    "fetch_core")
+      rbx_fetch_core
+      ;;
+    "setup_core")
+      rbx_setup_core
       ;;
     "-h"|"--help"|*)
       rbx_build_support_usage

--- a/scripts/configuration.sh
+++ b/scripts/configuration.sh
@@ -61,6 +61,10 @@ function rbx_runtime_core_name {
   echo "rubinius-runtime-core.tar.bz2"
 }
 
+function rbx_runtime_core_path {
+  echo "/runtime/"
+}
+
 function rbx_release_bucket {
   echo "rubinius-releases-rubinius-com"
 }


### PR DESCRIPTION
The use of Ruby in the build sytem severely complicates building and packaging
Rubinius and has resulted in Rubinius either not getting packaged for various
platforms or even removed from existing packages like Homebrew.
