### PR TITLE
Implement Array#prepend and Array#append

### DIFF
--- a/core/array.rb
+++ b/core/array.rb
@@ -1279,6 +1279,7 @@ class Array
 
     concat args
   end
+  alias_method :append, :push
 
   def rassoc(obj)
     each do |elem|
@@ -1979,6 +1980,7 @@ class Array
     @total += values.size
     self
   end
+  alias_method :prepend, :unshift
 
   def values_at(*args)
     out = []

--- a/spec/ruby/core/array/append_spec.rb
+++ b/spec/ruby/core/array/append_spec.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
+require_relative 'shared/push'
 
 describe "Array#<<" do
   it "pushes the object onto the end of the array" do
@@ -31,5 +32,11 @@ describe "Array#<<" do
 
   it "raises a RuntimeError on a frozen array" do
     lambda { ArraySpecs.frozen_array << 5 }.should raise_error(RuntimeError)
+  end
+
+  ruby_version_is "2.5" do
+    describe "Array#append" do
+      it_behaves_like :array_push, :append
+    end
   end
 end

--- a/spec/ruby/core/array/prepend_spec.rb
+++ b/spec/ruby/core/array/prepend_spec.rb
@@ -2,6 +2,8 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/unshift'
 
-describe "Array#unshift" do
-  it_behaves_like :array_unshift, :unshift
+ruby_version_is "2.5" do
+  describe "Array#prepend" do
+    it_behaves_like :array_unshift, :prepend
+  end
 end

--- a/spec/ruby/core/array/push_spec.rb
+++ b/spec/ruby/core/array/push_spec.rb
@@ -1,32 +1,7 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require File.expand_path('../fixtures/classes', __FILE__)
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative 'shared/push'
 
 describe "Array#push" do
-  it "appends the arguments to the array" do
-    a = [ "a", "b", "c" ]
-    a.push("d", "e", "f").should equal(a)
-    a.push().should == ["a", "b", "c", "d", "e", "f"]
-    a.push(5)
-    a.should == ["a", "b", "c", "d", "e", "f", 5]
-  end
-
-  it "isn't confused by previous shift" do
-    a = [ "a", "b", "c" ]
-    a.shift
-    a.push("foo")
-    a.should == ["b", "c", "foo"]
-  end
-
-  it "properly handles recursive arrays" do
-    empty = ArraySpecs.empty_recursive_array
-    empty.push(:last).should == [empty, :last]
-
-    array = ArraySpecs.recursive_array
-    array.push(:last).should == [1, 'two', 3.0, array, array, array, array, array, :last]
-  end
-
-  it "raises a RuntimeError on a frozen array" do
-    lambda { ArraySpecs.frozen_array.push(1) }.should raise_error(RuntimeError)
-    lambda { ArraySpecs.frozen_array.push }.should raise_error(RuntimeError)
-  end
+  it_behaves_like :array_push, :push
 end

--- a/spec/ruby/core/array/shared/push.rb
+++ b/spec/ruby/core/array/shared/push.rb
@@ -1,0 +1,33 @@
+describe :array_push, shared: true do
+  it "appends the arguments to the array" do
+    a = [ "a", "b", "c" ]
+    a.send(@method, "d", "e", "f").should equal(a)
+    a.send(@method).should == ["a", "b", "c", "d", "e", "f"]
+    a.send(@method, 5)
+    a.should == ["a", "b", "c", "d", "e", "f", 5]
+
+    a = [0, 1]
+    a.send(@method, 2)
+    a.should == [0, 1, 2]
+  end
+
+  it "isn't confused by previous shift" do
+    a = [ "a", "b", "c" ]
+    a.shift
+    a.send(@method, "foo")
+    a.should == ["b", "c", "foo"]
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.send(@method, :last).should == [empty, :last]
+
+    array = ArraySpecs.recursive_array
+    array.send(@method, :last).should == [1, 'two', 3.0, array, array, array, array, array, :last]
+  end
+
+  it "raises a RuntimeError on a frozen array" do
+    -> { ArraySpecs.frozen_array.send(@method, 1) }.should raise_error(RuntimeError)
+    -> { ArraySpecs.frozen_array.send(@method) }.should raise_error(RuntimeError)
+  end
+end

--- a/spec/ruby/core/array/shared/unshift.rb
+++ b/spec/ruby/core/array/shared/unshift.rb
@@ -1,0 +1,46 @@
+describe :array_unshift, shared: true do
+  it "prepends object to the original array" do
+    a = [1, 2, 3]
+    a.send(@method, "a").should equal(a)
+    a.should == ['a', 1, 2, 3]
+    a.send(@method).should equal(a)
+    a.should == ['a', 1, 2, 3]
+    a.send(@method, 5, 4, 3)
+    a.should == [5, 4, 3, 'a', 1, 2, 3]
+
+    # shift all but one element
+    a = [1, 2]
+    a.shift
+    a.send(@method, 3, 4)
+    a.should == [3, 4, 2]
+
+    # now shift all elements
+    a.shift
+    a.shift
+    a.shift
+    a.send(@method, 3, 4)
+    a.should == [3, 4]
+  end
+
+  it "quietly ignores unshifting nothing" do
+    [].send(@method).should == []
+  end
+
+  it "properly handles recursive arrays" do
+    empty = ArraySpecs.empty_recursive_array
+    empty.send(@method, :new).should == [:new, empty]
+
+    array = ArraySpecs.recursive_array
+    array.send(@method, :new)
+    array[0..5].should == [:new, 1, 'two', 3.0, array, array]
+  end
+
+  it "raises a RuntimeError on a frozen array when the array is modified" do
+    -> { ArraySpecs.frozen_array.send(@method, 1) }.should raise_error(RuntimeError)
+  end
+
+  # see [ruby-core:23666]
+  it "raises a RuntimeError on a frozen array when the array would not be modified" do
+    -> { ArraySpecs.frozen_array.send(@method) }.should raise_error(RuntimeError)
+  end
+end


### PR DESCRIPTION
1. Is this pull-request complete?

  - [x] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [ ] It fixes an issue with an existing features.
  - [x] It introduces a new feature.

3. Does this pull-request include tests?

  - [x] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...

`Array#append` and `Array#prepend` got introduced in Ruby 2.5.

See https://bugs.ruby-lang.org/issues/12746

Specs are c&p from https://github.com/ruby/spec