### PR TITLE
Add Rubinius::KERNEL_PATH constant

### DIFF
--- a/machine/ontology.cpp
+++ b/machine/ontology.cpp
@@ -365,6 +365,8 @@ namespace rubinius {
       G(rubinius)->set_const(state, "BIN_PATH", String::create(state, path.c_str()));
       path = prefix + RBX_CORE_PATH;
       G(rubinius)->set_const(state, "CORE_PATH", String::create(state, path.c_str()));
+      path = prefix + RBX_KERNEL_PATH;
+      G(rubinius)->set_const(state, "KERNEL_PATH", String::create(state, path.c_str()));
       path = prefix + RBX_LIB_PATH;
       G(rubinius)->set_const(state, "LIB_PATH", String::create(state, path.c_str()));
       path = prefix + RBX_ENC_PATH;


### PR DESCRIPTION
Without this commit, I'm unable to get working the rubinius-debugger gem.

This is the bug I'm experiencing:

```
ubuntu@ip-172-31-1-125:~/rubinius$ ruby -v
rubinius 3.49 (2.3.1 0c24d047 2016-07-22 3.6.0) [x86_64-linux-gnu]
ubuntu@ip-172-31-1-125:~/rubinius$ irb
irb(main):001:0> require "rubinius/debugger"
NameError: Missing or uninitialized constant: Rubinius::KERNEL_PATH
        from core/module.rb:548:in `const_missing'
        from /home/ubuntu/.rubies/rbx-3.49/gems/gems/rubinius-debugger-2.4/lib/rubinius/debugger.rb:20:in `__script__'
        from /home/ubuntu/.rubies/rbx-3.49/gems/gems/rubinius-debugger-2.4/lib/rubinius/debugger.rb:16:in `__script__'
        from core/code_loader.rb:233:in `require'
        from core/kernel.rb:856:in `gem_original_require (require)'
        from /home/ubuntu/.rubies/rbx-3.49/library/rubygems/core_ext/kernel_require.rb:55:in `require'
        from (irb):1
        from core/block_environment.rb:147:in `call_on_instance'
        from core/kernel.rb:1135:in `eval'
        from core/kernel.rb:590:in `loop'
        from core/proc.rb:20:in `call'
        from core/kernel.rb:1072:in `catch'
        from core/throw_catch.rb:8:in `register'
        from core/kernel.rb:1071:in `catch'
        from core/proc.rb:20:in `call'
        from core/kernel.rb:1072:in `catch'
        from core/throw_catch.rb:8:in `register'
        from core/kernel.rb:1071:in `catch'
        from /home/ubuntu/.rubies/rbx-3.49/gems/gems/rubysl-irb-2.1.1/bin/irb:12:in `__script__'
        from core/kernel.rb:577:in `load'
        from /home/ubuntu/.rubies/rbx-3.49/gems/bin/irb:22:in `__script__'
        from core/code_loader.rb:505:in `load_script'
        from core/code_loader.rb:590:in `load_script'
        from core/loader.rb:679:in `script'
        from core/loader.rb:862:in `main'irb(main):002:0> 
```

This is an unexpected behaviour vs. what is described in the documentation:

http://rubinius.com/doc/en/tools/debugger/

There is also code in the pry gem referencing this missing constant:

https://github.com/pry/pry/blob/v0.10.4/lib/pry/rbx_path.rb#L10