### PR TITLE
rakelib install_file: pass options as **options

### DIFF
--- a/rakelib/install.rake
+++ b/rakelib/install.rake
@@ -43,7 +43,7 @@ def install_file(source, prefix, dest, name=nil, options={})
   options[:mode] ||= 0644
   options[:verbose] ||= $verbose
 
-  install source, dest_name, options
+  install source, dest_name, **options
 end
 
 def install_bin(source, target)


### PR DESCRIPTION
This patch ensures that any `options` hash provided to **install_file** will be passed as `**options` to rake **install**

----

1. Is this pull-request complete?

  - [X] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [X] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [X] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
