### PR TITLE
Fix `Regexp.union` behavior on optional left parenthesis

### DIFF
--- a/core/regexp.rb
+++ b/core/regexp.rb
@@ -388,8 +388,10 @@ class Regexp
     def create_parts
       while @index < @source.size
         if @source[@index].chr == '('
+          escaped = @index > 0 && @source[@index - 1].chr == '\\'
+
           idx = @index + 1
-          if idx < @source.size and @source[idx].chr == '?'
+          if idx < @source.size and @source[idx].chr == '?' and !escaped
             process_group
           else
             push_current_character!

--- a/spec/ruby/core/regexp/union_spec.rb
+++ b/spec/ruby/core/regexp/union_spec.rb
@@ -17,6 +17,10 @@ describe "Regexp.union" do
     Regexp.union("n", ".").should == /n|\./
   end
 
+  it "handles the optional left parenthesis case correctly" do
+    Regexp.union(/\(?/, "").should == /(?-mix:\(?)|/
+  end
+
   it "returns a Regexp with the encoding of an ASCII-incompatible String argument" do
     Regexp.union("a".encode("UTF-16LE")).encoding.should == Encoding::UTF_16LE
   end


### PR DESCRIPTION
`Regexp::SourceParcer` always treats left parenthesis as a beginning of
a group. However, the parenthesis can be escaped and in this case an error will be raised.

Reproduction code:

```ruby
Regexp.union(/\(?/, "")
```

This change tweaks the `Regexp::SourceParcer#create_parts` method to
handle this case.

1. Is this pull-request complete?

  - [x] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [x] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [x] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
