### PR TITLE
Add error constant ENOTSUP

### DIFF
--- a/machine/ontology.cpp
+++ b/machine/ontology.cpp
@@ -998,6 +998,9 @@ namespace rubinius {
 #ifdef ERFKILL
     set_syserr(ERFKILL, "ERFKILL");
 #endif
+#ifdef ENOTSUP
+    set_syserr(ENOTSUP, "ENOTSUP");
+#endif
 
   }
 };


### PR DESCRIPTION
I noticed Errno::ENOTSUP is not defined as a constant.