### PR TITLE
Align frozen object's error message with MRI.

### DIFF
--- a/machine/class/exception.cpp
+++ b/machine/class/exception.cpp
@@ -142,7 +142,7 @@ namespace rubinius {
 
   Exception* Exception::make_frozen_exception(STATE, Object* obj) {
     std::ostringstream msg;
-    msg << "can't modify frozen instance of ";
+    msg << "can't modify frozen ";
     msg << obj->class_object(state)->module_name()->debug_str(state);
 
     return Exception::make_exception(state, G(exc_rte), msg.str().c_str());


### PR DESCRIPTION
This fixes https://github.com/rubinius/rubinius/issues/3663

Thank you for taking the time to submit a pull-request to Rubinius. We appreciate your contribution.

Please respond to the following questions to help us merge your pull-request. Please leave the form contents in place. If a question isn't relevant, please respond with N/A.

1. Is this pull-request complete?

  - [ ] Yes, this pull-request is ready to be reviewed and merged.
  - [X] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [X] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [X] No, it does not include tests because ...

I want to check the CI results at first.
