### PR TITLE
bignum.cpp: Avoid long to double conversion under shift

### DIFF
--- a/machine/class/bignum.cpp
+++ b/machine/class/bignum.cpp
@@ -1109,7 +1109,7 @@ namespace rubinius {
       Exception::raise_float_domain_error(state, "NaN");
     }
 
-    while(!(value <= (LONG_MAX >> 1)) || 0 != (long)value) {
+    while(!((long)value <= (LONG_MAX >> 1)) || 0 != (long)value) {
       value = value / (double)(DIGIT_RADIX);
       i++;
     }


### PR DESCRIPTION
This patch adds an additional cast for a conditional test form, in the definition of **`Bignum::from_double`** in `machine/class/bignum.cpp`

The cast should serve to ensure that the local variable `value` will be evaluated as being of a long type, within the left hand expression in the conditional test form. clang++ 11 has detected a potential type incompatibility, in this expression.

The value is already being cast to long, in the right hand expression in the test form, i.e `0 != (long)value`.

Previous to the patch, compiling with clang++ 11 on FreeBSD 11.1
~~~~
2: CXX machine/class/bignum.cpp
4: CXX machine/class/block_as_method.cpp
machine/class/bignum.cpp:1112:32: error: implicit conversion from 'long' to 'double' changes value from 4611686018427387903 to 4611686018427387904 [-Werror,-Wimplicit-const-int-float-convers>
    while(!(value <= (LONG_MAX >> 1)) || 0 != (long)value) {
                  ~~  ~~~~~~~~~^~~~
3: CXX machine/class/block_environment.cpp
1 error generated.
Error: /usr/local/bin/clang++11 -I/usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine -I/usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/mach>
/usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:69:in `command': Error compiling (RuntimeError)
        from /usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:235:in `cxx_compile'
        from /usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:222:in `compile'
        from /usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:438:in `build'
        from /usr/home/gimbal/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/build/scripts/daedalus.rb:958:in `block (2 levels) in perform_tasks'
~~~~

----

1. Is this pull-request complete?

  - [x] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [x] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [x] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
