### PR TITLE
configure.rb: Add alternate gettid() header (`unistd.h`)

### DIFF
--- a/configure.rb
+++ b/configure.rb
@@ -1295,7 +1295,9 @@ int main() { return tgetnum(""); }
       @defines << "HAVE_INOTIFY"
     end
 
-    if has_function("gettid", ["unistd.d", "sys/types.h"])
+    # On Linux systems providing gettid() (Glibc 2.30+), the header is `unistd.h`.
+    #
+    if has_function("gettid", ["unistd.d", "sys/types.h"]) || has_function("gettid", ["unistd.h"])
       @defines << "HAVE_GETTID"
     end
 


### PR DESCRIPTION
On Linux systems providing gettid(), the header is `unistd.h`, which is currently not evaluated. The consequence of this omission is that Rubinius' gettid() definition conflicts with Glibc's one - the former doesn't have the noexcept specifier, while the latter does (__THROW).

Closes #3847.

Extra context: this was not detected before because gettid() has been introduced on Glibc 2.30, which is not very old.