### PR TITLE
Remove an outdated tag

### DIFF
--- a/spec/tags/ruby/core/exception/receiver_tags.txt
+++ b/spec/tags/ruby/core/exception/receiver_tags.txt
@@ -1,1 +1,0 @@
-fails:NameError#receiver returns the receiver of the method call where the error occurred


### PR DESCRIPTION
1. This spec was tagged in rubinius#3581.
2. Fixed via rubinius@8b7d91b