### PR TITLE
Add Random::DEFAULT as an instance of Random

### DIFF
--- a/core/zed.rb
+++ b/core/zed.rb
@@ -1853,6 +1853,10 @@ class Time
   }
 end
 
+class Random
+  DEFAULT = new
+end
+
 module Rubinius
   class CodeDB
     class << self

--- a/spec/ruby/core/random/default_spec.rb
+++ b/spec/ruby/core/random/default_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe "Random::DEFAULT" do
+  it "returns a Random instance" do
+    Random::DEFAULT.should be_an_instance_of(Random)
+  end
+end


### PR DESCRIPTION
This is basically for MRI compatibility. This could be verified by:

    > ruby -ve 'p ObjectSpace.each_object(Random).to_a == [Random::DEFAULT]'
    ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
    true

Closes https://github.com/rubinius/rubinius/issues/3296

1. Is this pull-request complete?

  - [x] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [ ] It fixes an issue with an existing features.
  - [x] It introduces a new feature.

3. Does this pull-request include tests?

  - [x] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...

Unfortunately sorry that I have some difficulty to get Rubinius HEAD running, therefore I am not sure if this would work. One of the issues I have is:

```
Unable to send 'object_equal' on '#<Module>' (#<Class>)


0x7f92c1d1e170: Kernel#raise in core/alpha.rb:146 (+56)
0x7f92c1d1e800: Kernel#object_equal in core/alpha.rb:172 (+29)
0x7f92c1d1eeb0: BasicObject#! in core/basic_object.rb:15 (+6)
0x7f92c1d1f500: Random#initialize in core/random.rb:148 (+41)
0x7f92c1d1fb70: Class#new in core/alpha.rb:93 (+16)
0x7f92c1d20200: Object#script in core/random.rb:186 (+55)
```