### PR TITLE
Fixed keyword and placeholder arguments in zsuper instruction, improved tests

### DIFF
--- a/machine/instructions/zsuper.hpp
+++ b/machine/instructions/zsuper.hpp
@@ -62,19 +62,38 @@ namespace rubinius {
 
       if(mc->keywords) {
         native_int placeholder_position = splat_obj ? mc->total_args : mc->total_args - 1;
-        native_int keywords_position = placeholder_position + 1;
+        native_int keywords_position    = placeholder_position + 1;
 
-        Object* placeholder = scope->get_local(state, placeholder_position);
-        Array* ary = Array::create(state, 2);
+        // "Runtime.keyword_object?" requires keywords object to be convertable into Hash.
+        // TODO define "machine/class/hash" and use Hash::create instead of "[[key, value], ..].to_h".
 
-        for(native_int i = keywords_position; i <= mc->keywords_count; i++) {
-          ary->set(state, 0, as<Symbol>(call_frame->compiled_code->local_names()->at(state, i)));
-          ary->set(state, 1, scope->get_local(state, i));
+        Array* keywords = Array::create(state, mc->keywords_count);
 
-          placeholder->send(state, state->symbol("[]="), ary);
+        for(native_int index = 0; index < mc->keywords_count; index++) {
+          native_int keyword_position = keywords_position + index;
+          Symbol* name  = as<Symbol>(call_frame->compiled_code->local_names()->at(state, keyword_position));
+          Object* value = scope->get_local(state, keyword_position);
+
+          Array* keyword = Array::create(state, 2);
+          keyword->set(state, 0, name);
+          keyword->set(state, 1, value);
+
+          keywords->set(state, index, keyword);
         }
 
-        tup->put(state, tup_index++, scope->get_local(state, placeholder_position));
+        Object* keywords_hash = keywords->send(state, state->symbol("to_h"));
+
+        // We can receive optional arguments from "**args" at "placeholder_position".
+        // It can be "nil" or "Hash", we need to merge with it.
+
+        Object* placeholder = scope->get_local(state, placeholder_position);
+        if (!placeholder->nil_p()) {
+          Array* merge_arguments = Array::create(state, 1);
+          merge_arguments->set(state, 0, placeholder);
+          keywords_hash = keywords_hash->send(state, state->symbol("merge"), merge_arguments);
+        }
+
+        tup->put(state, tup_index++, keywords_hash);
       }
 
       CallSite* call_site = reinterpret_cast<CallSite*>(literal);

--- a/spec/ruby/language/fixtures/super.rb
+++ b/spec/ruby/language/fixtures/super.rb
@@ -328,34 +328,126 @@ module Super
     whatever
   end
 
-  module KeywordArguments
-    class A
+  module Keywords
+    class Arguments
       def foo(**args)
         args
       end
     end
 
-    class B < A
-      def foo(**)
+    # ----
+
+    class RequiredArguments < Arguments
+      def foo(a:)
         super
       end
     end
 
-    class C < A
-      def foo(a:, b: 'b', **)
+    class OptionalArguments < Arguments
+      def foo(b: 'b')
+        super
+      end
+    end
+
+    class PlaceholderArguments < Arguments
+      def foo(**args)
+        super
+      end
+    end
+
+    # ----
+
+    class RequiredAndOptionalArguments < Arguments
+      def foo(a:, b: 'b')
+        super
+      end
+    end
+
+    class RequiredAndPlaceholderArguments < Arguments
+      def foo(a:, **args)
+        super
+      end
+    end
+
+    class OptionalAndPlaceholderArguments < Arguments
+      def foo(b: 'b', **args)
+        super
+      end
+    end
+
+    # ----
+
+    class RequiredAndOptionalAndPlaceholderArguments < Arguments
+      def foo(a:, b: 'b', **args)
         super
       end
     end
   end
 
-  module SplatAndKeyword
-    class A
+  module RegularAndKeywords
+    class Arguments
+      def foo(a, **options)
+        [a, options]
+      end
+    end
+
+    # -----
+
+    class RequiredArguments < Arguments
+      def foo(a, b:)
+        super
+      end
+    end
+
+    class OptionalArguments < Arguments
+      def foo(a, c: 'c')
+        super
+      end
+    end
+
+    class PlaceholderArguments < Arguments
+      def foo(a, **options)
+        super
+      end
+    end
+
+    # -----
+
+    class RequiredAndOptionalArguments < Arguments
+      def foo(a, b:, c: 'c')
+        super
+      end
+    end
+
+    class RequiredAndPlaceholderArguments < Arguments
+      def foo(a, b:, **options)
+        super
+      end
+    end
+
+    class OptionalAndPlaceholderArguments < Arguments
+      def foo(a, c: 'c', **options)
+        super
+      end
+    end
+
+    # -----
+
+    class RequiredAndOptionalAndPlaceholderArguments < Arguments
+      def foo(a, b:, c: 'c', **options)
+        super
+      end
+    end
+  end
+
+  module SplatAndKeywords
+    class Arguments
       def foo(*args, **options)
         [args, options]
       end
     end
 
-    class B < A
+    class AllArguments < Arguments
       def foo(*args, **options)
         super
       end

--- a/spec/ruby/language/super_spec.rb
+++ b/spec/ruby/language/super_spec.rb
@@ -160,30 +160,106 @@ describe "The super keyword" do
   end
 
   describe 'when using keyword arguments' do
-    it 'passes any given keyword arguments to the parent' do
-      b = Super::KeywordArguments::B.new
+    req  = Super::Keywords::RequiredArguments.new
+    opts = Super::Keywords::OptionalArguments.new
+    etc  = Super::Keywords::PlaceholderArguments.new
 
-      b.foo(:number => 10).should == {:number => 10}
+    req_and_opts = Super::Keywords::RequiredAndOptionalArguments.new
+    req_and_etc  = Super::Keywords::RequiredAndPlaceholderArguments.new
+    opts_and_etc = Super::Keywords::OptionalAndPlaceholderArguments.new
+
+    req_and_opts_and_etc = Super::Keywords::RequiredAndOptionalAndPlaceholderArguments.new
+
+    it 'does not pass any arguments to the parent when none are given' do
+      etc.foo.should == {}
     end
 
-    it "passes any given keyword arguments including optional and required ones to the parent" do
-      c = Super::KeywordArguments::C.new
-
-      c.foo(a: 'a', c: 'c').should == {a: 'a', b: 'b', c: 'c'}
-    end
-
-    it 'does not pass any keyword arguments to the parent when none are given' do
-      b = Super::KeywordArguments::B.new
-
-      b.foo.should == {}
-    end
-
-    describe 'when using splat arguments' do
-      it 'passes splat arguments and keyword arguments to the parent' do
-        b = Super::SplatAndKeyword::B.new
-
-        b.foo('bar', baz: true).should == [['bar'], {baz: true}]
+    it 'passes only required arguments to the parent when no optional arguments are given' do
+      [req, req_and_etc].each do |obj|
+        obj.foo(a: 'a').should == {a: 'a'}
       end
+    end
+
+    it 'passes default argument values to the parent' do
+      [opts, opts_and_etc].each do |obj|
+        obj.foo.should == {b: 'b'}
+      end
+
+      [req_and_opts, opts_and_etc, req_and_opts_and_etc].each do |obj|
+        obj.foo(a: 'a').should == {a: 'a', b: 'b'}
+      end
+    end
+
+    it 'passes any given arguments including optional keyword arguments to the parent' do
+      [etc, req_and_opts, req_and_etc, opts_and_etc, req_and_opts_and_etc].each do |obj|
+        obj.foo(a: 'a', b: 'b').should == {a: 'a', b: 'b'}
+      end
+
+      [etc, req_and_etc, opts_and_etc, req_and_opts_and_etc].each do |obj|
+        obj.foo(a: 'a', b: 'b', c: 'c').should == {a: 'a', b: 'b', c: 'c'}
+      end
+    end
+  end
+
+  describe 'when using regular and keyword arguments' do
+    req  = Super::RegularAndKeywords::RequiredArguments.new
+    opts = Super::RegularAndKeywords::OptionalArguments.new
+    etc  = Super::RegularAndKeywords::PlaceholderArguments.new
+
+    req_and_opts = Super::RegularAndKeywords::RequiredAndOptionalArguments.new
+    req_and_etc  = Super::RegularAndKeywords::RequiredAndPlaceholderArguments.new
+    opts_and_etc = Super::RegularAndKeywords::OptionalAndPlaceholderArguments.new
+
+    req_and_opts_and_etc = Super::RegularAndKeywords::RequiredAndOptionalAndPlaceholderArguments.new
+
+    it 'passes only required regular arguments to the parent when no optional keyword arguments are given' do
+      etc.foo('a').should == ['a', {}]
+    end
+
+    it 'passes only required regular and keyword arguments to the parent when no optional keyword arguments are given' do
+      [req, req_and_etc].each do |obj|
+        obj.foo('a', b: 'b').should == ['a', {b: 'b'}]
+      end
+    end
+
+    it 'passes default argument values to the parent' do
+      [opts, opts_and_etc].each do |obj|
+        obj.foo('a').should == ['a', {c: 'c'}]
+      end
+
+      [req_and_opts, opts_and_etc, req_and_opts_and_etc].each do |obj|
+        obj.foo('a', b: 'b').should == ['a', {b: 'b', c: 'c'}]
+      end
+    end
+
+    it 'passes any given regular and keyword arguments including optional keyword arguments to the parent' do
+      [etc, req_and_opts, req_and_etc, opts_and_etc, req_and_opts_and_etc].each do |obj|
+        obj.foo('a', b: 'b', c: 'c').should == ['a', {b: 'b', c: 'c'}]
+      end
+
+      [etc, req_and_etc, opts_and_etc, req_and_opts_and_etc].each do |obj|
+        obj.foo('a', b: 'b', c: 'c', d: 'd').should == ['a', {b: 'b', c: 'c', d: 'd'}]
+      end
+    end
+  end
+
+  describe 'when using splat and keyword arguments' do
+    all = Super::SplatAndKeywords::AllArguments.new
+
+    it 'does not pass any arguments to the parent when none are given' do
+      all.foo.should == [[], {}]
+    end
+
+    it 'passes only splat arguments to the parent when no keyword arguments are given' do
+      all.foo('a').should == [['a'], {}]
+    end
+
+    it 'passes only keyword arguments to the parent when no splat arguments are given' do
+      all.foo(b: 'b').should == [[], {b: 'b'}]
+    end
+
+    it 'passes any given splat and keyword arguments to the parent' do
+      all.foo('a', b: 'b').should == [['a'], {b: 'b'}]
     end
   end
 end


### PR DESCRIPTION
Today I've finished issue #3295: `zsuper` instruction code was a bit broken. I've fixed it and improved tests for `super` method.

I left a `TODO` that `keywrods`wants to have `machine/class/hash` available. This class can improve readability of this code.

Existing spec was very poor. I've implemented a test that uses all combinations of 3 arguments types: regular, keywords and placeholder.

Please try to run improved tests without fix of `zsuper` instruction. You can see that all argument types are affected by this issue.

```
The super keyword when using keyword arguments does not pass any arguments to the parent when none are given ERROR
ArgumentError: method 'foo': given 1, expected 1

The super keyword when using keyword arguments passes default argument values to the parent ERROR
NoMethodError: undefined method `[]=' on nil:NilClass.

The super keyword when using regular and keyword arguments passes only required regular arguments to the parent when no 
optional keyword arguments are given ERROR
ArgumentError: method 'foo': given 2, expected 2

The super keyword when using regular and keyword arguments passes default argument values to the parent ERROR
ArgumentError: method 'foo': given 2, expected 2

The super keyword when using regular and keyword arguments passes any given regular and keyword arguments including optional 
keyword arguments to the parent FAILED
Expected ["a", {:b=>"b"}]
 to equal ["a", {:b=>"b", :c=>"c"}]

The super keyword when using splat and keyword arguments does not pass any arguments to the parent when none are given FAILED
Expected [[nil], {}]
 to equal [[], {}]

The super keyword when using splat and keyword arguments passes only splat arguments to the parent when no keyword arguments 
are given FAILED
Expected [["a", nil], {}]
```