### PR TITLE
Add a failing spec for Enumerator#peek with multiple yield arguments

### DIFF
--- a/spec/ruby/core/enumerator/peek_spec.rb
+++ b/spec/ruby/core/enumerator/peek_spec.rb
@@ -33,4 +33,19 @@ describe "Enumerator#peek" do
     5.times { @e.next }
     lambda { @e.peek }.should raise_error(StopIteration)
   end
+
+  context "when yielded with multiple arguments" do
+    before do
+      object = Object.new
+      def object.each
+        yield 1, 2
+      end
+      @multiple = object.to_enum
+    end
+
+    it "always returns new array" do
+      @multiple.peek.should == [1, 2]
+      @multiple.peek.should_not equal(@multiple.peek)
+    end
+  end
 end

--- a/spec/tags/ruby/core/enumerator/peek_tags.txt
+++ b/spec/tags/ruby/core/enumerator/peek_tags.txt
@@ -1,0 +1,1 @@
+fails:Enumerator#peek when yielded with multiple arguments always returns new array


### PR DESCRIPTION
I don't have simple idea to fix it 🤔  So just adding the failing specs for now.