### PR TITLE
ffi_util.cpp: include sys/sysmacros.h only under GNU Libc and uclibc

### DIFF
--- a/machine/ffi_util.cpp
+++ b/machine/ffi_util.cpp
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>
-#ifndef __APPLE__
+#if !defined(__APPLE__) && ( defined(__GLIBC__) || defined(__UCLIBC__) )
 #include <sys/sysmacros.h>
 #endif
 #ifdef RBX_WINDOWS


### PR DESCRIPTION
This patch will avoid including sys/sysmacros.h if neither uclibc nor
GNU glibc is available

% Rationale

If it may help to inform this or any alternate approach, there's some
commentary available about the macros defined in sys/sysmacros.h in a
discussion thread under the libc-alpha mailing list
  https://sourceware.org/pipermail/libc-alpha/2015-November/066302.html

Quoting the original message in the thread:
  sys/sysmacros.h defines three macros - major, minor, makedev

In the original ffi_util.cpp, the macros 'major' and 'minor' will
already have been defined when not previously defined.

If there may be any other use of sys/sysmacros.h e.g on Linux
platforms, this patch should serve to ensure that the file is still
included under a build on such platform, while not included under a
FreeBSD platform such that may not provide a sys/sysmacros.h

% Known Limitations

* This is an approximate test. Perhaps it could be addressed
  alternately, with an autoconf-like test during configure?

* This patch may not serve to include sys/sysmacros.h under musl libc
  builds on Linux. However, the 'major' and 'minor' macros would still
  have been defined on this platform, later in ffi_util.cpp

* Short of a feature test during configure, this could possibly be
  addressed alternately if testing for the __linux__ feature macro

It's a short patch towards building rbx on FreeBSD, where sys/sysmacros.h is
generally not available.

The patch has been tested with a build of Rubinius v5.0 with clang 9.0
and clang 11 on FreeBSD 11.1

Previous to the patch, when compiling Rubinius v5.0 with clang 9.0 on FreeBSD 11.1:
~~~~
3: CXX machine/environment.cpp
4: CXX machine/exception.cpp
2: CXX machine/exception_point.cpp
4: CXX machine/ffi.cpp
2: CXX machine/ffi_util.cpp
machine/ffi_util.cpp:7:10: fatal error: 'sys/sysmacros.h' file not found
         ^~~~~~~~~~~~~~~~~
1 error generated.
Error: /usr/local/bin/clang++90 -I/usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine -I/usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/mach>
/usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:69:in `command': Error compiling (RuntimeError)
        from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:235:in `cxx_compile'
        from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:222:in `compile'
        from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:438:in `build'
        from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:958:in `block (2 levels) in perform_tasks'
[...]
~~~~

Thank you for taking the time to submit a pull-request to Rubinius. We appreciate your contribution.

Please respond to the following questions to help us merge your pull-request. Please leave the form contents in place. If a question isn't relevant, please respond with N/A.

1. Is this pull-request complete?

  - [ ] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [ ] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
