### PR TITLE
Clean up timestamp files generated by Makefile

### DIFF
--- a/rakelib/core.rake
+++ b/rakelib/core.rake
@@ -23,6 +23,7 @@ def core_clean
            "spec/capi/ext/*.{o,sig,#{$dlext}}",
            "#{BUILD_CONFIG[:prefixdir]}/#{BUILD_CONFIG[:archdir]}/**/*.*",
            "#{BUILD_CONFIG[:bootstrap_gems_dir]}/**/Makefile",
+           "#{BUILD_CONFIG[:bootstrap_gems_dir]}/**/.RUBYARCHDIR.*",
           ],
     :verbose => $verbose
 end


### PR DESCRIPTION
core clean task must delete timestamp files created by make while building Rubinius or the next build operation relaunched after a rake clean will fail